### PR TITLE
US105009 - Switch from using displayName to concatenation of first na…

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -653,8 +653,8 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 		return this._followLink(entity, Rels.user)
 			.then(function(u) {
 				if (u && u.entity) {
-					const firstName = this._tryGetName(u.entity, Rels.firstName, '');
-					const lastName = this._tryGetName(u.entity, Rels.lastName, '');
+					const firstName = this._tryGetName(u.entity, Rels.firstName, null);
+					const lastName = this._tryGetName(u.entity, Rels.lastName, null);
 					const defaultDisplayName = this._tryGetName(u.entity, Rels.displayName, '');
 
 					const displayName = {

--- a/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -160,12 +160,12 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 									<template is="dom-if" if="[[s.userHref]]">
 										<d2l-profile-image class="d2l-user-badge-image" href="[[s.userHref]]" token="[[token]]" small=""></d2l-profile-image>
 									</template>
-									<d2l-offscreen id="d2l-quick-eval-activities-list-username">[[localize('evaluate', 'displayName', s.displayName)]]</d2l-offscreen>
+									<d2l-offscreen id="d2l-quick-eval-activities-list-username">[[_localizeEvaluationText(s)]]</d2l-offscreen>
 									<d2l-link
-										title="[[localize('evaluate', 'displayName', s.displayName)]]"
+										title="[[_localizeEvaluationText(s)]]"
 										aria-describedby$="d2l-quick-eval-activities-list-username"
 										href="[[s.activityLink]]"
-									>[[_getDataProperty(s, 'displayName')]]</d2l-link>
+									>[[_formatDisplayName(s)]]</d2l-link>
 									<d2l-activity-evaluation-icon-base draft$="[[s.isDraft]]"></d2l-activity-evaluation-icon-base>
 								</d2l-td>
 								<d2l-td class="d2l-quick-eval-truncated-column d2l-activity-name-column">
@@ -606,11 +606,20 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 			});
 	}
 
-	_formatDisplayName(
-		firstName,
-		lastName,
-		defaultDisplayName
+	_localizeEvaluationText(
+		data
 	) {
+		const formattedDisplayName = this._formatDisplayName(data);
+		return this.localize('evaluate', 'displayName', formattedDisplayName);
+	}
+
+	_formatDisplayName(
+		data
+	) {
+		const firstName = data.displayName.firstName;
+		const lastName = data.displayName.lastName;
+		const defaultDisplayName = data.displayName.defaultDisplayName;
+
 		if (!lastName && !firstName) {
 			return defaultDisplayName;
 		}
@@ -648,11 +657,11 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 					const lastName = this._tryGetName(u.entity, Rels.lastName, '');
 					const defaultDisplayName = this._tryGetName(u.entity, Rels.displayName, '');
 
-					const displayName = this._formatDisplayName(
-						firstName,
-						lastName,
-						defaultDisplayName
-					);
+					const displayName = {
+						'firstName': firstName,
+						'lastName': lastName,
+						'defaultDisplayName': defaultDisplayName
+					};
 
 					item.displayName = displayName;
 				}

--- a/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -606,13 +606,57 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 			});
 	}
 
