### PR TITLE
Hover and Focus for list item.

### DIFF
--- a/components/d2l-activity-list-item/d2l-activity-list-item-enroll.js
+++ b/components/d2l-activity-list-item/d2l-activity-list-item-enroll.js
@@ -16,6 +16,9 @@ class D2lActivityListItemEnroll extends ActivityListItemLocalize(PolymerElement)
 				:host {
 					display: block;
 				}
+				:host([hidden]) {
+					display: none;
+				}
 			</style>
 			<d2l-button id="d2l-activity-list-item-enroll" primary$=[[_hasActionBoolean(actionEnroll)]] disabled$=[[!_hasActionBoolean(actionEnroll)]]>
 				[[localize('enroll')]]

--- a/components/d2l-activity-list-item/d2l-activity-list-item.js
+++ b/components/d2l-activity-list-item/d2l-activity-list-item.js
@@ -35,9 +35,27 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 					border-color: rgba(0, 111, 191, 0.4);
 					box-shadow: 0 0 0 4px rgba(0, 111, 191, 0.3);
 				}
-				.d2l-activity-list-item-container:hover,
-				.d2l-activity-list-item-container:focus {
-					background-color: #FAFBFC; /* Pending Colin */
+				.d2l-activity-list-item-top-line,
+				.d2l-activity-list-item-bottom-line {
+					display: none;
+					border-top: 1px solid var(--d2l-color-mica);
+					margin: 0;
+				}
+				.d2l-activity-list-item-top-line {
+					margin-top: -2px;
+				}
+				.d2l-activity-list-item-bottom-line {
+					margin-bottom: -2px;
+				}
+				.d2l-activity-list-item-container:hover .d2l-activity-list-item-top-line,
+				.d2l-activity-list-item-container:hover .d2l-activity-list-item-bottom-line {
+					display: block;
+				}
+				.d2l-activity-list-item-container:hover {
+					background-color: var(--d2l-color-regolith);
+				}
+				.d2l-activity-list-item-container a.d2l-focusable:focus {
+
 				}
 				.d2l-activity-list-item-container {
 					position: relative;
@@ -45,7 +63,7 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 				}
 				.d2l-activity-list-item-link-container {
 					overflow: hidden;
-					display: flex;
+					display: inline-flex;
 					flex-direction: row;
 					flex-grow: 1;
 					flex-shrink: 1;
@@ -146,6 +164,7 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 				}
 			</style>
 			<div class="d2l-activity-list-item-container">
+				<hr class="d2l-activity-list-item-top-line" />
 				<a class="d2l-focusable" href$="[[_link]]">
 					<span class="d2l-activity-list-item-link-text">[[_accessibilityDataToString(_accessibilityData)]]</span>
 				</a>
@@ -173,6 +192,7 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 						</div>
 					</div>
 				</div>
+				<hr class="d2l-activity-list-item-bottom-line" />
 			</div>
 			<d2l-activity-list-item-enroll hidden$="[[actionEnrollHide]]" action-enroll="[[_actionEnroll]]"></d2l-activity-list-item-enroll>
 		`;
@@ -321,8 +341,8 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 
 		this._currentResponsiveConfig = currentConfig;
 		window.fastdom.mutate(() => {
-			const container = this.shadowRoot.querySelector('.d2l-activity-list-item-container');
-			container.style.padding = currentConfig.padding;
+			const container = this.shadowRoot.querySelector('.d2l-activity-list-item-link-container');
+			container.style.margin = currentConfig.padding;
 
 			const image = this.shadowRoot.querySelector('.d2l-activity-list-item-image');
 			image.style.width = currentConfig.image.width + 'px';

--- a/components/d2l-activity-list-item/d2l-activity-list-item.js
+++ b/components/d2l-activity-list-item/d2l-activity-list-item.js
@@ -31,21 +31,23 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 					display: block;
 					max-width: 842px;
 				}
-				:host([active]) {
+				:host([active]) a.d2l-focusable {
 					border-color: rgba(0, 111, 191, 0.4);
 					box-shadow: 0 0 0 4px rgba(0, 111, 191, 0.3);
+					border-radius: 6px;
 				}
 				.d2l-activity-list-item-top-line,
 				.d2l-activity-list-item-bottom-line {
 					display: none;
+					border: 0;
 					border-top: 1px solid var(--d2l-color-mica);
 					margin: 0;
 				}
 				.d2l-activity-list-item-top-line {
-					margin-top: -2px;
+					margin-top: -1px;
 				}
 				.d2l-activity-list-item-bottom-line {
-					margin-bottom: -2px;
+					margin-bottom: -1px;
 				}
 				.d2l-activity-list-item-container:hover .d2l-activity-list-item-top-line,
 				.d2l-activity-list-item-container:hover .d2l-activity-list-item-bottom-line {
@@ -53,9 +55,6 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 				}
 				.d2l-activity-list-item-container:hover {
 					background-color: var(--d2l-color-regolith);
-				}
-				.d2l-activity-list-item-container a.d2l-focusable:focus {
-
 				}
 				.d2l-activity-list-item-container {
 					position: relative;
@@ -112,7 +111,7 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 					margin: 0.2rem 0;
 				}
 				.d2l-activity-list-item-container:hover .d2l-activity-list-item-title ,
-				.d2l-activity-list-item-container:focus .d2l-activity-list-item-title {
+				:host([active]) .d2l-activity-list-item-title {
 					color: var(--d2l-color-celestine-minus-1);
 					text-decoration: underline;
 				}

--- a/components/d2l-activity-list-item/d2l-activity-list-item.js
+++ b/components/d2l-activity-list-item/d2l-activity-list-item.js
@@ -174,7 +174,7 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 					</div>
 				</div>
 			</div>
-			<d2l-activity-list-item-enroll hidden$="[[!_actionEnroll]]" action-enroll="[[_actionEnroll]]"></d2l-activity-list-item-enroll>
+			<d2l-activity-list-item-enroll hidden$="[[actionEnrollHide]]" action-enroll="[[_actionEnroll]]"></d2l-activity-list-item-enroll>
 		`;
 	}
 
@@ -231,6 +231,10 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 			actionEnroll: {
 				type: String,
 				value: ''
+			},
+			actionEnrollHide: {
+				type: Boolean,
+				value: true
 			},
 			_link: String,
 			_accessibilityData: {

--- a/demo/d2l-activity-list-item/index.html
+++ b/demo/d2l-activity-list-item/index.html
@@ -32,6 +32,9 @@
 				h3 {
 					text-align: center;
 				}
+				d2l-activity-list-item {
+					border-bottom: 1px solid var(--d2l-color-mica);
+				}
 		</style>
 	</head>
 	<body class="d2l-typography">


### PR DESCRIPTION
Update the behaviour of the activity list item for hover and focus.

A/C:
- A item is able to have focus and hover in AND/OR combinations
A user can have focused on a search result item with the keyboard and hover with the mouse on another (AKA don't move focus due to the user's hovering)
- When normal, the top item doesn't have a top border. When focused/hovered, it does
   Ensure that the layout doesn't change due to hover/focus
- When the cursor is in the "bounds" of the search result, the hover effect is activated
NOT just on the link
The background of the list item changes to #F9FAFB on hover
The link appears underlined when hovered

![image](https://user-images.githubusercontent.com/13232226/50925740-36f4cd00-1421-11e9-8bcb-7041f65cfa7f.png)
