### PR TITLE
US104726 - Retain number of shown activities on sort

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -426,7 +426,7 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 				return action;
 			}).bind(this))
 			.then((collectionAction => {
-				const customParams = this._numberOfCurrentlyShownActivities > 0 ? {pageSize: this._numberOfCurrentlyShownActivities} : {};
+				const customParams = this._numberOfCurrentlyShownActivities > 0 ? {pageSize: this._numberOfCurrentlyShownActivities} : undefined;
 				const collection = this._performSirenActionWithQueryParams(collectionAction, customParams);
 				return collection;
 			}).bind(this))

--- a/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -261,6 +261,10 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 				type: Array,
 				value: [ ]
 			},
+			_numberOfCurrentlyShownActivities: {
+				type: Number,
+				computed: '_computeNumberOfCurrentlyShownActivities(_data)'
+			},
 			_fullListLoading: {
 				type: Boolean,
 				value: true
@@ -307,6 +311,10 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 	setLoadingState(state) {
 		this.set('_fullListLoading', state);
 		this.set('_loading', state);
+	}
+
+	_computeNumberOfCurrentlyShownActivities(data) {
+		return data.length;
 	}
 
 	_myEntityStoreFetch(url) {
@@ -418,7 +426,8 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 				return action;
 			}).bind(this))
 			.then((collectionAction => {
-				const collection = this._performSirenActionWithQueryParams(collectionAction);
+				const customParams = this._numberOfCurrentlyShownActivities > 0 ? {pageSize: this._numberOfCurrentlyShownActivities} : {};
+				const collection = this._performSirenActionWithQueryParams(collectionAction, customParams);
 				return collection;
 			}).bind(this))
 			.then((collection => {
@@ -682,7 +691,7 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 		);
 	}
 
-	_performSirenActionWithQueryParams(action) {
+	_performSirenActionWithQueryParams(action, customParams) {
 		const url = new URL(action.href, window.location.origin);
 
 		if (!action.fields) {
@@ -694,6 +703,12 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 				action.fields.push({name: key, value: value, type: 'hidden'});
 			}
 		});
+
+		if (customParams) {
+			Object.keys(customParams).forEach(function(paramName) {
+				action.fields.push({name: paramName, value: customParams[paramName], type: 'hidden'});
+			});
+		}
 
 		return this.performSirenAction(action);
 	}

--- a/test/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -65,6 +65,15 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 		done();
 	}
 
+	function arrayContainsWhere(arr, f) {
+
+		const results = arr.map(function(elm) {
+			return f(elm);
+		});
+
+		return results.includes(true);
+	}
+
 	var expectedData = [
 		{
 			displayName: 'Special User Name',
@@ -410,6 +419,27 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			list._performSirenActionWithQueryParams(action);
 			sinon.assert.calledWith(stub, action);
 		});
+		test('when calling perform siren action with no query params and custom params, fields contain custom params', () => {
+
+			const action = {
+				href : 'http://127.0.0.1/',
+				name: 'apply',
+				type: 'application/x-www-form-urlencoded',
+				method: 'GET'
+			};
+
+			const customParams = { customParam1: 'custom', customParam2: 'custom2' };
+			sinon.stub(list, 'performSirenAction', function(passedAction) {
+				const fields = passedAction.fields;
+				assert.equal(Object.keys(customParams).length, fields.length);
+
+				Object.keys(customParams).forEach(function(p) {
+					assert.isTrue(arrayContainsWhere(fields, (elm) => elm.name === p && elm.value === customParams[p]));
+				});
+			});
+
+			list._performSirenActionWithQueryParams(action, customParams);
+		});
 		test('when calling perform siren action with query params, the query params are added as fields', () => {
 
 			const action = {
@@ -454,6 +484,44 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 
 			list._performSirenActionWithQueryParams(action);
 			sinon.assert.calledWith(stub, action);
+		});
+		test('when calling perform siren action with query params and custom params, fields contain query params and custom params', () => {
+
+			const defaultParams = [
+				{
+					type: 'hidden',
+					name : 'testname',
+					value: 'testvalue'
+				},
+				{
+					type: 'hidden',
+					name : 'anothertestname',
+					value: 'anothertestvalue'
+				}
+			];
+
+			const action = {
+				href : 'http://127.0.0.1/',
+				name: 'apply',
+				type: 'application/x-www-form-urlencoded',
+				method: 'GET',
+				fields : defaultParams
+			};
+
+			const customParams = { customParam1: 'custom', customParam2: 'custom2' };
+			sinon.stub(list, 'performSirenAction', function(passedAction) {
+				const fields = passedAction.fields;
+				assert.equal(4, fields.length);
+
+				assert.isTrue(arrayContainsWhere(fields, (elm) => elm.name === 'testname' && elm.value === 'testvalue'));
+				assert.isTrue(arrayContainsWhere(fields, (elm) => elm.name === 'anothertestname' && elm.value === 'anothertestvalue'));
+
+				Object.keys(customParams).forEach(function(p) {
+					assert.isTrue(arrayContainsWhere(fields, (elm) => elm.name === p && elm.value === customParams[p]));
+				});
+			});
+
+			list._performSirenActionWithQueryParams(action, customParams);
 		});
 		test('when parsing url for sort and filter params and url is null, return empty array', () => {
 

--- a/test/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -65,15 +65,6 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 		done();
 	}
 
-	function arrayContainsWhere(arr, f) {
-
-		const results = arr.map(function(elm) {
-			return f(elm);
-		});
-
-		return results.includes(true);
-	}
-
 	var expectedData = [
 		{
 			displayName: 'Special User Name',
@@ -434,7 +425,7 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 				assert.equal(Object.keys(customParams).length, fields.length);
 
 				Object.keys(customParams).forEach(function(p) {
-					assert.isTrue(arrayContainsWhere(fields, (elm) => elm.name === p && elm.value === customParams[p]));
+					assert.isTrue(fields.some(function(elm) { return elm.name === p && elm.value === customParams[p]; }));
 				});
 			});
 
@@ -513,11 +504,11 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 				const fields = passedAction.fields;
 				assert.equal(4, fields.length);
 
-				assert.isTrue(arrayContainsWhere(fields, (elm) => elm.name === 'testname' && elm.value === 'testvalue'));
-				assert.isTrue(arrayContainsWhere(fields, (elm) => elm.name === 'anothertestname' && elm.value === 'anothertestvalue'));
+				assert.isTrue(fields.some(function(elm) { return elm.name === 'testname' && elm.value === 'testvalue'; }));
+				assert.isTrue(fields.some(function(elm) { return elm.name === 'anothertestname' && elm.value === 'anothertestvalue'; }));
 
 				Object.keys(customParams).forEach(function(p) {
-					assert.isTrue(arrayContainsWhere(fields, (elm) => elm.name === p && elm.value === customParams[p]));
+					assert.isTrue(fields.some(function(elm) { return elm.name === p && elm.value === customParams[p]; }));
 				});
 			});
 


### PR DESCRIPTION
**Note:** Demo only works after https://github.com/BrightspaceHypermediaComponents/activities/pull/124

![retainNumActivities](https://user-images.githubusercontent.com/1176292/54700533-964e1800-4b09-11e9-9fd5-3a107a1cd335.gif)

* Retain number of activities shown when sorting
