### PR TITLE
US103573 - Simple base component that displays draft icon

### DIFF
--- a/components/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.js
+++ b/components/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.js
@@ -1,0 +1,40 @@
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import 'd2l-polymer-siren-behaviors/store/entity-behavior.js';
+import 'd2l-icons/d2l-icon.js';
+import 'd2l-icons/tier1-icons.js';
+
+/**
+ * @customElement
+ * @polymer
+ */
+
+class ActivityEvaluationIconBase extends PolymerElement {
+	static get template() {
+		return html`
+			<style>
+				:host(:not([draft])) {
+					display: none;
+				}
+				:host {
+					display: inline-block;
+				}
+			</style>
+			<template is="dom-if" if="[[draft]]">
+				<d2l-icon id="d2l-draft-icon" icon="d2l-tier1:draft"></d2l-icon>
+			</template>
+		`;
+	}
+
+	static get is() { return 'd2l-activity-evaluation-icon-base'; }
+
+	static get properties() {
+		return {
+			draft: {
+				type: Boolean,
+				value: false
+			}
+		};
+	}
+}
+
+window.customElements.define('d2l-activity-evaluation-icon-base', ActivityEvaluationIconBase);

--- a/demo/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.html
+++ b/demo/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+	<title>d2l-activity-evaluation-icon-base demo</title>
+	<script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+
+	<!-- For IE11 -->
+	<script src="../../node_modules/lie/dist/lie.polyfill.min.js"></script>
+	<script type="module" src="../../node_modules/whatwg-fetch/fetch.js"></script>
+
+	<script type="module">
+		import '@polymer/iron-demo-helpers/demo-pages-shared-styles';
+		import '@polymer/iron-demo-helpers/demo-snippet';
+		import 'd2l-typography/d2l-typography.js';
+		import '../../components/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.js';
+
+		const $_documentContainer = document.createElement('template');
+		$_documentContainer.innerHTML = `
+				<custom-style>
+					<style is="custom-style" include="demo-pages-shared-styles"></style>
+				</custom-style>
+				<custom-style include="d2l-typography">
+					<style is="custom-style" include="d2l-typography"></style>
+				</custom-style>
+				<style>
+					html {
+						font-size: 20px;
+					}
+				</style>
+			`;
+		document.body.appendChild($_documentContainer.content);
+	</script>
+</head>
+
+<body class="d2l-typography">
+	<div class="vertical-section-container fixedSize">
+		<h3>Basic d2l-activity-evaluation-icon-base demo</h3>
+		<demo-snippet>
+			<template strip-whitespace>
+				<h4>Icon when Evaluation on Activity is Undefined</h4>
+				<p>It is expected nothing is displayed when the evaluation on the activity is undefined</p>
+				<d2l-activity-evaluation-icon-base></d2l-activity-evaluation-icon-base>
+			</template>
+		</demo-snippet>
+
+		<demo-snippet>
+			<template strip-whitespace>
+				<h4>Icon when Evaluation on Activity is in Draft State</h4>
+				<d2l-activity-evaluation-icon-base draft></d2l-activity-evaluation-icon-base>
+			</template>
+		</demo-snippet>
+	</div>
+</body>
+
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -39,6 +39,8 @@
 				<h4>Evaluation Hub</h4>
 				<li><a href="d2l-evaluation-hub/d2l-evaluation-hub.html">d2l-evaluation-hub</a></li>
 				<li><a href="d2l-evaluation-hub/d2l-evaluation-hub-activities-list.html">d2l-evaluation-hub-activities-list</a></li>
+				<h4>Activity Evaluation Icon</h4>
+				<li><a href="d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.html">d2l-activity-evaluation-icon-base</a></li>
 			</ul>
 		</div>
 	</body>

--- a/test/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.html
+++ b/test/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+		<title>d2l-activity-evaluation-icon-base test</title>
+
+		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+		<script src="../../../@babel/polyfill/browser.js"></script>
+		<script src="../../../wct-browser-legacy/browser.js"></script>
+
+		<!-- For IE11 -->
+		<script src="../../../lie/dist/lie.polyfill.min.js"></script>
+		<script type="module" src="../../../whatwg-fetch/fetch.js"></script>
+
+		<script type="module" src="../../components/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.js"></script>
+	</head>
+	<body>
+		<test-fixture id="invalid">
+			<template strip-whitespace>
+				<d2l-activity-evaluation-icon-base></d2l-activity-evaluation-icon-base>
+			</template>
+		</test-fixture>
+		<test-fixture id="draft">
+			<template strip-whitespace>
+				<d2l-activity-evaluation-icon-base draft></d2l-activity-evaluation-icon-base>
+			</template>
+		</test-fixture>
+		<script type="module" src="./d2l-activity-evaluation-icon-base.js"></script>
+	</body>
+</html>

