### PR TITLE
Enforce usage of `const`/`let` over `var`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,10 @@
   "parserOptions": {
       "sourceType": "module"
   },
+  "rules": {
+    "no-var": "error",
+    "prefer-const": "error"
+  },
   "globals": {
     "fastdom": false
   }

--- a/components/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon.js
+++ b/components/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon.js
@@ -43,7 +43,7 @@ class ActivityEvaluationIcon extends mixinBehaviors([D2L.PolymerBehaviors.Siren.
 			return;
 		}
 
-		var evaluation = entity.getSubEntityByClass('evaluation');
+		const evaluation = entity.getSubEntityByClass('evaluation');
 		if (evaluation.properties.state === 'Draft') {
 			this._draft = true;
 		}

--- a/components/d2l-activity-list-item/ActivityListItemResponsiveConstants.js
+++ b/components/d2l-activity-list-item/ActivityListItemResponsiveConstants.js
@@ -198,7 +198,7 @@ const ActivityListItemResponsiveConstantsImpl = (superClass) => class extends su
 
 	_getResponsiveConfig(width) {
 		let responsiveConfig  = this._responsiveConfigs[0];
-		for (var nextConfig of this._responsiveConfigs) {
+		for (const nextConfig of this._responsiveConfigs) {
 			if (nextConfig.minWidth > width) {
 				break;
 			}

--- a/components/d2l-activity-list-item/d2l-activity-list-item.js
+++ b/components/d2l-activity-list-item/d2l-activity-list-item.js
@@ -667,7 +667,7 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 		if (!this._organizationUrl) {
 			return;
 		}
-		var match = /[0-9]+$/.exec(this._organizationUrl);
+		const match = /[0-9]+$/.exec(this._organizationUrl);
 
 		if (!match) {
 			return;

--- a/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -471,7 +471,7 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 
 		try {
 			if (entity.entities) {
-				var result = await this._parseActivities(entity);
+				const result = await this._parseActivities(entity);
 				this._data = result;
 			} else {
 				this._data = [];
@@ -494,12 +494,12 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 			this._followHref(this._pageNextHref)
 				.then(async function(u) {
 					if (u && u.entity) {
-						var tbody = this.shadowRoot.querySelector('d2l-tbody');
-						var lastFocusableTableElement = D2L.Dom.Focus.getLastFocusableDescendant(tbody, false);
+						const tbody = this.shadowRoot.querySelector('d2l-tbody');
+						const lastFocusableTableElement = D2L.Dom.Focus.getLastFocusableDescendant(tbody, false);
 
 						try {
 							if (u.entity.entities) {
-								var result = await this._parseActivities(u.entity);
+								const result = await this._parseActivities(u.entity);
 								this._data = this._data.concat(result);
 							}
 						} catch (e) {
@@ -508,7 +508,7 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 						} finally {
 							this._loading = false;
 							window.requestAnimationFrame(function() {
-								var newElementToFocus = D2L.Dom.Focus.getNextFocusable(lastFocusableTableElement, false);
+								const newElementToFocus = D2L.Dom.Focus.getNextFocusable(lastFocusableTableElement, false);
 								if (newElementToFocus) {
 									newElementToFocus.focus();
 								}
@@ -537,7 +537,7 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 	}
 
 	_followLink(entity, rel) {
-		var href = this._getHref(entity, rel);
+		const href = this._getHref(entity, rel);
 		return this._followHref(href);
 	}
 
@@ -556,13 +556,13 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 	}
 
 	async _parseActivities(entity) {
-		var extraParams = this._getExtraParams(this._getHref(entity, 'self'));
+		const extraParams = this._getExtraParams(this._getHref(entity, 'self'));
 
-		var promises = [];
+		const promises = [];
 		entity.entities.forEach(function(activity) {
 			promises.push(new Promise(function(resolve) {
 
-				var item = {
+				const item = {
 					displayName: '',
 					userHref: this._getUserHref(activity),
 					courseName: '',
@@ -573,9 +573,9 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 					isDraft: this._determineIfActivityIsDraft(activity)
 				};
 
-				var getUserName = this._getUserPromise(activity, item);
-				var getCourseName = this._getCoursePromise(activity, item);
-				var getMasterTeacherName =
+				const getUserName = this._getUserPromise(activity, item);
+				const getCourseName = this._getCoursePromise(activity, item);
+				const getMasterTeacherName =
 					this._shouldDisplayColumn('masterTeacher')
 						? this._getMasterTeacherPromise(activity, item)
 						: Promise.resolve();
@@ -595,7 +595,7 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 
 	_determineIfActivityIsDraft(activity) {
 		if (activity.hasSubEntityByRel('https://api.brightspace.com/rels/evaluation')) {
-			var evaluation = activity.getSubEntityByRel('https://api.brightspace.com/rels/evaluation');
+			const evaluation = activity.getSubEntityByRel('https://api.brightspace.com/rels/evaluation');
 			if (evaluation.properties && evaluation.properties.state === 'Draft') {
 				return true;
 			}
@@ -613,7 +613,7 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 			}.bind(this))
 			.then(function(enrollment) {
 				if (enrollment && enrollment.entity && enrollment.entity.hasSubEntityByRel(Rels.userEnrollment)) {
-					var userEnrollment = enrollment.entity.getSubEntityByRel(Rels.userEnrollment);
+					const userEnrollment = enrollment.entity.getSubEntityByRel(Rels.userEnrollment);
 					if (userEnrollment.href) {
 						return this._followHref(userEnrollment.href);
 					}
@@ -727,7 +727,7 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 
 	_getSubmissionDate(entity) {
 		if (entity.hasSubEntityByClass('localized-formatted-date')) {
-			var i = entity.getSubEntityByClass('localized-formatted-date');
+			const i = entity.getSubEntityByClass('localized-formatted-date');
 			return i.properties.text;
 		}
 		return '';
@@ -735,17 +735,17 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 
 	_getRelativeUriProperty(entity, extraParams) {
 		if (entity.hasSubEntityByClass(Classes.relativeUri)) {
-			var i = entity.getSubEntityByClass(Classes.relativeUri);
+			const i = entity.getSubEntityByClass(Classes.relativeUri);
 			return this._buildRelativeUri(i.properties.path, extraParams);
 		}
 		return '';
 	}
 
 	_getDataProperty(item, prop) {
-		var result;
+		let result;
 		if (Array.isArray(prop) && prop.length > 0) {
 			result = item;
-			for (var i = 0; i < prop.length; i++) {
+			for (let i = 0; i < prop.length; i++) {
 				result = result[prop[i]];
 			}
 		} else {
@@ -803,7 +803,7 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 
 		const extraParams = [];
 
-		var filterVal = this._getQueryStringParam('filter', url);
+		const filterVal = this._getQueryStringParam('filter', url);
 		if (filterVal) {
 			extraParams.push(
 				{
@@ -812,7 +812,7 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 				}
 			);
 		}
-		var sortVal = this._getQueryStringParam('sort', url);
+		const sortVal = this._getQueryStringParam('sort', url);
 		if (sortVal) {
 			extraParams.push(
 				{

--- a/demo/d2l-activity-list-item/index.html
+++ b/demo/d2l-activity-list-item/index.html
@@ -65,7 +65,7 @@
 					<d2l-activity-list-item href="../data/base/activity.json"></d2l-activity-list-item>
 					<d2l-activity-list-item href="../data/base/activity.json"></d2l-activity-list-item>
 					<script>
-						var items = document.querySelectorAll('d2l-activity-list-item');
+						const items = document.querySelectorAll('d2l-activity-list-item');
 
 						items.forEach(function(item) {
 							item._tags = ['Duration 1h30m', 'Metadata', 'Metadata'];

--- a/demo/d2l-activity-name/update-direction.js
+++ b/demo/d2l-activity-name/update-direction.js
@@ -1,5 +1,5 @@
 (function() {
-	var isRtl = (window.location.search.indexOf('dir=rtl') > -1);
+	const isRtl = (window.location.search.indexOf('dir=rtl') > -1);
 
 	if (isRtl && document.documentElement.dir !== 'rtl') {
 		document.documentElement.dir = 'rtl';

--- a/demo/d2l-quick-eval/page-handler.js
+++ b/demo/d2l-quick-eval/page-handler.js
@@ -41,7 +41,7 @@ function applySorts(activities, sorts, sortState) {
 }
 
 function createPageEndpoint(activities, sorts, filtersHref, sortsHref) {
-	var shouldFailOnLastLoadFirstTime = true;
+	let shouldFailOnLastLoadFirstTime = true;
 
 	return (url) => {
 

--- a/demo/d2l-quick-eval/update-direction.js
+++ b/demo/d2l-quick-eval/update-direction.js
@@ -1,5 +1,5 @@
 (function() {
-	var isRtl = (window.location.search.indexOf('dir=rtl') > -1);
+	const isRtl = (window.location.search.indexOf('dir=rtl') > -1);
 
 	if (isRtl && document.documentElement.dir !== 'rtl') {
 		document.documentElement.dir = 'rtl';

--- a/scripts/remove_attest_from_project.js
+++ b/scripts/remove_attest_from_project.js
@@ -1,7 +1,7 @@
 /* global require */
-var fs = require('fs');
+const fs = require('fs');
 //read in the package file
-var file_contents = JSON.parse(fs.readFileSync('package.json'));
+const file_contents = JSON.parse(fs.readFileSync('package.json'));
 if ('dependencies' in file_contents) {
 	if ('attest' in file_contents.dependencies) {
 		delete file_contents.dependencies.attest;


### PR DESCRIPTION
We shouldn't use `var` because it causes surprises due to it being function-scoped (vs block-scoped which is what C# developers are used to).

`const` allows developers to catch runtime errors at "compile-time"
`let` has block-scope, which many developers are used to and can avoid hard to catch bugs such as the one below (stolen from the eslint docs)

```js
var count = people.length;
var enoughFood = count > sandwiches.length;

if (enoughFood) {
    var count = sandwiches.length; // accidentally overriding the count variable
    console.log("We have " + count + " sandwiches for everyone. Plenty for all!");
}

// our count variable is no longer accurate
console.log("We have " + count + " people and " + sandwiches.length + " sandwiches!");
```

Some environments don't fully support it but I think we are shipping to the ones that do:
* https://caniuse.com/#feat=const
* https://caniuse.com/#feat=let