### PR TITLE
Moving filter dropdown closer to search (was 40px, now 5px).

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval.js
+++ b/components/d2l-quick-eval/d2l-quick-eval.js
@@ -36,7 +36,7 @@ class D2LQuickEval extends mixinBehaviors([D2L.PolymerBehaviors.Siren.EntityBeha
 				d2l-hm-search {
 					display: inline-block;
 					width: 250px;
-					margin-left: 2rem;
+					margin-left: .25rem;
 				}
 				.d2l-quick-eval-top-bar {
 					padding-top: 0.25rem;


### PR DESCRIPTION
Before change: 
![image](https://user-images.githubusercontent.com/29403611/55982521-1843e380-5c67-11e9-9a70-3e8ecba8c20b.png)
-

After change:
![image](https://user-images.githubusercontent.com/29403611/55982546-285bc300-5c67-11e9-80a8-91b59fd8c6f5.png)
-

To verify distance between elements (should be 5):
```
var t = document.querySelector('d2l-quick-eval').shadowRoot.querySelector('d2l-hm-filter').getBoundingClientRect();
var u = document.querySelector('d2l-quick-eval').shadowRoot.querySelector('d2l-hm-search').getBoundingClientRect();
u.left - t.right
```