--- a/test/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.js
+++ b/test/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.js
@@ -1,0 +1,37 @@
+(function() {
+	suite('d2l-activity-evaluation-icon-base as draft', function() {
+		let draftEvaluation;
+		let invalidEvaluation;
+
+		setup(function() {
+			invalidEvaluation = fixture('invalid');
+			draftEvaluation = fixture('draft');
+		});
+
+		test('instantiating the element works', function() {
+			assert.equal(draftEvaluation.tagName.toLowerCase(), 'd2l-activity-evaluation-icon-base');
+		});
+
+		test('activity evaluation without any attribute does not display an icon', function(done) {
+			flush(function() {
+
+				var icon = invalidEvaluation.shadowRoot.querySelector('d2l-icon');
+				assert.equal(null, icon);
+
+				done();
+			});
+		});
+
+		test('activity evaluation with draft attribute displayed draft icon', function(done) {
+			flush(function() {
+
+				var draftIcon = draftEvaluation.shadowRoot.querySelector('#d2l-draft-icon');
+				var draftIconName = draftIcon.getAttribute('icon');
+				assert.equal('d2l-tier1:draft', draftIconName);
+
+				done();
+			});
+		});
+
+	});
+})();

--- a/test/index.html
+++ b/test/index.html
@@ -1,24 +1,29 @@
 <!doctype html>
 <html>
-  <head>
-		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="../../wct-browser-legacy/browser.js"></script>
-  </head>
-  <body>
-    <script>
-      // Load and run all tests (.html, .js):
-      WCT.loadSuites([
-      	'd2l-activity-list-item/d2l-activity-list-item-test.html?wc-shadydom=true&wc-ce=true',
-      	'd2l-activity-list-item/d2l-activity-list-item-test.html?dom=shadow',
-      	'd2l-activity-name/d2l-activity-name.html?wc-shadydom=true&wc-ce=true',
-      	'd2l-activity-name/d2l-activity-name.html?dom=shadow',
-      	'd2l-evaluation-hub/d2l-evaluation-hub.html?wc-shadydom=true&wc-ce=true',
-      	'd2l-evaluation-hub/d2l-evaluation-hub.html?dom=shadow',
-      	'd2l-evaluation-hub/d2l-evaluation-hub-activities-list.html?wc-shadydom=true&wc-ce=true',
-      	'd2l-evaluation-hub/d2l-evaluation-hub-activities-list.html?dom=shadow'
-      ]);
-    </script>
-  </body>
+
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+	<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+	<script src="../../wct-browser-legacy/browser.js"></script>
+</head>
+
+<body>
+	<script>
+		// Load and run all tests (.html, .js):
+		WCT.loadSuites([
+			'd2l-activity-list-item/d2l-activity-list-item-test.html?wc-shadydom=true&wc-ce=true',
+			'd2l-activity-list-item/d2l-activity-list-item-test.html?dom=shadow',
+			'd2l-activity-name/d2l-activity-name.html?wc-shadydom=true&wc-ce=true',
+			'd2l-activity-name/d2l-activity-name.html?dom=shadow',
+			'd2l-evaluation-hub/d2l-evaluation-hub.html?wc-shadydom=true&wc-ce=true',
+			'd2l-evaluation-hub/d2l-evaluation-hub.html?dom=shadow',
+			'd2l-evaluation-hub/d2l-evaluation-hub-activities-list.html?wc-shadydom=true&wc-ce=true',
+			'd2l-evaluation-hub/d2l-evaluation-hub-activities-list.html?dom=shadow',
+			'd2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.html?wc-shadydom=true&wc-ce=true',
+			'd2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.html?dom=shadow'
+		]);
+	</script>
+</body>
+
 </html>


### PR DESCRIPTION
* Adding base component to display the draft icon when needed
* Next PR will look into adding the tool tip


![image](https://user-images.githubusercontent.com/1176292/53741856-4b73a580-3e65-11e9-9e2b-fab2c185da51.png)


* FYI some tests fail locally, does this happen for anyone else?
  * For test "Setting the href attributeshould sned text loaded event
```
Error: done() called multiple times
      forEach.testCase at d2l-activity-list-item-test.js:121
        Suite.describe at d2l-activity-list-item-test.js:96
  wrappedMochaFunction at /components/wct-browser-legacy/browser.js:2028
             <unknown> at d2l-activity-list-item-test.js:2
```