### PR TITLE
Add padding for draft icon

### DIFF
--- a/components/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.js
+++ b/components/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.js
@@ -44,6 +44,13 @@ class D2LEvaluationHubActivitiesList extends mixinBehaviors([D2L.PolymerBehavior
 					max-width: 10rem;
 					white-space: nowrap;
 				}
+				d2l-activity-evaluation-icon-base {
+					padding-left: 0.6rem;
+				}
+				:host(:dir(rtl)) d2l-activity-evaluation-icon-base {
+					padding-left: 0;
+					padding-right: 0.6rem;
+				}
 				.d2l-activity-name-column {
 					padding-right: 2.4rem;
 				}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1176292/54138681-55158400-43f6-11e9-8aa0-a334ef394f60.png)

![image](https://user-images.githubusercontent.com/1176292/54138668-4f1fa300-43f6-11e9-8901-b102742ee195.png)


* Draft icon seemed too close to name
* I used same spacing as in https://github.com/BrightspaceHypermediaComponents/activities/pull/74


Unsure why RTL looks weird for activity. Probably because everything is still left justified, I'm not sure what is normal for RTL case