### PR TITLE
Refactor to make ie11 work

### DIFF
--- a/demo/d2l-evaluation-hub/demo-data-parser.js
+++ b/demo/d2l-evaluation-hub/demo-data-parser.js
@@ -4,9 +4,17 @@ function formatName(firstName, lastName) {
 	return firstName + ' ' + lastName;
 }
 
+function distinct_ie11_safe(array) {
+	const map = {};
+	array.forEach(ele => {
+		map[ele] = ele;
+	});
+	return Object.keys(map);
+}
+
 function parseUsers(data) {
 	const names = data.map(row => formatName(row.firstName, row.lastName));
-	const uniqueNames = [... new Set(names)];
+	const uniqueNames = distinct_ie11_safe(names);
 
 	return uniqueNames;
 }
@@ -30,7 +38,7 @@ function getHrefForUserId(id) {
 
 function parseActivityNames(data) {
 	const activityNames = data.map(row => row.activityName);
-	const uniqueActivityNames = [... new Set(activityNames)];
+	const uniqueActivityNames = distinct_ie11_safe(activityNames);
 
 	return uniqueActivityNames;
 }
@@ -49,7 +57,7 @@ function getHrefForActivityNameId(id) {
 
 function parseCourses(data) {
 	const courseNames = data.map(row => row.courseName);
-	const uniqueCourseNames = [... new Set(courseNames)];
+	const uniqueCourseNames = distinct_ie11_safe(courseNames);
 
 	return uniqueCourseNames;
 }


### PR DESCRIPTION
No spread operator (`...`) so I took it out. Then I had a hard time making `Set` work before I realized ie11 only partially supports `Set`. I couldn't figure out how to turn a `Set` into an array for ie11 so I just hacked something together.