### PR TITLE
fixing version ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
 		"d2l-offscreen": "BrightspaceUI/offscreen#semver:^4",
 		"d2l-organizations": "BrightspaceHypermediaComponents/organizations#semver:^1",
 		"d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
-		"d2l-polymer-siren-behaviors": "Brightspace/polymer-siren-behaviors#semver:^1.0.0",
-		"d2l-table": "BrightspaceUI/table#semver:^2.0.0",
+		"d2l-polymer-siren-behaviors": "Brightspace/polymer-siren-behaviors#semver:^1",
+		"d2l-table": "BrightspaceUI/table#semver:^2",
 		"d2l-typography": "BrightspaceUI/typography#semver:^7",
 		"fastdom": "^1.0.8"
 	}


### PR DESCRIPTION
These are currently causing pages in the LMS with tables on them to blow up, since we end up with two copies of `d2l-table` defined.