### PR TITLE
US105524 - Computed number of activities to show should never go down

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -282,9 +282,10 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 				type: Array,
 				value: [ ]
 			},
-			_numberOfCurrentlyShownActivities: {
+			_numberOfActivitiesToShow: {
 				type: Number,
-				computed: '_computeNumberOfCurrentlyShownActivities(_data)'
+				computed: '_computerNumberOfActivitiesToShow(_data, _numberOfActivitiesToShow)',
+				value: 0
 			},
 			_fullListLoading: {
 				type: Boolean,
@@ -339,8 +340,8 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 		return !fullListLoading && isLoading;
 	}
 
-	_computeNumberOfCurrentlyShownActivities(data) {
-		return data.length;
+	_computerNumberOfActivitiesToShow(data, currentNumberOfActivitiesShown) {
+		return Math.max(data.length, currentNumberOfActivitiesShown);
 	}
 
 	_handleNameSwap(entry) {
@@ -459,7 +460,7 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 				if (!action) {
 					return Promise.reject(new Error(`Could not find apply action in ${sortsEntity}`));
 				}
-				const customParams = this._numberOfCurrentlyShownActivities > 0 ? {pageSize: this._numberOfCurrentlyShownActivities} : undefined;
+				const customParams = this._numberOfActivitiesToShow > 0 ? {pageSize: this._numberOfActivitiesToShow} : undefined;
 				return this._performSirenActionWithQueryParams(action, customParams);
 			}).bind(this))
 			.then((collection => {

--- a/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -284,7 +284,7 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 			},
 			_numberOfActivitiesToShow: {
 				type: Number,
-				computed: '_computerNumberOfActivitiesToShow(_data, _numberOfActivitiesToShow)',
+				computed: '_computeNumberOfActivitiesToShow(_data, _numberOfActivitiesToShow)',
 				value: 0
 			},
 			_fullListLoading: {
@@ -340,7 +340,7 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 		return !fullListLoading && isLoading;
 	}
 
-	_computerNumberOfActivitiesToShow(data, currentNumberOfActivitiesShown) {
+	_computeNumberOfActivitiesToShow(data, currentNumberOfActivitiesShown) {
 		return Math.max(data.length, currentNumberOfActivitiesShown);
 	}
 

--- a/test/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -792,5 +792,13 @@ import SirenParse from 'siren-parser';
 
 			});
 		});
+
+		test('_computerNumberOfActivitiesToShow returns max of data lenght, and previously shown number of activities', function() {
+			const numberOfActivitiesToShowWhenDataLarger = list._computerNumberOfActivitiesToShow([1, 2, 3, 4], 1);
+			assert.equal(4, numberOfActivitiesToShowWhenDataLarger);
+
+			const numberOfActivitiesToShowWhenPreviousLarger = list._computerNumberOfActivitiesToShow([1], 5);
+			assert.equal(5, numberOfActivitiesToShowWhenPreviousLarger);
+		});
 	});
 })();

--- a/test/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -793,11 +793,11 @@ import SirenParse from 'siren-parser';
 			});
 		});
 
-		test('_computerNumberOfActivitiesToShow returns max of data lenght, and previously shown number of activities', function() {
-			const numberOfActivitiesToShowWhenDataLarger = list._computerNumberOfActivitiesToShow([1, 2, 3, 4], 1);
+		test('_computeNumberOfActivitiesToShow returns max of data length, and previously shown number of activities', function() {
+			const numberOfActivitiesToShowWhenDataLarger = list._computeNumberOfActivitiesToShow([1, 2, 3, 4], 1);
 			assert.equal(4, numberOfActivitiesToShowWhenDataLarger);
 
-			const numberOfActivitiesToShowWhenPreviousLarger = list._computerNumberOfActivitiesToShow([1], 5);
+			const numberOfActivitiesToShowWhenPreviousLarger = list._computeNumberOfActivitiesToShow([1], 5);
 			assert.equal(5, numberOfActivitiesToShowWhenPreviousLarger);
 		});
 	});


### PR DESCRIPTION
* This is prep work for filters to try and maintain the number of activities to show
* This is needed because filters may reduce the number of activities shown, and I don't think we ever want to reduce the number of activities shown if we can avoid it