### PR TITLE
Remove the max width constraint for d2l-activity-list-item

### DIFF
--- a/components/d2l-activity-list-item/d2l-activity-list-item.js
+++ b/components/d2l-activity-list-item/d2l-activity-list-item.js
@@ -30,7 +30,6 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 			<style include="d2l-offscreen-shared-styles">
 				:host {
 					display: block;
-					max-width: 842px;
 				}
 				:host([active]) a.d2l-focusable {
 					border-color: rgba(0, 111, 191, 0.4);


### PR DESCRIPTION
I talked to Colin about this and his suggestion was to remove the max width constraint in the component and impose a max width constraint in the containers that use the component.

Any concerns with removing this max width?