### PR TITLE
DE33386 - Remove all usages for url.searchParams

### DIFF
--- a/components/d2l-quick-eval/compatability/universal-methods.js
+++ b/components/d2l-quick-eval/compatability/universal-methods.js
@@ -14,6 +14,22 @@ const StringEndsWith = (str, search) => {
 	return str.substring(str.length - search.length, str.length) === search;
 };
 
+const DictToQueryString = (queryParams) => {
+	if (queryParams === null || queryParams === undefined) {
+		return '';
+	}
+
+	const queryParamsAsString = Object.keys(queryParams).map(function(key) {
+		return window.encodeURIComponent(key) + '=' + window.encodeURIComponent(queryParams[key]);
+	});
+
+	if (queryParamsAsString.length <= 0) {
+		return '';
+	}
+
+	return '?' + queryParamsAsString.join('&');
+};
+
 const GetQueryStringParams = (queryString) => {
 	const query = {};
 	if (queryString) {
@@ -44,4 +60,4 @@ const GetQueryStringParam = (name, url) => {
 	return null;
 };
 
-export { StringEndsWith, GetQueryStringParam, GetQueryStringParams };
+export { DictToQueryString, StringEndsWith, GetQueryStringParam, GetQueryStringParams };

--- a/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -18,7 +18,7 @@ import './d2l-quick-eval-no-submissions-image.js';
 import './d2l-quick-eval-no-criteria-results-image.js';
 import './d2l-quick-eval-skeleton.js';
 import 'd2l-loading-spinner/d2l-loading-spinner.js';
-import {StringEndsWith, GetQueryStringParams, GetQueryStringParam} from './compatability/universal-methods.js';
+import {DictToQueryString, StringEndsWith, GetQueryStringParams, GetQueryStringParam} from './compatability/universal-methods.js';
 
 /**
  * @customElement
@@ -890,12 +890,12 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors([D2L.PolymerBehaviors.Si
 		}
 
 		const parsedUrl = new window.URL(url, 'https://notused.com');
+		const searchParams = GetQueryStringParams(parsedUrl.search);
 
 		extraParams.forEach(param => {
-			parsedUrl.searchParams.set(param.name, param.value);
+			searchParams[param.name] = param.value;
 		});
-
-		return parsedUrl.pathname + parsedUrl.search;
+		return parsedUrl.pathname + DictToQueryString(searchParams);
 	}
 
 	_dispatchPageSizeEvent(numberOfActivitiesToShow) {

--- a/test/d2l-quick-eval/compatability/universal-methods.js
+++ b/test/d2l-quick-eval/compatability/universal-methods.js
@@ -1,4 +1,4 @@
-import { StringEndsWith, GetQueryStringParams, GetQueryStringParam } from '../../../components/d2l-quick-eval/compatability/universal-methods.js';
+import { DictToQueryString, StringEndsWith, GetQueryStringParams, GetQueryStringParam } from '../../../components/d2l-quick-eval/compatability/universal-methods.js';
 
 suite('StringEndsWith', () => {
 	const testCases = [
@@ -73,6 +73,44 @@ suite('GetQueryStringParam', () => {
 
 		test(`Given ${url} searching for query param ${name} should return ${expectedResult}`, () => {
 			assert.equal(expectedResult, GetQueryStringParam(name, new window.URL(url)));
+		});
+	});
+});
+
+suite('DictToQueryString', () => {
+	const testCases = [
+		{ params: {}, expectedStringParams: [] },
+		{ params: {'x': null }, expectedStringParams: ['x=null'] },
+		{ params: {'x': undefined }, expectedStringParams: ['x=undefined'] },
+		{ params: {'x': 1 }, expectedStringParams: ['x=1'] },
+		{ params: {'x': 1, 'y': 2 }, expectedStringParams: ['x=1', 'y=2'] },
+		{ params: {'y': 2, 'x': 1 }, expectedStringParams: ['x=1', 'y=2'] },
+		{ params: {'x': '??' }, expectedStringParams: ['x=%3F%3F'] },
+		{ params: {'??': 1 }, expectedStringParams: ['%3F%3F=1'] },
+	];
+
+	testCases.forEach(function(testCase) {
+		const params = testCase.params;
+		const expectedStringParams = testCase.expectedStringParams;
+
+		test(`Given ${JSON.stringify(params)} should contains these query params ${JSON.stringify(expectedStringParams)}`, () => {
+			const result = DictToQueryString(params);
+
+			if (expectedStringParams && expectedStringParams.length > 0) {
+				assert.equal('?', result[0]);
+
+				const stringParams = result.substr(1).split('&');
+
+				expectedStringParams.forEach(function(expectedStringParam) {
+					assert.isTrue(
+						stringParams.some(function(stringParam) { return stringParam === expectedStringParam; }),
+						`Query param string '${expectedStringParam}' not found in '${result}'`
+					);
+				});
+			}
+			else {
+				assert.equal('', result);
+			}
 		});
 	});
 });


### PR DESCRIPTION
* QE component should now be comptable with IE11
* Filtering still doesn't work
* Reason why QE actions will still not work in IE11 is because of https://github.com/Brightspace/polymer-siren-behaviors/issues/41 but this is a platform issue not a QE issue