### PR TITLE
Fire the d2l-activity-text-loaded event after next render.

### DIFF
--- a/components/d2l-activity-list-item/d2l-activity-list-item.js
+++ b/components/d2l-activity-list-item/d2l-activity-list-item.js
@@ -217,7 +217,7 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 					margin-right: 0.5rem;
 				}
 			</style>
-			<div class="d2l-activity-list-item-container">
+			<div class="d2l-activity-list-item-container" style="visibility:hidden;">
 				<hr class="d2l-activity-list-item-top-line" />
 				<a class="d2l-focusable" href$="[[_activityHomepage]]">
 					<span class="d2l-activity-list-item-link-text">[[_accessibilityDataToString(_accessibilityData)]]</span>
@@ -420,6 +420,13 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 		this._accessibilityData.semesterName = e.detail.semesterName && e.detail.semesterName;
 
 		this.notifyPath('_accessibilityData');
+
+		afterNextRender(this, () => {
+			this.dispatchEvent(new CustomEvent('d2l-activity-text-loaded', {
+				bubbles: true,
+				composed: true
+			}));
+		});
 	}
 
 	_accessibilityDataToString(accessibility) {
@@ -494,6 +501,12 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 
 			if (this.textPlaceholder) {
 				this._setTextPlaceholderStyles(currentConfig);
+			}
+			const listItemContainer = this.shadowRoot.querySelector('.d2l-activity-list-item-container');
+			if (listItemContainer.style.visibility === 'hidden') {
+				afterNextRender(this, () => {
+					listItemContainer.style.visibility = 'visible';
+				});
 			}
 		});
 	}
@@ -584,13 +597,6 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 		}
 		this._activityHomepage = sirenEntity.hasLink(Rels.Activities.activityHomepage) && sirenEntity.getLinkByRel(Rels.Activities.activityHomepage).href;
 		this._organizationUrl = sirenEntity.hasLink(Rels.organization) && sirenEntity.getLinkByRel(Rels.organization).href;
-
-		afterNextRender(this, () => {
-			this.dispatchEvent(new CustomEvent('d2l-activity-text-loaded', {
-				bubbles: true,
-				composed: true
-			}));
-		});
 
 		if (this._organizationUrl) {
 			this._fetchEntity(this._organizationUrl)

--- a/components/d2l-activity-list-item/d2l-activity-list-item.js
+++ b/components/d2l-activity-list-item/d2l-activity-list-item.js
@@ -585,10 +585,12 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 		this._activityHomepage = sirenEntity.hasLink(Rels.Activities.activityHomepage) && sirenEntity.getLinkByRel(Rels.Activities.activityHomepage).href;
 		this._organizationUrl = sirenEntity.hasLink(Rels.organization) && sirenEntity.getLinkByRel(Rels.organization).href;
 
-		this.dispatchEvent(new CustomEvent('d2l-activity-text-loaded', {
-			bubbles: true,
-			composed: true
-		}));
+		afterNextRender(this, () => {
+			this.dispatchEvent(new CustomEvent('d2l-activity-text-loaded', {
+				bubbles: true,
+				composed: true
+			}));
+		});
 
 		if (this._organizationUrl) {
 			this._fetchEntity(this._organizationUrl)

--- a/test/d2l-activity-list-item/d2l-activity-list-item-test.js
+++ b/test/d2l-activity-list-item/d2l-activity-list-item-test.js
@@ -137,13 +137,13 @@ describe('d2l-activity-list-item', () => {
 				expect(component._activityHomepage).to.equal('#');
 			});
 
-			it(testCase.name + 'should send text loaded event', done => {
-				window.document.addEventListener('d2l-activity-text-loaded', () => {
-					done();
-				});
-				testCase.beforeEachFn();
-			});
+		});
 
+		it(testCase.name + 'should send text loaded event', done => {
+			window.document.addEventListener('d2l-activity-text-loaded', () => {
+				done();
+			});
+			testCase.beforeEachFn();
 		});
 
 		it(testCase.name + 'should send image loaded event', done => {

--- a/test/d2l-activity-list-item/d2l-activity-list-item-test.js
+++ b/test/d2l-activity-list-item/d2l-activity-list-item-test.js
@@ -137,8 +137,11 @@ describe('d2l-activity-list-item', () => {
 				expect(component._activityHomepage).to.equal('#');
 			});
 
-			it('should send text loaded event', () => {
-				expect(textLoadedSuccessfulSpy.calledOnce).to.be.true;
+			it(testCase.name + 'should send text loaded event', done => {
+				window.document.addEventListener('d2l-activity-text-loaded', () => {
+					done();
+				});
+				testCase.beforeEachFn();
 			});
 
 		});
@@ -149,7 +152,6 @@ describe('d2l-activity-list-item', () => {
 			});
 			testCase.beforeEachFn();
 		});
-
 	});
 
 	describe('Accessibility', () => {


### PR DESCRIPTION
This seems to fix the issue of firing the event too early before the element is stamped (I experienced this in a dom-repeat situation).
`d2l-course-image` does this as well.
Any issues that anyone can think of?