### PR TITLE
Using flex to allow line wrapping.

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval.js
+++ b/components/d2l-quick-eval/d2l-quick-eval.js
@@ -25,14 +25,6 @@ class D2LQuickEval extends mixinBehaviors([D2L.PolymerBehaviors.Siren.EntityBeha
 					@apply --d2l-heading-1;
 					margin: 0;
 				}
-				.d2l-quick-eval-activity-list-modifiers {
-					position: absolute;
-					right: 0;
-					bottom: 0;
-				}
-				:host(:dir(rtl)) .d2l-quick-eval-activity-list-modifiers {
-					left: 0;
-				}
 				d2l-hm-search {
 					display: inline-block;
 					width: 250px;
@@ -40,7 +32,10 @@ class D2LQuickEval extends mixinBehaviors([D2L.PolymerBehaviors.Siren.EntityBeha
 				}
 				.d2l-quick-eval-top-bar {
 					padding-top: 0.25rem;
-					position: relative;
+					display: flex;
+					flex-wrap: wrap;
+					justify-content: space-between;
+					align-items: flex-end;
 				}
 				d2l-quick-eval-activities-list {
 					display: block;


### PR DESCRIPTION
Filter/search should still be on the right and bottom when screen is wide enough:
![image](https://user-images.githubusercontent.com/29403611/56502660-23a5d300-64e1-11e9-8660-77a477739e65.png)
They will wrap together when the width decreases:
![image](https://user-images.githubusercontent.com/29403611/56502762-72ec0380-64e1-11e9-8c85-5941fd43a9bb.png)
And they will wrap separately when the width decreases even further:
![image](https://user-images.githubusercontent.com/29403611/56502794-88f9c400-64e1-11e9-86af-7406c1f4dc4b.png)