+	_formatDisplayName(
+		firstName,
+		lastName,
+		defaultDisplayName
+	) {
+		if (!lastName && !firstName) {
+			return defaultDisplayName;
+		}
+		if (!lastName) {
+			return firstName;
+		}
+		if (!firstName) {
+			return lastName;
+		}
+		return firstName + ' ' + lastName;
+	}
+
+	_tryGetName(
+		entity,
+		rel,
+		defaultValue
+	) {
+		if (!entity || !entity.hasSubEntityByRel(rel)) {
+			return defaultValue;
+		}
+
+		const subEntity =  entity.getSubEntityByRel(rel);
+		if (!subEntity || !subEntity.properties || subEntity.hasClass('default-name')) {
+			return defaultValue;
+		}
+
+		return subEntity.properties.name;
+	}
+
 	_getUserPromise(entity, item) {
 		return this._followLink(entity, Rels.user)
 			.then(function(u) {
-				if (u && u.entity && u.entity.hasSubEntityByRel(Rels.displayName)) {
-					item.displayName = u.entity.getSubEntityByRel(Rels.displayName).properties.name;
+				if (u && u.entity) {
+					const firstName = this._tryGetName(u.entity, Rels.firstName, '');
+					const lastName = this._tryGetName(u.entity, Rels.lastName, '');
+					const defaultDisplayName = this._tryGetName(u.entity, Rels.displayName, '');
+
+					const displayName = this._formatDisplayName(
+						firstName,
+						lastName,
+						defaultDisplayName
+					);
+
+					item.displayName = displayName;
 				}
-			});
+			}.bind(this));
 	}
 
 	_getUserHref(entity) {

--- a/test/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -19,7 +19,7 @@ import SirenParse from 'siren-parser';
 
 			var activityColumns = [];
 
-			activityColumns.push({ text: item.displayName, href: item.activityLink });
+			activityColumns.push({ text: item.displayName.defaultDisplayName, href: item.activityLink });
 			activityColumns.push({ href: item.activityNameHref });
 			activityColumns.push({ text: item.courseName });
 			activityColumns.push({ text: item.submissionDate });
@@ -68,7 +68,7 @@ import SirenParse from 'siren-parser';
 
 	var expectedData = [
 		{
-			displayName: 'Special User Name',
+			displayName: { firstName: 'Special User', lastName: 'Name', defaultDisplayName: 'Special User Name' },
 			userHref: 'data/userUnique.json',
 			courseName: 'Org Name',
 			activityNameHref: 'data/assignmentActivity.json',
@@ -78,7 +78,7 @@ import SirenParse from 'siren-parser';
 			isDraft: true
 		},
 		{
-			displayName: 'User Name',
+			displayName: { firstName: 'User', lastName: 'Name', defaultDisplayName: 'User Name' },
 			userHref: 'data/user.json',
 			courseName: 'Org Name',
 			activityNameHref: 'data/quizAttemptActivity.json',
@@ -88,7 +88,7 @@ import SirenParse from 'siren-parser';
 			isDraft: false
 		},
 		{
-			displayName: 'User Name',
+			displayName: { firstName: 'User', lastName: 'Name', defaultDisplayName: 'User Name' },
 			userHref: 'data/user.json',
 			courseName: 'Org Name',
 			activityNameHref: 'data/topicActivity.json',
@@ -112,7 +112,7 @@ import SirenParse from 'siren-parser';
 
 	var expectedNextData = [
 		{
-			displayName: 'User Name',
+			displayName: { firstName: 'User', lastName: 'Name', defaultDisplayName: 'User Name' },
 			userHref: 'data/user.json',
 			courseName: 'Org Name',
 			activityNameHref: 'data/nextAssignmentActivity.json',
@@ -122,7 +122,7 @@ import SirenParse from 'siren-parser';
 			isDraft: true
 		},
 		{
-			displayName: 'User Name',
+			displayName: { firstName: 'User', lastName: 'Name', defaultDisplayName: 'User Name' },
 			userHref: 'data/user.json',
 			courseName: 'Org Name',
 			activityNameHref: 'data/nextQuizAttemptActivity.json',
@@ -132,7 +132,7 @@ import SirenParse from 'siren-parser';
 			isDraft: false
 		},
 		{
-			displayName: 'User Name',
+			displayName: { firstName: 'User', lastName: 'Name', defaultDisplayName: 'User Name' },
 			userHref: 'data/user.json',
 			courseName: 'Org Name',
 			activityNameHref: 'data/nextTopicActivity.json',
@@ -556,24 +556,56 @@ import SirenParse from 'siren-parser';
 
 		test('_formatDisplayName return firstName when firstName defined and lastName undefined', () => {
 			const expectedDisplayName = 'firstName';
-			const displayName = list._formatDisplayName(expectedDisplayName, '', '');
+			const displayName = list._formatDisplayName(
+				{
+					displayName: {
+						firstName: expectedDisplayName,
+						lastName: '',
+						defaultDisplayName: ''
+					}
+				}
+			);
 			assert.equal(expectedDisplayName, displayName);
 		});
 
 		test('_formatDisplayName return lastName when firstName undefined and lastName defined', () => {
 			const expectedDisplayName = 'lastName';
-			const displayName = list._formatDisplayName('', expectedDisplayName, '');
+			const displayName = list._formatDisplayName(
+				{
+					displayName: {
+						firstName: '',
+						lastName: expectedDisplayName,
+						defaultDisplayName: ''
+					}
+				}
+			);
 			assert.equal(expectedDisplayName, displayName);
 		});
 
 		test('_formatDisplayName return firstName and lastName when firstName defined and lastName defined', () => {
-			const displayName = list._formatDisplayName('firstName', 'lastName', '');
+			const displayName = list._formatDisplayName(
+				{
+					displayName: {
+						firstName: 'firstName',
+						lastName: 'lastName',
+						defaultDisplayName: ''
+					}
+				}
+			);
 			assert.equal('firstName lastName', displayName);
 		});
 
 		test('_formatDisplayName return displayName when firstName undefined and lastName undefined', () => {
 			const expectedDisplayName = 'displayName';
-			const displayName = list._formatDisplayName('', '', expectedDisplayName);
+			const displayName = list._formatDisplayName(
+				{
+					displayName: {
+						firstName: '',
+						lastName: '',
+						defaultDisplayName: expectedDisplayName
+					}
+				}
+			);
 			assert.equal(expectedDisplayName, displayName);
 		});
 

--- a/test/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -1,4 +1,5 @@
 import '@polymer/iron-test-helpers/mock-interactions.js';
+import SirenParse from 'siren-parser';
 
 (function() {
 	var list;
@@ -551,6 +552,69 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 
 			var evalLink = list._buildRelativeUri(url, params);
 			assert.equal(evalLink, expectedEvalLink);
+		});
+
+		test('_formatDisplayName return firstName when firstName defined and lastName undefined', () => {
+			const expectedDisplayName = 'firstName';
+			const displayName = list._formatDisplayName(expectedDisplayName, '', '');
+			assert.equal(expectedDisplayName, displayName);
+		});
+
+		test('_formatDisplayName return lastName when firstName undefined and lastName defined', () => {
+			const expectedDisplayName = 'lastName';
+			const displayName = list._formatDisplayName('', expectedDisplayName, '');
+			assert.equal(expectedDisplayName, displayName);
+		});
+
+		test('_formatDisplayName return firstName and lastName when firstName defined and lastName defined', () => {
+			const displayName = list._formatDisplayName('firstName', 'lastName', '');
+			assert.equal('firstName lastName', displayName);
+		});
+
+		test('_formatDisplayName return displayName when firstName undefined and lastName undefined', () => {
+			const expectedDisplayName = 'displayName';
+			const displayName = list._formatDisplayName('', '', expectedDisplayName);
+			assert.equal(expectedDisplayName, displayName);
+		});
+
+		test('_tryGetName returns default value when subentity has class "default-name"', () => {
+			const nameRel = 'nameRel';
+			const expectedName = 'defaultValue';
+
+			const userEntity = {
+				'entities': [
+					{
+						'class': ['default-name'],
+						'rel': [ nameRel ],
+						'properties': {
+							'name': 'someName'
+						}
+					}
+				]
+			};
+
+			const name = list._tryGetName(SirenParse(userEntity), nameRel, expectedName);
+			assert.equal(name, expectedName);
+		});
+
+		test('_tryGetName returns expected name value name subentity is valid', () => {
+			const nameRel = 'nameRel';
+			const expectedName = 'expectedName';
+
+			const userEntity = {
+				'entities': [
+					{
+						'class': [],
+						'rel': [ nameRel ],
+						'properties': {
+							'name': expectedName
+						}
+					}
+				]
+			};
+
+			const name = list._tryGetName(SirenParse(userEntity), nameRel, 'defaultValue');
+			assert.equal(name, expectedName);
 		});
 
 	});

--- a/test/d2l-quick-eval/data/user.json
+++ b/test/d2l-quick-eval/data/user.json
@@ -1,9 +1,35 @@
 {
-	"entities":[
+	"entities": [
 		{
-			"rel":["https://api.brightspace.com/rels/display-name"],
-			"properties":{
-				"name":"User Name"
+			"rel": [
+				"https://api.brightspace.com/rels/display-name"
+			],
+			"properties": {
+				"name": "User Name"
+			}
+		},
+		{
+			"class": [
+				"first",
+				"name"
+			],
+			"rel": [
+				"https://api.brightspace.com/rels/first-name"
+			],
+			"properties": {
+				"name": "User"
+			}
+		},
+		{
+			"class": [
+				"last",
+				"name"
+			],
+			"rel": [
+				"https://api.brightspace.com/rels/last-name"
+			],
+			"properties": {
+				"name": "Name"
 			}
 		}
 	]

--- a/test/d2l-quick-eval/data/userUnique.json
+++ b/test/d2l-quick-eval/data/userUnique.json
@@ -1,9 +1,35 @@
 {
-	"entities":[
+	"entities": [
 		{
-			"rel":["https://api.brightspace.com/rels/display-name"],
-			"properties":{
-				"name":"Special User Name"
+			"rel": [
+				"https://api.brightspace.com/rels/display-name"
+			],
+			"properties": {
+				"name": "Special User Name"
+			}
+		},
+		{
+			"class": [
+				"first",
+				"name"
+			],
+			"rel": [
+				"https://api.brightspace.com/rels/first-name"
+			],
+			"properties": {
+				"name": "Special User"
+			}
+		},
+		{
+			"class": [
+				"last",
+				"name"
+			],
+			"rel": [
+				"https://api.brightspace.com/rels/last-name"
+			],
+			"properties": {
+				"name": "Name"
 			}
 		}
 	]


### PR DESCRIPTION
* This is step one to achieving the swap between first name and last name on sort
* Instead of using display name, we will get the firstName and lastName individually and then concat them together
* When you can't see either first name or last name, you will see "Anonymous User"
* This change shouldn't be introducing any new behavior, should be acting the same way as before
* Tested against LMS as well, seems like things are working as intended