### PR TITLE
US104761 - Load sort state on load

### DIFF
--- a/components/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.js
+++ b/components/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.js
@@ -250,6 +250,11 @@ class D2LEvaluationHubActivitiesList extends mixinBehaviors([D2L.PolymerBehavior
 							const sort = sortsEntity.entity.getSubEntityByClass(header.sortClass);
 							if (sort) {
 								this.set(`_headerColumns.${i}.headers.${j}.canSort`, true);
+								if (sort.properties && sort.properties.applied && (sort.properties.priority === 0)) {
+									const descending = sort.properties.direction === 'descending';
+									this.set(`_headerColumns.${i}.headers.${j}.sorted`, true);
+									this.set(`_headerColumns.${i}.headers.${j}.desc`, descending);
+								}
 							}
 						}
 					});

--- a/demo/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.html
+++ b/demo/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.html
@@ -51,7 +51,7 @@
 				<h4>Note: Load more button is expected to fail on second click, but should resolve itself when clicking it again</h4>
 				<hr/><br/>
 				<template strip-whitespace>
-					<d2l-evaluation-hub-activities-list href="pages/0" token="whatever"></d2l-evaluation-hub-activities-list>
+					<d2l-evaluation-hub-activities-list href="pages/0?sort=bydate-a" token="whatever"></d2l-evaluation-hub-activities-list>
 				</template>
 			</demo-snippet>
 			<demo-snippet>

--- a/demo/d2l-evaluation-hub/d2l-evaluation-hub.html
+++ b/demo/d2l-evaluation-hub/d2l-evaluation-hub.html
@@ -51,7 +51,7 @@
 				<h4>Note: Load more button is expected to fail on second click, but should resolve itself when clicking it again</h4>
 				<hr/><br/>
 				<template strip-whitespace>
-					<d2l-evaluation-hub master-teacher href="pages/0" token="whatever"></d2l-evaluation-hub>
+					<d2l-evaluation-hub master-teacher href="pages/0?sort=bydate-a" token="whatever"></d2l-evaluation-hub>
 				</template>
 			</demo-snippet>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1176292/54136783-c2bfb100-43f2-11e9-8296-509d51e3d24c.png)

* Demo now shows sort state on initial load. I use `?sort=bydate-a` in demo data. LMS will need to be configured to use this sort by default as well.
* Demo will work correctly after https://github.com/BrightspaceHypermediaComponents/activities/pull/89

