### PR TITLE
Add data concatenation just to Load More

### DIFF
--- a/test/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.js
+++ b/test/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.js
@@ -132,18 +132,18 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			assert.equal(list.href, 'blah');
 			assert.equal(list.token, 't');
 		});
-		test('_initialLoading and _loading are set to true before data is loaded, and loading-spinner is present', () => {
+		test('_fullListLoading and _loading are set to true before data is loaded, and loading-spinner is present', () => {
 			var loadingSpinner = list.shadowRoot.querySelector('d2l-loading-spinner');
 			assert.equal(loadingSpinner.hidden, false);
-			assert.equal(list._initialLoading, true);
+			assert.equal(list._fullListLoading, true);
 			assert.equal(list._loading, true);
 		});
-		test('_initialLoading and _loading is set to false after data is loaded and the loading spinner is hidden', (done) => {
+		test('_fullListLoading and _loading is set to false after data is loaded and the loading spinner is hidden', (done) => {
 			var loadingSpinner = list.shadowRoot.querySelector('d2l-loading-spinner');
 
 			loadPromise('data/unassessedActivities.json').then(function() {
 				assert.equal(loadingSpinner.hidden, true);
-				assert.equal(list._initialLoading, false);
+				assert.equal(list._fullListLoading, false);
 				assert.equal(list._loading, false);
 				done();
 			});


### PR DESCRIPTION
This is something filter and sorting is going to need, so trying to help pave the way for those.  Now, `_loadMore` will concat data and add to the table, but the initial load and changes to the href will just call `_loadData` which replaces the table (and shows a loading spinner over the whole table as that is fetched). 
 Sorting and filtering should use the `_loadData` function.