### PR TITLE
Combine the header into the link for screen reader.

### DIFF
--- a/components/d2l-activity-list-item/d2l-activity-list-item.js
+++ b/components/d2l-activity-list-item/d2l-activity-list-item.js
@@ -222,11 +222,11 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 			</style>
 			<div class="d2l-activity-list-item-container" style="visibility:hidden;">
 				<hr class="d2l-activity-list-item-top-line" />
-				<h1 class="d2l-activity-list-item-header-no-margin">
+				<h2 class="d2l-activity-list-item-header-no-margin">
 					<a class="d2l-focusable" href$="[[_activityHomepage]]" aria-label$="[[_accessibilityDataToString(_accessibilityData)]]">
 						<span class="d2l-activity-list-item-link-text">[[_accessibilityDataToString(_accessibilityData)]]</span>
 					</a>
-				</h1>
+				</h2>
 				<div class="d2l-activity-list-item-link-container">
 					<div class="d2l-activity-list-item-image">
 						<div class="d2l-activity-list-item-image-shimmer" hidden$="[[!imageShimmer]]"></div>

--- a/components/d2l-activity-list-item/d2l-activity-list-item.js
+++ b/components/d2l-activity-list-item/d2l-activity-list-item.js
@@ -216,12 +216,17 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 					margin-top: 0.7rem;
 					margin-right: 0.5rem;
 				}
+				.d2l-activity-list-item-header-no-margin {
+					margin: 0;
+				}
 			</style>
 			<div class="d2l-activity-list-item-container" style="visibility:hidden;">
 				<hr class="d2l-activity-list-item-top-line" />
-				<a class="d2l-focusable" href$="[[_activityHomepage]]">
-					<span class="d2l-activity-list-item-link-text">[[_accessibilityDataToString(_accessibilityData)]]</span>
-				</a>
+				<h1 class="d2l-activity-list-item-header-no-margin">
+					<a class="d2l-focusable" href$="[[_activityHomepage]]" aria-label$="[[_accessibilityDataToString(_accessibilityData)]]">
+						<span class="d2l-activity-list-item-link-text">[[_accessibilityDataToString(_accessibilityData)]]</span>
+					</a>
+				</h1>
 				<div class="d2l-activity-list-item-link-container">
 					<div class="d2l-activity-list-item-image">
 						<div class="d2l-activity-list-item-image-shimmer" hidden$="[[!imageShimmer]]"></div>
@@ -243,7 +248,7 @@ class D2lActivityListItem extends mixinBehaviors([IronResizableBehavior, D2L.Pol
 							</div>
 						</div>
 
-						<div>
+						<div aria-hidden="true">
 							<div hidden$="[[!_textPlaceholder]]">
 								<div class="d2l-activity-list-item-text-placeholder d2l-activity-list-item-title-placeholder"></div>
 							</div>


### PR DESCRIPTION
Story: https://rally1.rallydev.com/#/39602890252d/detail/userstory/299905420308

I've mainly tested in Chrome, IE11, and Edge in Windows using NVDA. Tested in Chrome and Safari on MAC using VoiceOver.

Adding the aria-label allows chrome to announce the link with the accessibility text properly. Previously Chrome announced "link 123456" where 123456 is the end of the link (e.g. "leinstance.com/d2l/le/discovery/view/course/123456").

Keeping the span within the link tag allows Edge to announce the link properly. Removing the span will make Edge announce "blank" when selecting the item. The aria-label doesn't seem to do anything here in edge.

IE11 didn't need either of these changes.

H1 was added to the link tag to make it appear in heading rotors. It'll also appear in link rotors. (Tested using voiceover utility on MAC and on Chrome and Safari).

Adding aria-hidden to the ~h2~ div of the organization title stops the title from being announced a second time.