### PR TITLE
hypermedia calls can start directly from https://activities.api.prodev.d2l/my-unassessed-activities, don't have to go through root.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,13 @@ To lint AND run local unit tests:
 npm test
 ```
 
+## Usage
+
+The unassessed activites list should be pulled directly from `my-unassessed-activities`:
+
+```html
+<d2l-evaluation-hub href="https://activities.[[apiUrl]]/my-unassessed-activities" token="token"></d2l-evaluation-hub>
+```
+
 [ci-url]: https://travis-ci.org/BrightspaceUI/activities
 [ci-image]: https://travis-ci.org/BrightspaceUI/activities.svg?branch=master

--- a/demo/d2l-evaluation-hub/data/activities/activitiesList/root.json
+++ b/demo/d2l-evaluation-hub/data/activities/activitiesList/root.json
@@ -1,8 +1,0 @@
-{
-	"links":[
-		{
-			"rel":["https://api.brightspace.com/rels/whoami"],
-			"href":"data/activities/activitiesList/whoami.json"
-		}
-	]
-}

--- a/demo/d2l-evaluation-hub/data/activities/activitiesList/whoami.json
+++ b/demo/d2l-evaluation-hub/data/activities/activitiesList/whoami.json
@@ -1,8 +1,0 @@
-{
-	"links":[
-		{
-			"rel":["https://activities.api.brightspace.com/rels/my-unassessed-activities"],
-			"href":"data/activities/activitiesList/unassessedActivities.json"
-		}
-	]
-}

--- a/demo/d2l-evaluation-hub/index.html
+++ b/demo/d2l-evaluation-hub/index.html
@@ -35,7 +35,6 @@
 			<demo-snippet>
 				<template strip-whitespace>
 					<d2l-evaluation-hub-activities-list href="data/activities/activitiesList/unassessedActivities.json" token="token"></d2l-evaluation-hub-activities-list>
-					<!-- <d2l-evaluation-hub-activities-list href="https://activities.api.proddev.d2l/my-unassessed-activities" token="token"></d2l-evaluation-hub-activities-list> -->
 				</template>
 			</demo-snippet>
 		</div>

--- a/demo/d2l-evaluation-hub/index.html
+++ b/demo/d2l-evaluation-hub/index.html
@@ -34,7 +34,8 @@
 			<h3>d2l-evaluation-hub-activities-list demo</h3>
 			<demo-snippet>
 				<template strip-whitespace>
-					<d2l-evaluation-hub-activities-list href="data/activities/activitiesList/root.json" token="whatever"></d2l-evaluation-hub-activities-list>
+					<d2l-evaluation-hub-activities-list href="data/activities/activitiesList/unassessedActivities.json" token="token"></d2l-evaluation-hub-activities-list>
+					<!-- <d2l-evaluation-hub-activities-list href="https://activities.api.proddev.d2l/my-unassessed-activities" token="token"></d2l-evaluation-hub-activities-list> -->
 				</template>
 			</demo-snippet>
 		</div>

--- a/test/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.js
+++ b/test/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.js
@@ -1,15 +1,9 @@
 (function() {
 	var list;
 
-	function loadPromise(url, fromEntity) {
-		return window.D2L.Siren.EntityStore.fetch(url, '')
-			.then(function(entity) {
-				if (fromEntity) {
-					return list.loadData(entity.entity);
-				} else {
-					return list.loadData(entity);
-				}
-			});
+	async function loadPromise(url) {
+		var entity = await window.D2L.Siren.EntityStore.fetch(url, '');
+		await list.loadData(entity.entity);
 	}
 
 	var expectedData = [
@@ -44,14 +38,8 @@
 				}
 			});
 		});
-		test('data is imported from root correctly', async() => {
-			await loadPromise('data/root.json', true);
-
-			assert.equal(list._data.length, expectedData.length);
-			assert.deepEqual(list._data, expectedData);
-		});
-		test('data is imported from activities correctly', async() => {
-			await loadPromise('data/unassessedActivities.json', false);
+		test('data is imported correctly', async() => {
+			await loadPromise('data/unassessedActivities.json');
 
 			assert.equal(list._data.length, expectedData.length);
 			assert.deepEqual(list._data, expectedData);
@@ -66,7 +54,7 @@
 				expected.push(item.submissionDate);
 			});
 
-			await loadPromise('data/root.json', true);
+			await loadPromise('data/unassessedActivities.json');
 
 			var data = list.shadowRoot.querySelectorAll('d2l-td');
 			for (var i = 0; i < expected.length; i++) {

--- a/test/d2l-evaluation-hub/data/root.json
+++ b/test/d2l-evaluation-hub/data/root.json
@@ -1,8 +1,0 @@
-{
-	"links":[
-		{
-			"rel":["https://api.brightspace.com/rels/whoami"],
-			"href":"data/whoami.json"
-		}
-	]
-}

--- a/test/d2l-evaluation-hub/data/whoami.json
+++ b/test/d2l-evaluation-hub/data/whoami.json
@@ -1,8 +1,0 @@
-{
-	"links":[
-		{
-			"rel":["https://activities.api.brightspace.com/rels/my-unassessed-activities"],
-			"href":"data/unassessedActivities.json"
-		}
-	]
-}


### PR DESCRIPTION
Also simplified some Promises to async/await for readability, added some null checks, rewrote `followLink()` to use `getHref()`.