### PR TITLE
US105617 - Use attribute variable 

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -190,7 +190,7 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 									<d2l-link
 										title="[[_localizeEvaluationText(s, _headerColumns.0.meta.firstThenLast)]]"
 										href="[[s.activityLink]]"
-										aria-label="[[_localizeEvaluationText(s, _headerColumns.0.meta.firstThenLast)]]"
+										aria-label$="[[_localizeEvaluationText(s, _headerColumns.0.meta.firstThenLast)]]"
 									>[[_formatDisplayName(s, _headerColumns.0.meta.firstThenLast)]]</d2l-link>
 									<d2l-activity-evaluation-icon-base draft$="[[s.isDraft]]"></d2l-activity-evaluation-icon-base>
 								</d2l-td>


### PR DESCRIPTION
* Noticed aria-label wasn't used when using activities-list within quick-eval
* This should fix it