### PR TITLE
bump version number to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"wct-browser-legacy": "^1.0.1",
 		"whatwg-fetch": "^3.0.0"
 	},
-	"version": "1.23.0",
+	"version": "2.0.0",
 	"resolutions": {
 		"inherits": "2.0.3",
 		"samsam": "1.1.3",


### PR DESCRIPTION
Should be a one time thing.

In future this bump will happen as part of the PR with the changes (as per my suggested readme changes):
https://d2l.slack.com/archives/CBTK3JB6D/p1553084666352400