### PR TITLE
US105524 - Maintain number of activities shown when filters are modified

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -285,7 +285,7 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 			_numberOfActivitiesToShow: {
 				type: Number,
 				computed: '_computeNumberOfActivitiesToShow(_data, _numberOfActivitiesToShow)',
-				value: 0
+				value: 20
 			},
 			_fullListLoading: {
 				type: Boolean,
@@ -316,7 +316,8 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 		return [
 			'_loadData(entity)',
 			'_loadSorts(entity)',
-			'_handleNameSwap(_headerColumns.0.headers.*)'
+			'_handleNameSwap(_headerColumns.0.headers.*)',
+			'_dispatchPageSizeEvent(_numberOfActivitiesToShow)'
 		];
 	}
 	ready() {
@@ -879,6 +880,21 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 		});
 
 		return parsedUrl.pathname + parsedUrl.search;
+	}
+
+	_dispatchPageSizeEvent(numberOfActivitiesToShow) {
+		this.dispatchEvent(
+			new CustomEvent(
+				'd2l-quick-eval-activities-list-activities-shown-number-updated',
+				{
+					detail: {
+						count: numberOfActivitiesToShow
+					},
+					composed: true,
+					bubbles: true
+				}
+			)
+		);
 	}
 
 }

--- a/components/d2l-quick-eval/d2l-quick-eval.js
+++ b/components/d2l-quick-eval/d2l-quick-eval.js
@@ -68,7 +68,12 @@ class D2LQuickEval extends mixinBehaviors([D2L.PolymerBehaviors.Siren.EntityBeha
 					<h1>[[headerText]]</h1>
 				</template>
 				<div class="d2l-quick-eval-activity-list-modifiers">
-					<d2l-hm-filter href="[[_filterHref]]" token="[[token]]" category-whitelist="[[_filterIds]]"></d2l-hm-filter>
+					<d2l-hm-filter
+						href="[[_filterHref]]"
+						token="[[token]]"
+						category-whitelist="[[_filterIds]]"
+						result-size="[[_numberOfActivitiesToShow]]">
+					</d2l-hm-filter>
 					<d2l-hm-search hidden$="[[!searchEnabled]]"></d2l-hm-search>
 				</div>
 			</div>
@@ -104,6 +109,10 @@ class D2LQuickEval extends mixinBehaviors([D2L.PolymerBehaviors.Siren.EntityBeha
 				type: Array,
 				computed: '_getFilterIds(masterTeacher)'
 			},
+			_numberOfActivitiesToShow: {
+				type: Number,
+				value: 20
+			},
 			_showFilterError: {
 				type: Boolean,
 				value: false
@@ -127,6 +136,7 @@ class D2LQuickEval extends mixinBehaviors([D2L.PolymerBehaviors.Siren.EntityBeha
 		this.addEventListener('d2l-hm-filter-filters-updated', this._filtersChanged);
 		this.addEventListener('d2l-hm-filter-error', this._filterError);
 		this.addEventListener('d2l-quick-eval-activities-list-sort-updated', this._sortChanged);
+		this.addEventListener('d2l-quick-eval-activities-list-activities-shown-number-updated', this._updateNumberOfActivitiesToShow);
 	}
 
 	detached() {
@@ -135,6 +145,13 @@ class D2LQuickEval extends mixinBehaviors([D2L.PolymerBehaviors.Siren.EntityBeha
 		this.removeEventListener('d2l-hm-filter-filters-updated', this._filtersChanged);
 		this.removeEventListener('d2l-hm-filter-error', this._filterError);
 		this.removeEventListener('d2l-quick-eval-activities-list-sort-updated', this._sortChanged);
+		this.removeEventListener('d2l-quick-eval-activities-list-activities-shown-number-updated', this._updateNumberOfActivitiesToShow);
+	}
+
+	_updateNumberOfActivitiesToShow(e) {
+		if (e && e.detail) {
+			this.set('_numberOfActivitiesToShow', e.detail.count);
+		}
 	}
 
 	_getFilterHref(entity) {

--- a/test/d2l-quick-eval/d2l-quick-eval-activities-list-sorting.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activities-list-sorting.js
@@ -223,7 +223,7 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 
 			followLinkStub.withArgs(list.entity, Rels.sorts).returns(Promise.resolve({ entity: sorts }));
 			performActionStub.withArgs(sortAction).returns(sorts);
-			performActionStub.withArgs(applyAction, undefined).returns(collection);
+			performActionStub.withArgs(applyAction, sinon.match.any).returns(collection);
 
 			return list._fetchSortedData('activity-name', false)
 				.then(actual => {

--- a/test/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -157,13 +157,38 @@ import SirenParse from 'siren-parser';
 		test('instantiating the element works', function() {
 			assert.equal(list.tagName.toLowerCase(), 'd2l-quick-eval-activities-list');
 		});
+		test('_numberOfActivitiesToShow starts with default value of 20', function() {
+			assert.equal(20, list._numberOfActivitiesToShow);
+		});
 		test('attributes are set correctly', function() {
 			assert.equal(list.href, 'blah');
 			assert.equal(list.token, 't');
 		});
 		test('no alert displayed when healthy', function() {
-			var alert = list.shadowRoot.querySelector('#list-alert');
+			const alert = list.shadowRoot.querySelector('#list-alert');
 			assert.equal(true, alert.hasAttribute('hidden'));
+		});
+		test('when _updateNumberOfActivitiesToShow updated, event "d2l-quick-eval-activities-list-activities-shown-number-updated" fires', function(done) {
+			const expectedNumberOfActivitiesToShow = 50;
+
+			list.addEventListener('d2l-quick-eval-activities-list-activities-shown-number-updated', function(e) {
+				assert.equal(expectedNumberOfActivitiesToShow, e.detail.count);
+				done();
+			});
+
+			list._numberOfActivitiesToShow = expectedNumberOfActivitiesToShow;
+		});
+		test('when data size increased, _numberOfActivitiesToShow matches size and event is triggered', function(done) {
+			const expectedNumberOfActivitiesToShow = 100;
+			const fakeData = new Array(expectedNumberOfActivitiesToShow);
+
+			list.addEventListener('d2l-quick-eval-activities-list-activities-shown-number-updated', function(e) {
+				assert.equal(expectedNumberOfActivitiesToShow, list._numberOfActivitiesToShow);
+				assert.equal(expectedNumberOfActivitiesToShow, e.detail.count);
+				done();
+			});
+
+			list._data = fakeData;
 		});
 		test('_fullListLoading and _loading are set to true before data is loaded, and loading-skeleton is present', () => {
 			var loadingskeleton = list.shadowRoot.querySelector('d2l-quick-eval-skeleton');

--- a/test/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -185,6 +185,7 @@ import SirenParse from 'siren-parser';
 			list.addEventListener('d2l-quick-eval-activities-list-activities-shown-number-updated', function(e) {
 				assert.equal(expectedNumberOfActivitiesToShow, list._numberOfActivitiesToShow);
 				assert.equal(expectedNumberOfActivitiesToShow, e.detail.count);
+				list._data = [];
 				done();
 			});
 

--- a/test/d2l-quick-eval/d2l-quick-eval.html
+++ b/test/d2l-quick-eval/d2l-quick-eval.html
@@ -84,6 +84,26 @@
 				test('instantiating the element works', function() {
 					assert.equal(quickEval.tagName.toLowerCase(), 'd2l-quick-eval');
 				});
+				test('_numberOfActivitiesToShow starts with default value of 20', function() {
+					assert.equal(20, quickEval._numberOfActivitiesToShow);
+				});
+				test('when event "d2l-quick-eval-activities-list-activities-shown-number-updated" fired, result-size attribute updated on d2l-hm-filter', function(done) {
+					const expectedResultSize = 333;
+
+					quickEval.addEventListener('d2l-quick-eval-activities-list-activities-shown-number-updated', function() {
+						flush(function() {
+							assert.equal(expectedResultSize, quickEval._numberOfActivitiesToShow);
+							assert.equal(expectedResultSize, filter.getAttribute('result-size'));
+							done();
+						});
+					});
+					quickEval.dispatchEvent(
+						new CustomEvent(
+							'd2l-quick-eval-activities-list-activities-shown-number-updated',
+							{ detail: { count: expectedResultSize } }
+						)
+					);
+				});
 				test('the filter and list exist', function() {
 					assert.isNotNull(filter);
 					assert.isNotNull(list);


### PR DESCRIPTION
* Anytime `_numberOfActivitiesToShow` is updated in quick-eval-activities-list, we fire that event
* quick-eval listens for that event, and tells the filter component, "next time you request for activities, try to give me X amount"
* this way the number of activities should persist as best as possible through sort and filter
* Tested in LMS seems to be working fine

![filter_size](https://user-images.githubusercontent.com/1176292/55420173-63157b00-5544-11e9-8c81-ea377801ee9e.gif)

#### Dependencies
* Requires changes from https://github.com/BrightspaceHypermediaComponents/common/pull/19 to work