### PR TITLE
Only try to focus if the new element exists

### DIFF
--- a/components/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.js
+++ b/components/d2l-evaluation-hub/d2l-evaluation-hub-activities-list.js
@@ -401,7 +401,9 @@ class D2LEvaluationHubActivitiesList extends mixinBehaviors([D2L.PolymerBehavior
 							this._loading = false;
 							window.requestAnimationFrame(function() {
 								var newElementToFocus = D2L.Dom.Focus.getNextFocusable(lastFocusableTableElement, false);
-								newElementToFocus.focus();
+								if (newElementToFocus) {
+									newElementToFocus.focus();
+								}
 							});
 						}
 					}


### PR DESCRIPTION
This is coming up in a Firefox test a lot making it flaky.  The change itself is good anyways.