### PR TITLE
US103318 - Add empty master teacher column, toggled by attribute

### DIFF
--- a/components/d2l-evaluation-hub/build/lang/ar.js
+++ b/components/d2l-evaluation-hub/build/lang/ar.js
@@ -12,8 +12,8 @@ const LangArImpl = (superClass) => class extends superClass {
 			'displayName': 'الاسم الأول، اسم العائلة',
 			'loading': 'Loading',
 			'loadMore': 'تحميل المزيد',
-			'submissionDate': 'تاريخ الإرسال',
-			'masterTeacher': 'Master Teacher'
+			'masterTeacher': 'Master Teacher',
+			'submissionDate': 'تاريخ الإرسال'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/ar.js
+++ b/components/d2l-evaluation-hub/build/lang/ar.js
@@ -12,7 +12,8 @@ const LangArImpl = (superClass) => class extends superClass {
 			'displayName': 'الاسم الأول، اسم العائلة',
 			'loading': 'Loading',
 			'loadMore': 'تحميل المزيد',
-			'submissionDate': 'تاريخ الإرسال'
+			'submissionDate': 'تاريخ الإرسال',
+			'masterTeacher': 'Master Teacher'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/de.js
+++ b/components/d2l-evaluation-hub/build/lang/de.js
@@ -12,8 +12,8 @@ const LangDeImpl = (superClass) => class extends superClass {
 			'displayName': 'Vorname, Nachname',
 			'loading': 'Loading',
 			'loadMore': 'Mehr laden',
-			'submissionDate': 'Abgabedatum',
-			'masterTeacher': 'Master Teacher'
+			'masterTeacher': 'Master Teacher',
+			'submissionDate': 'Abgabedatum'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/de.js
+++ b/components/d2l-evaluation-hub/build/lang/de.js
@@ -12,7 +12,8 @@ const LangDeImpl = (superClass) => class extends superClass {
 			'displayName': 'Vorname, Nachname',
 			'loading': 'Loading',
 			'loadMore': 'Mehr laden',
-			'submissionDate': 'Abgabedatum'
+			'submissionDate': 'Abgabedatum',
+			'masterTeacher': 'Master Teacher'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/en.js
+++ b/components/d2l-evaluation-hub/build/lang/en.js
@@ -12,8 +12,8 @@ const LangEnImpl = (superClass) => class extends superClass {
 			'displayName': 'First Name, Last Name',
 			'loading': 'Loading',
 			'loadMore': 'Load more',
-			'submissionDate': 'Submission Date',
-			'masterTeacher': 'Master Teacher'
+			'masterTeacher': 'Master Teacher',
+			'submissionDate': 'Submission Date'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/en.js
+++ b/components/d2l-evaluation-hub/build/lang/en.js
@@ -12,7 +12,8 @@ const LangEnImpl = (superClass) => class extends superClass {
 			'displayName': 'First Name, Last Name',
 			'loading': 'Loading',
 			'loadMore': 'Load more',
-			'submissionDate': 'Submission Date'
+			'submissionDate': 'Submission Date',
+			'masterTeacher': 'Master Teacher'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/es.js
+++ b/components/d2l-evaluation-hub/build/lang/es.js
@@ -12,7 +12,8 @@ const LangEsImpl = (superClass) => class extends superClass {
 			'displayName': 'Nombre Apellido',
 			'loading': 'Loading',
 			'loadMore': 'Cargar más',
-			'submissionDate': 'Fecha del material enviado'
+			'submissionDate': 'Fecha del material enviado',
+			'masterTeacher': 'Master Teacher'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/es.js
+++ b/components/d2l-evaluation-hub/build/lang/es.js
@@ -12,8 +12,8 @@ const LangEsImpl = (superClass) => class extends superClass {
 			'displayName': 'Nombre Apellido',
 			'loading': 'Loading',
 			'loadMore': 'Cargar más',
-			'submissionDate': 'Fecha del material enviado',
-			'masterTeacher': 'Master Teacher'
+			'masterTeacher': 'Master Teacher',
+			'submissionDate': 'Fecha del material enviado'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/fi.js
+++ b/components/d2l-evaluation-hub/build/lang/fi.js
@@ -12,7 +12,8 @@ const LangFiImpl = (superClass) => class extends superClass {
 			'displayName': 'First Name, Last Name',
 			'loading': 'Loading',
 			'loadMore': 'Load more',
-			'submissionDate': 'Submission Date'
+			'submissionDate': 'Submission Date',
+			'masterTeacher': 'Master Teacher'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/fi.js
+++ b/components/d2l-evaluation-hub/build/lang/fi.js
@@ -12,8 +12,8 @@ const LangFiImpl = (superClass) => class extends superClass {
 			'displayName': 'First Name, Last Name',
 			'loading': 'Loading',
 			'loadMore': 'Load more',
-			'submissionDate': 'Submission Date',
-			'masterTeacher': 'Master Teacher'
+			'masterTeacher': 'Master Teacher',
+			'submissionDate': 'Submission Date'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/fr.js
+++ b/components/d2l-evaluation-hub/build/lang/fr.js
@@ -12,8 +12,8 @@ const LangFrImpl = (superClass) => class extends superClass {
 			'displayName': 'Prénom et Nom de famille',
 			'loading': 'Loading',
 			'loadMore': 'En voir plus',
-			'submissionDate': 'Date de soumission',
-			'masterTeacher': 'Master Teacher'
+			'masterTeacher': 'Master Teacher',
+			'submissionDate': 'Date de soumission'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/fr.js
+++ b/components/d2l-evaluation-hub/build/lang/fr.js
@@ -12,7 +12,8 @@ const LangFrImpl = (superClass) => class extends superClass {
 			'displayName': 'Prénom et Nom de famille',
 			'loading': 'Loading',
 			'loadMore': 'En voir plus',
-			'submissionDate': 'Date de soumission'
+			'submissionDate': 'Date de soumission',
+			'masterTeacher': 'Master Teacher'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/ja.js
+++ b/components/d2l-evaluation-hub/build/lang/ja.js
@@ -12,8 +12,8 @@ const LangJaImpl = (superClass) => class extends superClass {
 			'displayName': '名, 姓',
 			'loading': 'Loading',
 			'loadMore': 'さらに読み込む',
-			'submissionDate': '送信日',
-			'masterTeacher': 'Master Teacher'
+			'masterTeacher': 'Master Teacher',
+			'submissionDate': '送信日'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/ja.js
+++ b/components/d2l-evaluation-hub/build/lang/ja.js
@@ -12,7 +12,8 @@ const LangJaImpl = (superClass) => class extends superClass {
 			'displayName': '名, 姓',
 			'loading': 'Loading',
 			'loadMore': 'さらに読み込む',
-			'submissionDate': '送信日'
+			'submissionDate': '送信日',
+			'masterTeacher': 'Master Teacher'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/ko.js
+++ b/components/d2l-evaluation-hub/build/lang/ko.js
@@ -12,7 +12,8 @@ const LangKoImpl = (superClass) => class extends superClass {
 			'displayName': '이름, 성',
 			'loading': 'Loading',
 			'loadMore': '더 많이 로드',
-			'submissionDate': '제출일'
+			'submissionDate': '제출일',
+			'masterTeacher': 'Master Teacher'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/ko.js
+++ b/components/d2l-evaluation-hub/build/lang/ko.js
@@ -12,8 +12,8 @@ const LangKoImpl = (superClass) => class extends superClass {
 			'displayName': '이름, 성',
 			'loading': 'Loading',
 			'loadMore': '더 많이 로드',
-			'submissionDate': '제출일',
-			'masterTeacher': 'Master Teacher'
+			'masterTeacher': 'Master Teacher',
+			'submissionDate': '제출일'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/nl.js
+++ b/components/d2l-evaluation-hub/build/lang/nl.js
@@ -12,8 +12,8 @@ const LangNlImpl = (superClass) => class extends superClass {
 			'displayName': 'Voornaam, achternaam',
 			'loading': 'Loading',
 			'loadMore': 'Meer laden',
-			'submissionDate': 'Datum van indiening',
-			'masterTeacher': 'Master Teacher'
+			'masterTeacher': 'Master Teacher',
+			'submissionDate': 'Datum van indiening'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/nl.js
+++ b/components/d2l-evaluation-hub/build/lang/nl.js
@@ -12,7 +12,8 @@ const LangNlImpl = (superClass) => class extends superClass {
 			'displayName': 'Voornaam, achternaam',
 			'loading': 'Loading',
 			'loadMore': 'Meer laden',
-			'submissionDate': 'Datum van indiening'
+			'submissionDate': 'Datum van indiening',
+			'masterTeacher': 'Master Teacher'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/pt.js
+++ b/components/d2l-evaluation-hub/build/lang/pt.js
@@ -12,8 +12,8 @@ const LangPtImpl = (superClass) => class extends superClass {
 			'displayName': 'Nome e Sobrenome',
 			'loading': 'Loading',
 			'loadMore': 'Carregar mais',
-			'submissionDate': 'Data do Envio',
-			'masterTeacher': 'Master Teacher'
+			'masterTeacher': 'Master Teacher',
+			'submissionDate': 'Data do Envio'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/pt.js
+++ b/components/d2l-evaluation-hub/build/lang/pt.js
@@ -12,7 +12,8 @@ const LangPtImpl = (superClass) => class extends superClass {
 			'displayName': 'Nome e Sobrenome',
 			'loading': 'Loading',
 			'loadMore': 'Carregar mais',
-			'submissionDate': 'Data do Envio'
+			'submissionDate': 'Data do Envio',
+			'masterTeacher': 'Master Teacher'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/sv.js
+++ b/components/d2l-evaluation-hub/build/lang/sv.js
@@ -12,7 +12,8 @@ const LangSvImpl = (superClass) => class extends superClass {
 			'displayName': 'Förnamn, efternamn',
 			'loading': 'Loading',
 			'loadMore': 'Ladda mer',
-			'submissionDate': 'Inlämningsdatum'
+			'submissionDate': 'Inlämningsdatum',
+			'masterTeacher': 'Master Teacher'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/sv.js
+++ b/components/d2l-evaluation-hub/build/lang/sv.js
@@ -12,8 +12,8 @@ const LangSvImpl = (superClass) => class extends superClass {
 			'displayName': 'Förnamn, efternamn',
 			'loading': 'Loading',
 			'loadMore': 'Ladda mer',
-			'submissionDate': 'Inlämningsdatum',
-			'masterTeacher': 'Master Teacher'
+			'masterTeacher': 'Master Teacher',
+			'submissionDate': 'Inlämningsdatum'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/tr.js
+++ b/components/d2l-evaluation-hub/build/lang/tr.js
@@ -12,8 +12,8 @@ const LangTrImpl = (superClass) => class extends superClass {
 			'displayName': 'Ad, Soyad',
 			'loading': 'Loading',
 			'loadMore': 'Daha fazla yükle',
-			'submissionDate': 'Gönderme Tarihi',
-			'masterTeacher': 'Master Teacher'
+			'masterTeacher': 'Master Teacher',
+			'submissionDate': 'Gönderme Tarihi'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/tr.js
+++ b/components/d2l-evaluation-hub/build/lang/tr.js
@@ -12,7 +12,8 @@ const LangTrImpl = (superClass) => class extends superClass {
 			'displayName': 'Ad, Soyad',
 			'loading': 'Loading',
 			'loadMore': 'Daha fazla yükle',
-			'submissionDate': 'Gönderme Tarihi'
+			'submissionDate': 'Gönderme Tarihi',
+			'masterTeacher': 'Master Teacher'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/zh-tw.js
+++ b/components/d2l-evaluation-hub/build/lang/zh-tw.js
@@ -12,8 +12,8 @@ const LangZhtwImpl = (superClass) => class extends superClass {
 			'displayName': '名字，姓氏',
 			'loading': 'Loading',
 			'loadMore': '載入更多',
-			'submissionDate': '提交日期',
-			'masterTeacher': 'Master Teacher'
+			'masterTeacher': 'Master Teacher',
+			'submissionDate': '提交日期'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/zh-tw.js
+++ b/components/d2l-evaluation-hub/build/lang/zh-tw.js
@@ -12,7 +12,8 @@ const LangZhtwImpl = (superClass) => class extends superClass {
 			'displayName': '名字，姓氏',
 			'loading': 'Loading',
 			'loadMore': '載入更多',
-			'submissionDate': '提交日期'
+			'submissionDate': '提交日期',
+			'masterTeacher': 'Master Teacher'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/zh.js
+++ b/components/d2l-evaluation-hub/build/lang/zh.js
@@ -12,8 +12,8 @@ const LangZhImpl = (superClass) => class extends superClass {
 			'displayName': '名字，姓氏',
 			'loading': 'Loading',
 			'loadMore': '加载更多',
-			'submissionDate': '提交日期',
-			'masterTeacher': 'Master Teacher'
+			'masterTeacher': 'Master Teacher',
+			'submissionDate': '提交日期'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/build/lang/zh.js
+++ b/components/d2l-evaluation-hub/build/lang/zh.js
@@ -12,7 +12,8 @@ const LangZhImpl = (superClass) => class extends superClass {
 			'displayName': '名字，姓氏',
 			'loading': 'Loading',
 			'loadMore': '加载更多',
-			'submissionDate': '提交日期'
+			'submissionDate': '提交日期',
+			'masterTeacher': 'Master Teacher'
 		};
 	}
 };

--- a/components/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.js
+++ b/components/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.js
@@ -81,8 +81,10 @@ class D2LEvaluationHubActivitiesList extends mixinBehaviors([D2L.PolymerBehavior
 	static get is() { return 'd2l-evaluation-hub-activities-list'; }
 	static get properties() {
 		return {
-			'master-teacher': {
-				type: Boolean
+			'masterTeacher': {
+				type: Boolean,
+				value: false,
+				reflectToAttribute: true
 			},
 			_headers: {
 				type: Array,
@@ -310,7 +312,7 @@ class D2LEvaluationHubActivitiesList extends mixinBehaviors([D2L.PolymerBehavior
 
 	_shouldDisplayColumn(columnKey) {
 		if (columnKey.includes('masterTeacher')) {
-			return this['master-teacher'];
+			return this['masterTeacher'];
 		}
 		return true;
 	}

--- a/components/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.js
+++ b/components/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.js
@@ -43,7 +43,9 @@ class D2LEvaluationHubActivitiesList extends mixinBehaviors([D2L.PolymerBehavior
 					<d2l-tr>
 						<dom-repeat items="[[_headers]]">
 							<template>
-								<d2l-th><d2l-table-col-sort-button nosort on-click="_sort"><span>[[localize(item.localizationKey)]]</span></d2l-table-col-sort-button></d2l-th>
+								<template is="dom-if" if="[[_shouldDisplayColumn(item.key)]]">
+									<d2l-th><d2l-table-col-sort-button nosort on-click="_sort"><span>[[localize(item.localizationKey)]]</span></d2l-table-col-sort-button></d2l-th>
+								</template>
 							</template>
 						</dom-repeat>
 					</d2l-tr>
@@ -54,10 +56,12 @@ class D2LEvaluationHubActivitiesList extends mixinBehaviors([D2L.PolymerBehavior
 							<d2l-tr>
 								<dom-repeat items="[[_headers]]" as="h">
 									<template>
-										<d2l-td>
-											<d2l-link href="[[s.activityLink]]" hidden$="[[!h.canLink]]">[[_getDataProperty(s, h.key)]]</d2l-link>
-											<span hidden$="[[h.canLink]]">[[_getDataProperty(s, h.key)]]</span>
-										</d2l-td>
+										<template is="dom-if" if="[[_shouldDisplayColumn(h.key)]]">
+											<d2l-td>
+												<d2l-link href="[[s.activityLink]]" hidden$="[[!h.canLink]]">[[_getDataProperty(s, h.key)]]</d2l-link>
+												<span hidden$="[[h.canLink]]">[[_getDataProperty(s, h.key)]]</span>
+											</d2l-td>
+										</template>
 									</template>
 								</dom-repeat>
 							</d2l-tr>
@@ -77,13 +81,17 @@ class D2LEvaluationHubActivitiesList extends mixinBehaviors([D2L.PolymerBehavior
 	static get is() { return 'd2l-evaluation-hub-activities-list'; }
 	static get properties() {
 		return {
+			'master-teacher': {
+				type: Boolean
+			},
 			_headers: {
 				type: Array,
 				value: [
 					{ key: [ 'displayName' ], sortKey: 'displayName', localizationKey: 'displayName', canLink: true },
 					{ key: [ 'activityName' ], sortKey: 'activityName', localizationKey: 'activityName', canLink: false },
 					{ key: [ 'courseName' ], sortKey: 'courseName', localizationKey: 'courseName', canLink: false },
-					{ key: [ 'submissionDate' ], sortKey: 'submissionDate', localizationKey: 'submissionDate', canLink: false }
+					{ key: [ 'submissionDate' ], sortKey: 'submissionDate', localizationKey: 'submissionDate', canLink: false },
+					{ key: [ 'masterTeacher' ], sortKey: 'masterTeacher', localizationKey: 'masterTeacher', canLink: false }
 				]
 			},
 			_data: {
@@ -298,6 +306,13 @@ class D2LEvaluationHubActivitiesList extends mixinBehaviors([D2L.PolymerBehavior
 			result = item[prop];
 		}
 		return result;
+	}
+
+	_shouldDisplayColumn(columnKey) {
+		if (columnKey.includes('masterTeacher')) {
+			return this['master-teacher'];
+		}
+		return true;
 	}
 }
 

--- a/components/d2l-evaluation-hub/d2l-evaluation-hub.js
+++ b/components/d2l-evaluation-hub/d2l-evaluation-hub.js
@@ -15,9 +15,18 @@ class D2LEvaluationHub extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Entity
 					display: block;
 				}
 			</style>
-			<d2l-evaluation-hub-activities-list href="[[href]]" token="[[token]]"></d2l-evaluation-hub-activities-list>
+			<d2l-evaluation-hub-activities-list href="[[href]]" token="[[token]]" master-teacher="[[master-teacher]]"></d2l-evaluation-hub-activities-list>
 		`;
 	}
+
+	static get properties() {
+		return {
+			'master-teacher': {
+				type: Boolean
+			}
+		};
+	}
+
 	static get is() { return 'd2l-evaluation-hub'; }
 
 }

--- a/components/d2l-evaluation-hub/d2l-evaluation-hub.js
+++ b/components/d2l-evaluation-hub/d2l-evaluation-hub.js
@@ -15,14 +15,16 @@ class D2LEvaluationHub extends mixinBehaviors([D2L.PolymerBehaviors.Siren.Entity
 					display: block;
 				}
 			</style>
-			<d2l-evaluation-hub-activities-list href="[[href]]" token="[[token]]" master-teacher="[[master-teacher]]"></d2l-evaluation-hub-activities-list>
+			<d2l-evaluation-hub-activities-list href="[[href]]" token="[[token]]" master-teacher="[[masterTeacher]]"></d2l-evaluation-hub-activities-list>
 		`;
 	}
 
 	static get properties() {
 		return {
-			'master-teacher': {
-				type: Boolean
+			'masterTeacher': {
+				type: Boolean,
+				value: false,
+				reflectToAttribute: true
 			}
 		};
 	}

--- a/components/d2l-evaluation-hub/lang/ar.json
+++ b/components/d2l-evaluation-hub/lang/ar.json
@@ -4,5 +4,6 @@
    "displayName" : "الاسم الأول، اسم العائلة",
    "loading": "Loading",
    "loadMore" : "تحميل المزيد",
-   "submissionDate" : "تاريخ الإرسال"
+   "submissionDate" : "تاريخ الإرسال",
+   "masterTeacher": "Master Teacher"
 }

--- a/components/d2l-evaluation-hub/lang/ar.json
+++ b/components/d2l-evaluation-hub/lang/ar.json
@@ -4,6 +4,6 @@
    "displayName" : "الاسم الأول، اسم العائلة",
    "loading": "Loading",
    "loadMore" : "تحميل المزيد",
-   "submissionDate" : "تاريخ الإرسال",
-   "masterTeacher": "Master Teacher"
+   "masterTeacher": "Master Teacher",
+   "submissionDate" : "تاريخ الإرسال"
 }

--- a/components/d2l-evaluation-hub/lang/de.json
+++ b/components/d2l-evaluation-hub/lang/de.json
@@ -4,5 +4,6 @@
    "displayName" : "Vorname, Nachname",
    "loading": "Loading",
    "loadMore" : "Mehr laden",
-   "submissionDate" : "Abgabedatum"
+   "submissionDate" : "Abgabedatum",
+   "masterTeacher": "Master Teacher"
 }

--- a/components/d2l-evaluation-hub/lang/de.json
+++ b/components/d2l-evaluation-hub/lang/de.json
@@ -4,6 +4,6 @@
    "displayName" : "Vorname, Nachname",
    "loading": "Loading",
    "loadMore" : "Mehr laden",
-   "submissionDate" : "Abgabedatum",
-   "masterTeacher": "Master Teacher"
+   "masterTeacher": "Master Teacher",
+   "submissionDate" : "Abgabedatum"
 }

--- a/components/d2l-evaluation-hub/lang/en.json
+++ b/components/d2l-evaluation-hub/lang/en.json
@@ -4,6 +4,6 @@
   "displayName": "First Name, Last Name",
   "loading": "Loading",
   "loadMore": "Load more",
-  "submissionDate": "Submission Date",
-  "masterTeacher": "Master Teacher"
+  "masterTeacher": "Master Teacher",
+  "submissionDate": "Submission Date"
 }

--- a/components/d2l-evaluation-hub/lang/en.json
+++ b/components/d2l-evaluation-hub/lang/en.json
@@ -4,5 +4,6 @@
   "displayName": "First Name, Last Name",
   "loading": "Loading",
   "loadMore": "Load more",
-  "submissionDate": "Submission Date"
+  "submissionDate": "Submission Date",
+  "masterTeacher": "Master Teacher"
 }

--- a/components/d2l-evaluation-hub/lang/es.json
+++ b/components/d2l-evaluation-hub/lang/es.json
@@ -4,5 +4,6 @@
    "displayName" : "Nombre Apellido",
    "loading": "Loading",
    "loadMore" : "Cargar más",
-   "submissionDate" : "Fecha del material enviado"
+   "submissionDate" : "Fecha del material enviado",
+   "masterTeacher": "Master Teacher"
 }

--- a/components/d2l-evaluation-hub/lang/es.json
+++ b/components/d2l-evaluation-hub/lang/es.json
@@ -4,6 +4,6 @@
    "displayName" : "Nombre Apellido",
    "loading": "Loading",
    "loadMore" : "Cargar más",
-   "submissionDate" : "Fecha del material enviado",
-   "masterTeacher": "Master Teacher"
+   "masterTeacher": "Master Teacher",
+   "submissionDate" : "Fecha del material enviado"
 }

--- a/components/d2l-evaluation-hub/lang/fi.json
+++ b/components/d2l-evaluation-hub/lang/fi.json
@@ -4,6 +4,6 @@
   "displayName": "First Name, Last Name",
   "loading": "Loading",
   "loadMore": "Load more",
-  "submissionDate": "Submission Date",
-  "masterTeacher": "Master Teacher"
+  "masterTeacher": "Master Teacher",
+  "submissionDate": "Submission Date"
 }

--- a/components/d2l-evaluation-hub/lang/fi.json
+++ b/components/d2l-evaluation-hub/lang/fi.json
@@ -4,5 +4,6 @@
   "displayName": "First Name, Last Name",
   "loading": "Loading",
   "loadMore": "Load more",
-  "submissionDate": "Submission Date"
+  "submissionDate": "Submission Date",
+  "masterTeacher": "Master Teacher"
 }

--- a/components/d2l-evaluation-hub/lang/fr.json
+++ b/components/d2l-evaluation-hub/lang/fr.json
@@ -4,6 +4,6 @@
    "displayName" : "Prénom et Nom de famille",
    "loading": "Loading",
    "loadMore" : "En voir plus",
-   "submissionDate" : "Date de soumission",
-   "masterTeacher": "Master Teacher"
+   "masterTeacher": "Master Teacher",
+   "submissionDate" : "Date de soumission"
 }

--- a/components/d2l-evaluation-hub/lang/fr.json
+++ b/components/d2l-evaluation-hub/lang/fr.json
@@ -4,5 +4,6 @@
    "displayName" : "Prénom et Nom de famille",
    "loading": "Loading",
    "loadMore" : "En voir plus",
-   "submissionDate" : "Date de soumission"
+   "submissionDate" : "Date de soumission",
+   "masterTeacher": "Master Teacher"
 }

--- a/components/d2l-evaluation-hub/lang/ja.json
+++ b/components/d2l-evaluation-hub/lang/ja.json
@@ -4,5 +4,6 @@
    "displayName" : "名, 姓",
    "loading": "Loading",
    "loadMore" : "さらに読み込む",
-   "submissionDate" : "送信日"
+   "submissionDate" : "送信日",
+   "masterTeacher": "Master Teacher"
 }

--- a/components/d2l-evaluation-hub/lang/ja.json
+++ b/components/d2l-evaluation-hub/lang/ja.json
@@ -4,6 +4,6 @@
    "displayName" : "名, 姓",
    "loading": "Loading",
    "loadMore" : "さらに読み込む",
-   "submissionDate" : "送信日",
-   "masterTeacher": "Master Teacher"
+   "masterTeacher": "Master Teacher",
+   "submissionDate" : "送信日"
 }

--- a/components/d2l-evaluation-hub/lang/ko.json
+++ b/components/d2l-evaluation-hub/lang/ko.json
@@ -4,6 +4,6 @@
    "displayName" : "이름, 성",
    "loading": "Loading",
    "loadMore" : "더 많이 로드",
-   "submissionDate" : "제출일",
-   "masterTeacher": "Master Teacher"
+   "masterTeacher": "Master Teacher",
+   "submissionDate" : "제출일"
 }

--- a/components/d2l-evaluation-hub/lang/ko.json
+++ b/components/d2l-evaluation-hub/lang/ko.json
@@ -4,5 +4,6 @@
    "displayName" : "이름, 성",
    "loading": "Loading",
    "loadMore" : "더 많이 로드",
-   "submissionDate" : "제출일"
+   "submissionDate" : "제출일",
+   "masterTeacher": "Master Teacher"
 }

--- a/components/d2l-evaluation-hub/lang/nl.json
+++ b/components/d2l-evaluation-hub/lang/nl.json
@@ -4,5 +4,6 @@
    "displayName" : "Voornaam, achternaam",
    "loading": "Loading",
    "loadMore" : "Meer laden",
-   "submissionDate" : "Datum van indiening"
+   "submissionDate" : "Datum van indiening",
+   "masterTeacher": "Master Teacher"
 }

--- a/components/d2l-evaluation-hub/lang/nl.json
+++ b/components/d2l-evaluation-hub/lang/nl.json
@@ -4,6 +4,6 @@
    "displayName" : "Voornaam, achternaam",
    "loading": "Loading",
    "loadMore" : "Meer laden",
-   "submissionDate" : "Datum van indiening",
-   "masterTeacher": "Master Teacher"
+   "masterTeacher": "Master Teacher",
+   "submissionDate" : "Datum van indiening"
 }

--- a/components/d2l-evaluation-hub/lang/pt.json
+++ b/components/d2l-evaluation-hub/lang/pt.json
@@ -4,5 +4,6 @@
    "displayName" : "Nome e Sobrenome",
    "loading": "Loading",
    "loadMore" : "Carregar mais",
-   "submissionDate" : "Data do Envio"
+   "submissionDate" : "Data do Envio",
+   "masterTeacher": "Master Teacher"
 }

--- a/components/d2l-evaluation-hub/lang/pt.json
+++ b/components/d2l-evaluation-hub/lang/pt.json
@@ -4,6 +4,6 @@
    "displayName" : "Nome e Sobrenome",
    "loading": "Loading",
    "loadMore" : "Carregar mais",
-   "submissionDate" : "Data do Envio",
-   "masterTeacher": "Master Teacher"
+   "masterTeacher": "Master Teacher",
+   "submissionDate" : "Data do Envio"
 }

--- a/components/d2l-evaluation-hub/lang/sv.json
+++ b/components/d2l-evaluation-hub/lang/sv.json
@@ -4,6 +4,6 @@
    "displayName" : "Förnamn, efternamn",
    "loading": "Loading",
    "loadMore" : "Ladda mer",
-   "submissionDate" : "Inlämningsdatum",
-   "masterTeacher": "Master Teacher"
+   "masterTeacher": "Master Teacher",
+   "submissionDate" : "Inlämningsdatum"
 }

--- a/components/d2l-evaluation-hub/lang/sv.json
+++ b/components/d2l-evaluation-hub/lang/sv.json
@@ -4,5 +4,6 @@
    "displayName" : "Förnamn, efternamn",
    "loading": "Loading",
    "loadMore" : "Ladda mer",
-   "submissionDate" : "Inlämningsdatum"
+   "submissionDate" : "Inlämningsdatum",
+   "masterTeacher": "Master Teacher"
 }

--- a/components/d2l-evaluation-hub/lang/tr.json
+++ b/components/d2l-evaluation-hub/lang/tr.json
@@ -4,5 +4,6 @@
    "displayName" : "Ad, Soyad",
    "loading": "Loading",
    "loadMore" : "Daha fazla yükle",
-   "submissionDate" : "Gönderme Tarihi"
+   "submissionDate" : "Gönderme Tarihi",
+   "masterTeacher": "Master Teacher"
 }

--- a/components/d2l-evaluation-hub/lang/tr.json
+++ b/components/d2l-evaluation-hub/lang/tr.json
@@ -4,6 +4,6 @@
    "displayName" : "Ad, Soyad",
    "loading": "Loading",
    "loadMore" : "Daha fazla yükle",
-   "submissionDate" : "Gönderme Tarihi",
-   "masterTeacher": "Master Teacher"
+   "masterTeacher": "Master Teacher",
+   "submissionDate" : "Gönderme Tarihi"
 }

--- a/components/d2l-evaluation-hub/lang/zh-tw.json
+++ b/components/d2l-evaluation-hub/lang/zh-tw.json
@@ -4,6 +4,6 @@
    "displayName" : "名字，姓氏",
    "loading": "Loading",
    "loadMore" : "載入更多",
-   "submissionDate" : "提交日期",
-   "masterTeacher": "Master Teacher"
+   "masterTeacher": "Master Teacher",
+   "submissionDate" : "提交日期"
 }

--- a/components/d2l-evaluation-hub/lang/zh-tw.json
+++ b/components/d2l-evaluation-hub/lang/zh-tw.json
@@ -4,5 +4,6 @@
    "displayName" : "名字，姓氏",
    "loading": "Loading",
    "loadMore" : "載入更多",
-   "submissionDate" : "提交日期"
+   "submissionDate" : "提交日期",
+   "masterTeacher": "Master Teacher"
 }

--- a/components/d2l-evaluation-hub/lang/zh.json
+++ b/components/d2l-evaluation-hub/lang/zh.json
@@ -4,6 +4,6 @@
    "displayName" : "名字，姓氏",
    "loading": "Loading",
    "loadMore" : "加载更多",
-   "submissionDate" : "提交日期",
-   "masterTeacher": "Master Teacher"
+   "masterTeacher": "Master Teacher",
+   "submissionDate" : "提交日期"
 }

--- a/components/d2l-evaluation-hub/lang/zh.json
+++ b/components/d2l-evaluation-hub/lang/zh.json
@@ -4,5 +4,6 @@
    "displayName" : "名字，姓氏",
    "loading": "Loading",
    "loadMore" : "加载更多",
-   "submissionDate" : "提交日期"
+   "submissionDate" : "提交日期",
+   "masterTeacher": "Master Teacher"
 }

--- a/test/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.js
+++ b/test/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.js
@@ -93,6 +93,7 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 	var expectedHeaders = [
 		'First Name, Last Name', 'Activity Name', 'Course', 'Submission Date'
 	];
+	var expectedHeadersWithMasterTeacher = expectedHeaders.concat('Master Teacher');
 
 	suite('d2l-evaluation-hub-activities-list', function() {
 		setup(function() {
@@ -121,12 +122,30 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 				done();
 			});
 		});
-		test('headers display correctly', function() {
+		test('headers display correctly', function(done) {
 			flush(function() {
 				var headers = list.shadowRoot.querySelectorAll('d2l-th d2l-table-col-sort-button');
+
+				assert.equal(expectedHeaders.length, headers.length);
+
 				for (var i = 0; i < expectedHeaders.length; i++) {
 					assert.include(headers[i].innerHTML, expectedHeaders[i]);
 				}
+				done();
+			});
+		});
+		test('headers include master teacher when toggled on, and is display correctly', function(done) {
+			list.setAttribute('master-teacher', '');
+
+			flush(function() {
+
+				var headers = list.shadowRoot.querySelectorAll('d2l-th d2l-table-col-sort-button');
+				assert.equal(expectedHeadersWithMasterTeacher.length, headers.length);
+
+				for (var i = 0; i < expectedHeadersWithMasterTeacher.length; i++) {
+					assert.include(headers[i].innerHTML, expectedHeadersWithMasterTeacher[i]);
+				}
+				done();
 			});
 		});
 		test('data is imported correctly', (done) => {


### PR DESCRIPTION
When teacher attribute is on display master teacher column. Currently the column will always be empty, I will populate it in a future PR. Should be safe to merge.

![image](https://user-images.githubusercontent.com/1176292/53127401-56a70700-3530-11e9-94f5-1275abb65552.png)
