### PR TITLE
Fixed issue where contents of list item would overflow

### DIFF
--- a/components/d2l-activity-list-item/d2l-activity-list-item.js
+++ b/components/d2l-activity-list-item/d2l-activity-list-item.js
@@ -174,8 +174,7 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 						<d2l-course-image
 							image="[[_image]]"
 							sizes="[[_tileSizes]]"
-							type="narrow"
-							aria-hidden>
+							type="narrow">
 						</d2l-course-image>
 					</div>
 					<div class="d2l-activity-list-item-content">

--- a/components/d2l-activity-list-item/d2l-activity-list-item.js
+++ b/components/d2l-activity-list-item/d2l-activity-list-item.js
@@ -30,6 +30,7 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 			<style include="d2l-offscreen-shared-styles">
 				:host {
 					display: block;
+					overflow: hidden;
 					max-width: 842px;
 				}
 				:host([active]) a.d2l-focusable {
@@ -173,7 +174,8 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 						<d2l-course-image
 							image="[[_image]]"
 							sizes="[[_tileSizes]]"
-							type="narrow">
+							type="narrow"
+							aria-hidden>
 						</d2l-course-image>
 					</div>
 					<div class="d2l-activity-list-item-content">


### PR DESCRIPTION
Fixed issue where image on the list item wasn't hidden to screen reader.

Image is decorative.
> Decorative images don’t add information to the content of a page. For example, the information provided by the image might already be given using adjacent text, or the image might be included to make the website more visually attractive.

NAMELY:

> the information provided by the image might already be given using adjacent text,

https://www.w3.org/WAI/tutorials/images/decorative/