### PR TITLE
US104170 - truncate + nowrap for CourseName

### DIFF
--- a/components/d2l-activity-name/d2l-activity-name.js
+++ b/components/d2l-activity-name/d2l-activity-name.js
@@ -16,7 +16,6 @@ class D2LActivityName extends mixinBehaviors([D2L.PolymerBehaviors.Siren.EntityB
 			<style>
 				:host {
 					display: block;
-					white-space: nowrap;
 				}
 				.d2l-activity-name-icon {
 					display: inline-block;

--- a/components/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.js
+++ b/components/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.js
@@ -38,7 +38,7 @@ class D2LEvaluationHubActivitiesList extends mixinBehaviors([D2L.PolymerBehavior
 					white-space: nowrap;
 				}
 				.d2l-activity-name-column {
-					padding-right: 2.4em;
+					padding-right: 2.4rem;
 				}
 				:host(:dir(rtl)) .d2l-activity-name-column {
 					padding-right: 0;

--- a/components/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.js
+++ b/components/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.js
@@ -33,6 +33,21 @@ class D2LEvaluationHubActivitiesList extends mixinBehaviors([D2L.PolymerBehavior
 					text-align: right;
 					width: 100%;
 				}
+				.d2l-evaluation-hub-truncated-column {
+					max-width: 10rem;
+					white-space: nowrap;
+				}
+				.d2l-activity-name-column {
+					padding-right: 2.4em;
+				}
+				:host(:dir(rtl)) .d2l-activity-name-column {
+					padding-right: 0;
+					padding-left: 2.4rem;
+				}
+				.d2l-course-name-column {
+					overflow: hidden;
+					text-overflow: ellipsis;
+				}
 				[hidden] {
 					display: none;
 				}
@@ -62,10 +77,10 @@ class D2LEvaluationHubActivitiesList extends mixinBehaviors([D2L.PolymerBehavior
 									<d2l-link href="[[s.activityLink]]">[[_getDataProperty(s, 'displayName')]]</d2l-link>
 									<d2l-activity-evaluation-icon-base draft$="[[s.isDraft]]"></d2l-activity-evaluation-icon-base>
 								</d2l-td>
-								<d2l-td>
+								<d2l-td class="d2l-evaluation-hub-truncated-column d2l-activity-name-column">
 									<d2l-activity-name href="[[_getDataProperty(s, 'activityNameHref')]]" token="[[token]]"></d2l-activity-name>
 								</d2l-td>
-								<d2l-td>
+								<d2l-td class="d2l-evaluation-hub-truncated-column d2l-course-name-column">
 									<span>[[_getDataProperty(s, 'courseName')]]</span>
 								</d2l-td>
 								<d2l-td>

--- a/demo/d2l-evaluation-hub/table.js
+++ b/demo/d2l-evaluation-hub/table.js
@@ -54,7 +54,7 @@ export default
 			'lastName': 'Bedley',
 			'activityType': 'assignment',
 			'activityName': 'What is Love?',
-			'courseName': 'Music 304 - A Study of Haddaway',
+			'courseName': 'Music 304 - A Study of Haddaway Music 304 - A Study of Haddaway Music 304 - A Study of Haddaway Music 304 - A Study of Haddaway',
 			'localizedFormattedDate': '3/9/2019 10:16 AM',
 			'masterTeacher': {
 				'firstName': 'Brett',
@@ -65,7 +65,7 @@ export default
 			'firstName': 'Alex',
 			'lastName': 'Bedley',
 			'activityType': 'assignment',
-			'activityName': 'The Bestest Number',
+			'activityName': 'The Bestest Number The Bestest Number The Bestest Number The Bestest Number The Bestest Number The Bestest Number',
 			'courseName': 'Math 102 - Numbers',
 			'localizedFormattedDate': '3/9/2019 10:16 AM',
 			'masterTeacher': {


### PR DESCRIPTION
As per design discussion, we are only adding truncate and nowrap for ActivityName (which already has it) and CourseName.

- First cut at truncate and no wrap for course name
- Specify padding for activity name

![truncate_nowrap_coursename](https://user-images.githubusercontent.com/11618509/53987585-6e18ef00-40ef-11e9-9f52-784d943ed846.PNG)

This is as small as the ActivityName and CourseName columns would get:

![image](https://user-images.githubusercontent.com/11618509/53987721-cea82c00-40ef-11e9-81ae-67518c1d90a0.png)