### PR TITLE
initial checkin

### DIFF
--- a/components/d2l-quick-eval/build/lang/ar.js
+++ b/components/d2l-quick-eval/build/lang/ar.js
@@ -7,6 +7,7 @@ const LangArImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.ar = {
+			'activities': 'Activities',
 			'activityName': 'اسم النشاط',
 			'caughtUp': 'لقد انتهيت من مهامك!',
 			'checkBackOften': 'تحقق باستمرار من احتمال توفر عمليات إرسال جديدة.',
@@ -32,6 +33,7 @@ const LangArImpl = (superClass) => class extends superClass {
 			'searchResultsSingle': 'نتيجة بحث واحدة',
 			'sortBy': 'الفرز بحسب {columnName}',
 			'submissionDate': 'تاريخ الإرسال',
+			'submissions': 'Submissions',
 			'tableTitle': 'قائمة بعمليات إرسال المتعلّم غير المقيّمة من المقررات التعليمية والأدوات',
 			'tryAgain': 'المحاولة مرة أخرى'
 		};

--- a/components/d2l-quick-eval/build/lang/da-dk.js
+++ b/components/d2l-quick-eval/build/lang/da-dk.js
@@ -7,6 +7,7 @@ const LangDadkImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.dadk = {
+			'activities': 'Activities',
 			'activityName': 'Aktivitetsnavn',
 			'caughtUp': 'Du er helt med!',
 			'checkBackOften': 'Kom tilbage med jævne mellemrum for at se nye afleveringer.',
@@ -32,6 +33,7 @@ const LangDadkImpl = (superClass) => class extends superClass {
 			'searchResultsSingle': '1 søgeresultat',
 			'sortBy': 'Sortér efter {columnName}',
 			'submissionDate': 'Afleveringsdato',
+			'submissions': 'Submissions',
 			'tableTitle': 'Liste over ikke-evaluerede elevafleveringer på tværs af kurser og værktøjer',
 			'tryAgain': 'Prøv igen'
 		};

--- a/components/d2l-quick-eval/build/lang/de.js
+++ b/components/d2l-quick-eval/build/lang/de.js
@@ -7,6 +7,7 @@ const LangDeImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.de = {
+			'activities': 'Activities',
 			'activityName': 'Name der Aktivität',
 			'caughtUp': 'Sie sind auf dem neuesten Stand!',
 			'checkBackOften': 'Sehen Sie regelmäßig nach, ob neue Abgaben verfügbar sind.',
@@ -32,6 +33,7 @@ const LangDeImpl = (superClass) => class extends superClass {
 			'searchResultsSingle': '1 Suchergebnis',
 			'sortBy': 'Sortieren nach {columnName}',
 			'submissionDate': 'Abgabedatum',
+			'submissions': 'Submissions',
 			'tableTitle': 'Liste nicht bewerteter Abgaben von Lernern in allen Kursen und Tools',
 			'tryAgain': 'Erneut versuchen'
 		};

--- a/components/d2l-quick-eval/build/lang/en.js
+++ b/components/d2l-quick-eval/build/lang/en.js
@@ -7,6 +7,7 @@ const LangEnImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.en = {
+			'activities': 'Activities',
 			'activityName': 'Activity Name',
 			'caughtUp': 'You\'re all caught up!',
 			'checkBackOften': 'Check back often for new submissions.',
@@ -32,6 +33,7 @@ const LangEnImpl = (superClass) => class extends superClass {
 			'searchResultsMore': '{num}+ Search Results',
 			'sortBy': 'Sort by {columnName}',
 			'submissionDate': 'Submission Date',
+			'submissions': 'Submissions',
 			'tableTitle': 'List of unevaluated Learner submissions from across courses and tools',
 			'tryAgain': 'Try Again'
 		};

--- a/components/d2l-quick-eval/build/lang/es.js
+++ b/components/d2l-quick-eval/build/lang/es.js
@@ -7,6 +7,7 @@ const LangEsImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.es = {
+			'activities': 'Activities',
 			'activityName': 'Nombre de la actividad',
 			'caughtUp': 'Ya está al día.',
 			'checkBackOften': 'Vuelva a revisar a menudo para ver los nuevos envíos.',
@@ -32,6 +33,7 @@ const LangEsImpl = (superClass) => class extends superClass {
 			'searchResultsSingle': '1 resultado de búsqueda',
 			'sortBy': 'Ordenar por {columnName}',
 			'submissionDate': 'Fecha del material enviado',
+			'submissions': 'Submissions',
 			'tableTitle': 'Lista de envíos no evaluados del estudiante de todos los cursos y herramientas',
 			'tryAgain': 'Volver a intentarlo'
 		};

--- a/components/d2l-quick-eval/build/lang/fi.js
+++ b/components/d2l-quick-eval/build/lang/fi.js
@@ -7,6 +7,7 @@ const LangFiImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.fi = {
+			'activities': 'Activities',
 			'activityName': 'Activity Name',
 			'caughtUp': 'You\'re all caught up!',
 			'checkBackOften': 'Check back often for new submissions.',
@@ -32,6 +33,7 @@ const LangFiImpl = (superClass) => class extends superClass {
 			'searchResultsMore': '{num}+ Search Results',
 			'sortBy': 'Sort by {columnName}',
 			'submissionDate': 'Submission Date',
+			'submissions': 'Submissions',
 			'tableTitle': 'List of unevaluated Learner submissions from across courses and tools',
 			'tryAgain': 'Try Again'
 		};

--- a/components/d2l-quick-eval/build/lang/fr-fr.js
+++ b/components/d2l-quick-eval/build/lang/fr-fr.js
@@ -7,6 +7,7 @@ const LangFrfrImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.frfr = {
+			'activities': 'Activities',
 			'activityName': 'Nom de l’activité',
 			'caughtUp': 'Vous êtes à jour !',
 			'checkBackOften': 'Vérifiez régulièrement si vous avez de nouvelles soumissions de devoirs.',
@@ -32,6 +33,7 @@ const LangFrfrImpl = (superClass) => class extends superClass {
 			'searchResultsSingle': '1 Search Result',
 			'sortBy': 'Sort by {columnName}',
 			'submissionDate': 'Date de la soumission',
+			'submissions': 'Submissions',
 			'tableTitle': 'Liste des soumissions non évaluées de l’apprenant dans l’ensemble des cours et des outils',
 			'tryAgain': 'Réessayez'
 		};

--- a/components/d2l-quick-eval/build/lang/fr.js
+++ b/components/d2l-quick-eval/build/lang/fr.js
@@ -7,6 +7,7 @@ const LangFrImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.fr = {
+			'activities': 'Activities',
 			'activityName': 'Nom de l’activité',
 			'caughtUp': 'Vous avez terminé!',
 			'checkBackOften': 'Revenez régulièrement pour de nouvelles soumissions.',
@@ -32,6 +33,7 @@ const LangFrImpl = (superClass) => class extends superClass {
 			'searchResultsSingle': '1 résultat de recherche',
 			'sortBy': 'Trier par {columnName}',
 			'submissionDate': 'Date de soumission',
+			'submissions': 'Submissions',
 			'tableTitle': 'Liste des soumissions des apprenants non évaluées provenant des cours et des outils',
 			'tryAgain': 'Réessayer'
 		};

--- a/components/d2l-quick-eval/build/lang/ja.js
+++ b/components/d2l-quick-eval/build/lang/ja.js
@@ -7,6 +7,7 @@ const LangJaImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.ja = {
+			'activities': 'Activities',
 			'activityName': 'アクティビティ名',
 			'caughtUp': '学習はすべて順調に進んでいます！',
 			'checkBackOften': '新規送信物を頻繁にチェックしてください。',
@@ -32,6 +33,7 @@ const LangJaImpl = (superClass) => class extends superClass {
 			'searchResultsSingle': '1 件の検索結果',
 			'sortBy': '{columnName} で並べ替え',
 			'submissionDate': '送信日',
+			'submissions': 'Submissions',
 			'tableTitle': 'コースやツールをまたいだ、受講者からの未評価の送信物リスト',
 			'tryAgain': 'もう一度試してください'
 		};

--- a/components/d2l-quick-eval/build/lang/ko.js
+++ b/components/d2l-quick-eval/build/lang/ko.js
@@ -7,6 +7,7 @@ const LangKoImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.ko = {
+			'activities': 'Activities',
 			'activityName': '활동 이름',
 			'caughtUp': '거의 따라잡았습니다!',
 			'checkBackOften': '새로운 제출 항목이 있는지 자주 다시 확인하십시오.',
@@ -32,6 +33,7 @@ const LangKoImpl = (superClass) => class extends superClass {
 			'searchResultsSingle': '1 탐색 결과',
 			'sortBy': '{columnName}으로 정렬',
 			'submissionDate': '제출일',
+			'submissions': 'Submissions',
 			'tableTitle': '강의 및 도구 전체의 평가되지 않은 학습자 제출 항목 목록',
 			'tryAgain': '다시 시도'
 		};

--- a/components/d2l-quick-eval/build/lang/nl.js
+++ b/components/d2l-quick-eval/build/lang/nl.js
@@ -7,6 +7,7 @@ const LangNlImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.nl = {
+			'activities': 'Activities',
 			'activityName': 'Naam activiteit',
 			'caughtUp': 'U bent weer helemaal bij!',
 			'checkBackOften': 'Kijk regelmatig of er nieuwe indieningen via postvak zijn.',
@@ -32,6 +33,7 @@ const LangNlImpl = (superClass) => class extends superClass {
 			'searchResultsSingle': '1 zoekresultaat',
 			'sortBy': 'Sorteren op {columnName}',
 			'submissionDate': 'Datum van indiening via postvak',
+			'submissions': 'Submissions',
 			'tableTitle': 'Lijst van niet-geëvalueerde indieningen via postvak van cursisten van alle cursussen en tools',
 			'tryAgain': 'Probeer het opnieuw'
 		};

--- a/components/d2l-quick-eval/build/lang/pt.js
+++ b/components/d2l-quick-eval/build/lang/pt.js
@@ -7,6 +7,7 @@ const LangPtImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.pt = {
+			'activities': 'Activities',
 			'activityName': 'Nome da Atividade',
 			'caughtUp': 'Você está em dia!',
 			'checkBackOften': 'Verifique com frequência se há novos envios.',
@@ -32,6 +33,7 @@ const LangPtImpl = (superClass) => class extends superClass {
 			'searchResultsSingle': '1 resultado da pesquisa',
 			'sortBy': 'Classificar por {columnName}',
 			'submissionDate': 'Data do Envio',
+			'submissions': 'Submissions',
 			'tableTitle': 'Lista de envios de alunos não avaliados de todos os cursos e ferramentas',
 			'tryAgain': 'Tentar novamente'
 		};

--- a/components/d2l-quick-eval/build/lang/sv.js
+++ b/components/d2l-quick-eval/build/lang/sv.js
@@ -7,6 +7,7 @@ const LangSvImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.sv = {
+			'activities': 'Activities',
 			'activityName': 'Aktivitetsnamn',
 			'caughtUp': 'Du är ifatt!',
 			'checkBackOften': 'Du bör kontrollera om det finns nya inlämningar här med regelbundna intervall.',
@@ -32,6 +33,7 @@ const LangSvImpl = (superClass) => class extends superClass {
 			'searchResultsSingle': '1 sökresultat',
 			'sortBy': 'Sortera efter {columnName}',
 			'submissionDate': 'Inlämningsdatum',
+			'submissions': 'Submissions',
 			'tableTitle': 'Lista över ej utvärderade elevinlämningar från kurser och verktyg',
 			'tryAgain': 'Försök på nytt'
 		};

--- a/components/d2l-quick-eval/build/lang/tr.js
+++ b/components/d2l-quick-eval/build/lang/tr.js
@@ -7,6 +7,7 @@ const LangTrImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.tr = {
+			'activities': 'Activities',
 			'activityName': 'Etkinlik Adı',
 			'caughtUp': 'Yetiştin!',
 			'checkBackOften': 'Yeni gönderiler için belirli aralıklarla tekrar kontrol edin.',
@@ -32,6 +33,7 @@ const LangTrImpl = (superClass) => class extends superClass {
 			'searchResultsSingle': '1 Arama Sonucu',
 			'sortBy': 'Şuna göre sırala: {columnName}',
 			'submissionDate': 'Gönderme Tarihi',
+			'submissions': 'Submissions',
 			'tableTitle': 'Dersler ve araçlar genelinde değerlendirilmemiş Öğrenci gönderilerinin listesi',
 			'tryAgain': 'Tekrar Dene'
 		};

--- a/components/d2l-quick-eval/build/lang/zh-tw.js
+++ b/components/d2l-quick-eval/build/lang/zh-tw.js
@@ -7,6 +7,7 @@ const LangZhtwImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.zhtw = {
+			'activities': 'Activities',
 			'activityName': '活動名稱',
 			'caughtUp': '您已趕上最新進度！',
 			'checkBackOften': '請經常返回查看新的提交項目。',
@@ -32,6 +33,7 @@ const LangZhtwImpl = (superClass) => class extends superClass {
 			'searchResultsSingle': '1 個搜尋結果',
 			'sortBy': '排序方式：{columnName}',
 			'submissionDate': '提交日期',
+			'submissions': 'Submissions',
 			'tableTitle': '此清單包含所有課程和工具中未評估的學習者提交項目',
 			'tryAgain': '再試一次'
 		};

--- a/components/d2l-quick-eval/build/lang/zh.js
+++ b/components/d2l-quick-eval/build/lang/zh.js
@@ -7,6 +7,7 @@ const LangZhImpl = (superClass) => class extends superClass {
 	constructor() {
 		super();
 		this.zh = {
+			'activities': 'Activities',
 			'activityName': '活动名称',
 			'caughtUp': '您已跟上进度！',
 			'checkBackOften': '请稍后时常查看新的提交。',
@@ -32,6 +33,7 @@ const LangZhImpl = (superClass) => class extends superClass {
 			'searchResultsSingle': '个搜索结果',
 			'sortBy': 'Sort by {columnName}',
 			'submissionDate': '提交日期',
+			'submissions': 'Submissions',
 			'tableTitle': '来自各个课程和工具的未评估学员提交的列表',
 			'tryAgain': '请重试'
 		};

--- a/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
@@ -55,8 +55,8 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 				}
 			</style>
 			<div>
-				<button class="d2l-quick-eval-view-toggle-left" on-click="_selectSubmissions" selected$="[[_submissionsSelected]]">[[localize('submissions')]]</button>
-				<button class="d2l-quick-eval-view-toggle-right" on-click="_selectActivities" selected$="[[_activitiesSelected]]">[[localize('activities')]]</button>
+				<button class="d2l-quick-eval-view-toggle-left" on-click="_selectSubmissions" selected$="[[_isSelected(_viewTypes.submissions, currentSelected)]]">[[localize('submissions')]]</button>
+				<button class="d2l-quick-eval-view-toggle-right" on-click="_selectActivities" selected$="[[_isSelected(_viewTypes.activities, currentSelected)]]">[[localize('activities')]]</button>
 			<div>
 		`;
 		toggleTemplate.setAttribute('strip-whitespace', 'strip-whitespace');
@@ -65,15 +65,8 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 	static get properties() {
 		return {
 			currentSelected: {
-				type: String
-			},
-			_submissionsSelected: {
-				type: Boolean,
-				computed: '_isSelected("submissions", currentSelected)'
-			},
-			_activitiesSelected: {
-				type: Boolean,
-				computed: '_isSelected("activities", currentSelected)'
+				type: String,
+				observer: '_dispatchSelectionChanged'
 			},
 			_viewTypes: {
 				type: Object,
@@ -85,16 +78,10 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 		};
 	}
 	_selectSubmissions() {
-		if (this.currentSelected !== this._viewTypes.submissions) {
-			this.currentSelected = this._viewTypes.submissions;
-			this._dispatchSelectionChanged(this._viewTypes.submissions);
-		}
+		this.currentSelected = this._viewTypes.submissions;
 	}
 	_selectActivities() {
-		if (this.currentSelected !== this._viewTypes.activities) {
-			this.currentSelected = this._viewTypes.activities;
-			this._dispatchSelectionChanged(this._viewTypes.activities);
-		}
+		this.currentSelected = this._viewTypes.activities;
 	}
 	_isSelected(view) {
 		return this.currentSelected === view;

--- a/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
@@ -9,7 +9,7 @@ import 'd2l-colors/d2l-colors.js';
 class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 	static get is() { return 'd2l-quick-eval-view-toggle'; }
 	static get template() {
-		const temp = html`
+		const toggleTemplate = html`
 			<style>
 				.d2l-quick-eval-view-toggle-left,
 				:host(:dir(rtl)) .d2l-quick-eval-view-toggle-right {
@@ -59,8 +59,8 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 				<button class="d2l-quick-eval-view-toggle-right" on-click="_selectActivities" selected$="[[_activitiesSelected]]">[[localize('activities')]]</button>
 			<div>
 		`;
-		temp.setAttribute('strip-whitespace', 'strip-whitespace');
-		return temp;
+		toggleTemplate.setAttribute('strip-whitespace', 'strip-whitespace');
+		return toggleTemplate;
 	}
 	static get properties() {
 		return {

--- a/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
@@ -1,0 +1,108 @@
+import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
+import {QuickEvalLocalize} from './QuickEvalLocalize.js';
+import 'd2l-colors/d2l-colors.js';
+
+/**
+ * @customElement
+ * @polymer
+ */
+class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
+	static get is() { return 'd2l-quick-eval-view-toggle'; }
+	static get template() {
+		const temp = html`
+			<style>
+				.d2l-quick-eval-view-toggle-left {
+					border-top-left-radius: 0.3em;
+					border-bottom-left-radius: 0.3em;
+					border-width: 1px;
+				}
+				.d2l-quick-eval-view-toggle-right {
+					border-top-right-radius: 0.3em;
+					border-bottom-right-radius: 0.3em;
+					border-width: 1px 1px 1px 0;
+				}
+				:host button {
+					background-color: var(--d2l-color-regolith);
+					border-color: var(--d2l-color-mica);
+					border-style: solid;
+					box-sizing: border-box;
+					color: var(--d2l-color-ferrite);
+					cursor: pointer;
+					display: inline;
+					margin: 0;
+					min-height: calc(2rem + 2px);
+					outline: none;
+					padding: 0.5rem 1.5rem;
+					text-align: center;
+					transition: box-shadow 0.2s;
+					user-select: none;
+					vertical-align: middle;
+					white-space: nowrap;
+					width: auto;
+					-webkit-user-select: none;
+					-moz-user-select: none;
+					-ms-user-select: none;
+				}
+				:host button:hover,
+				:host button[selected] {
+					background-color: var(--d2l-color-gypsum);
+				}
+				:host button:focus-within {
+					box-shadow: 0 0 0 4px rgba(0, 111, 191, 0.3);
+					position: relative;
+				}
+			</style>
+			<div>
+				<button class="d2l-quick-eval-view-toggle-left" on-click="_selectSubmissions" selected$="[[_isSelected('submissions')]]">[[localize('submissions')]]</button>
+				<button class="d2l-quick-eval-view-toggle-right" on-click="_selectActivities" selected$="[[_isSelected('activities')]]">[[localize('activities')]]</button>
+			<div>
+		`;
+		temp.setAttribute('strip-whitespace', 'strip-whitespace');
+		return temp;
+	}
+	static get properties() {
+		return {
+			currentSelected: {
+				type: String
+			},
+			_viewTypes: {
+				type: Object,
+				value: {
+					submissions: 'submissions',
+					activities: 'activities'
+				}
+			}
+		};
+	}
+	_selectSubmissions() {
+		if (this.currentSelected !== this._viewTypes.submissions) {
+			this.currentSelected = this._viewTypes.submissions;
+			this._dispatchSelectionChanged(this._viewTypes.submissions);
+		}
+	}
+	_selectActivities() {
+		if (this.currentSelected !== this._viewTypes.activities) {
+			this.currentSelected = this._viewTypes.activities;
+			this._dispatchSelectionChanged(this._viewTypes.activities);
+		}
+	}
+	_isSelected(view) {
+		return this.currentSelected === view;
+	}
+	_dispatchSelectionChanged(view) {
+		this.dispatchEvent(
+			new CustomEvent(
+				'd2l-quick-eval-view-toggle-changed',
+				{
+					detail: {
+						view: view
+					},
+					composed: true,
+					bubbles: true
+				}
+			)
+		);
+	}
+}
+
+window.customElements.define(D2LQuickEvalViewToggle.is, D2LQuickEvalViewToggle);

--- a/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
@@ -53,8 +53,8 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 				}
 			</style>
 			<div>
-				<button class="d2l-quick-eval-view-toggle-left" on-click="_selectSubmissions" selected$="[[_isSelected('submissions')]]">[[localize('submissions')]]</button>
-				<button class="d2l-quick-eval-view-toggle-right" on-click="_selectActivities" selected$="[[_isSelected('activities')]]">[[localize('activities')]]</button>
+				<button class="d2l-quick-eval-view-toggle-left" on-click="_selectSubmissions" selected$="[[_submissionsSelected]]">[[localize('submissions')]]</button>
+				<button class="d2l-quick-eval-view-toggle-right" on-click="_selectActivities" selected$="[[_activitiesSelected]]">[[localize('activities')]]</button>
 			<div>
 		`;
 		temp.setAttribute('strip-whitespace', 'strip-whitespace');
@@ -64,6 +64,14 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 		return {
 			currentSelected: {
 				type: String
+			},
+			_submissionsSelected: {
+				type: Boolean,
+				computed: '_isSelected("submissions", currentSelected)'
+			},
+			_activitiesSelected: {
+				type: Boolean,
+				computed: '_isSelected("activities", currentSelected)'
 			},
 			_viewTypes: {
 				type: Object,

--- a/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
@@ -11,12 +11,14 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 	static get template() {
 		const temp = html`
 			<style>
-				.d2l-quick-eval-view-toggle-left {
+				.d2l-quick-eval-view-toggle-left,
+				:host(:dir(rtl)) .d2l-quick-eval-view-toggle-right {
 					border-top-left-radius: 0.3em;
 					border-bottom-left-radius: 0.3em;
 					border-width: 1px;
 				}
-				.d2l-quick-eval-view-toggle-right {
+				.d2l-quick-eval-view-toggle-right,
+				:host(:dir(rtl)) .d2l-quick-eval-view-toggle-left {
 					border-top-right-radius: 0.3em;
 					border-bottom-right-radius: 0.3em;
 					border-width: 1px 1px 1px 0;

--- a/components/d2l-quick-eval/lang/ar.json
+++ b/components/d2l-quick-eval/lang/ar.json
@@ -1,4 +1,5 @@
 {
+   "activities": "Activities",
    "activityName" : "اسم النشاط",
    "caughtUp" : "لقد انتهيت من مهامك!",
    "checkBackOften" : "تحقق باستمرار من احتمال توفر عمليات إرسال جديدة.",
@@ -24,6 +25,7 @@
    "searchResultsSingle" : "نتيجة بحث واحدة",
    "sortBy" : "الفرز بحسب {columnName}",
    "submissionDate" : "تاريخ الإرسال",
+   "submissions": "Submissions",
    "tableTitle" : "قائمة بعمليات إرسال المتعلّم غير المقيّمة من المقررات التعليمية والأدوات",
    "tryAgain" : "المحاولة مرة أخرى"
 }

--- a/components/d2l-quick-eval/lang/da-dk.json
+++ b/components/d2l-quick-eval/lang/da-dk.json
@@ -1,4 +1,5 @@
 {
+   "activities": "Activities",
    "activityName" : "Aktivitetsnavn",
    "caughtUp" : "Du er helt med!",
    "checkBackOften" : "Kom tilbage med jævne mellemrum for at se nye afleveringer.",
@@ -24,6 +25,7 @@
    "searchResultsSingle" : "1 søgeresultat",
    "sortBy" : "Sortér efter {columnName}",
    "submissionDate" : "Afleveringsdato",
+   "submissions": "Submissions",
    "tableTitle" : "Liste over ikke-evaluerede elevafleveringer på tværs af kurser og værktøjer",
    "tryAgain" : "Prøv igen"
 }

--- a/components/d2l-quick-eval/lang/de.json
+++ b/components/d2l-quick-eval/lang/de.json
@@ -1,4 +1,5 @@
 {
+   "activities": "Activities",
    "activityName" : "Name der Aktivität",
    "caughtUp" : "Sie sind auf dem neuesten Stand!",
    "checkBackOften" : "Sehen Sie regelmäßig nach, ob neue Abgaben verfügbar sind.",
@@ -24,6 +25,7 @@
    "searchResultsSingle" : "1 Suchergebnis",
    "sortBy" : "Sortieren nach {columnName}",
    "submissionDate" : "Abgabedatum",
+   "submissions": "Submissions",
    "tableTitle" : "Liste nicht bewerteter Abgaben von Lernern in allen Kursen und Tools",
    "tryAgain" : "Erneut versuchen"
 }

--- a/components/d2l-quick-eval/lang/en.json
+++ b/components/d2l-quick-eval/lang/en.json
@@ -1,4 +1,5 @@
 {
+  "activities": "Activities",
   "activityName": "Activity Name",
   "caughtUp": "You're all caught up!",
   "checkBackOften": "Check back often for new submissions.",
@@ -24,6 +25,7 @@
   "searchResultsMore": "{num}+ Search Results",
   "sortBy": "Sort by {columnName}",
   "submissionDate": "Submission Date",
+  "submissions": "Submissions",
   "tableTitle": "List of unevaluated Learner submissions from across courses and tools",
   "tryAgain": "Try Again"
 }

--- a/components/d2l-quick-eval/lang/es.json
+++ b/components/d2l-quick-eval/lang/es.json
@@ -1,4 +1,5 @@
 {
+   "activities": "Activities",
    "activityName" : "Nombre de la actividad",
    "caughtUp" : "Ya está al día.",
    "checkBackOften" : "Vuelva a revisar a menudo para ver los nuevos envíos.",
@@ -24,6 +25,7 @@
    "searchResultsSingle" : "1 resultado de búsqueda",
    "sortBy" : "Ordenar por {columnName}",
    "submissionDate" : "Fecha del material enviado",
+   "submissions": "Submissions",
    "tableTitle" : "Lista de envíos no evaluados del estudiante de todos los cursos y herramientas",
    "tryAgain" : "Volver a intentarlo"
 }

--- a/components/d2l-quick-eval/lang/fi.json
+++ b/components/d2l-quick-eval/lang/fi.json
@@ -1,4 +1,5 @@
 {
+  "activities": "Activities",
   "activityName": "Activity Name",
   "caughtUp": "You're all caught up!",
   "checkBackOften": "Check back often for new submissions.",
@@ -24,6 +25,7 @@
   "searchResultsMore": "{num}+ Search Results",
   "sortBy": "Sort by {columnName}",
   "submissionDate": "Submission Date",
+  "submissions": "Submissions",
   "tableTitle": "List of unevaluated Learner submissions from across courses and tools",
   "tryAgain": "Try Again"
 }

--- a/components/d2l-quick-eval/lang/fr-fr.json
+++ b/components/d2l-quick-eval/lang/fr-fr.json
@@ -1,4 +1,5 @@
 {
+   "activities": "Activities",
    "activityName" : "Nom de l’activité",
    "caughtUp" : "Vous êtes à jour !",
    "checkBackOften" : "Vérifiez régulièrement si vous avez de nouvelles soumissions de devoirs.",
@@ -24,6 +25,7 @@
    "searchResultsSingle" : "1 Search Result",
    "sortBy" : "Sort by {columnName}",
    "submissionDate" : "Date de la soumission",
+   "submissions": "Submissions",
    "tableTitle" : "Liste des soumissions non évaluées de l’apprenant dans l’ensemble des cours et des outils",
    "tryAgain" : "Réessayez"
 }

--- a/components/d2l-quick-eval/lang/fr.json
+++ b/components/d2l-quick-eval/lang/fr.json
@@ -1,4 +1,5 @@
 {
+   "activities": "Activities",
    "activityName" : "Nom de l’activité",
    "caughtUp" : "Vous avez terminé!",
    "checkBackOften" : "Revenez régulièrement pour de nouvelles soumissions.",
@@ -24,6 +25,7 @@
    "searchResultsSingle" : "1 résultat de recherche",
    "sortBy" : "Trier par {columnName}",
    "submissionDate" : "Date de soumission",
+   "submissions": "Submissions",
    "tableTitle" : "Liste des soumissions des apprenants non évaluées provenant des cours et des outils",
    "tryAgain" : "Réessayer"
 }

--- a/components/d2l-quick-eval/lang/ja.json
+++ b/components/d2l-quick-eval/lang/ja.json
@@ -1,4 +1,5 @@
 {
+   "activities": "Activities",
    "activityName" : "アクティビティ名",
    "caughtUp" : "学習はすべて順調に進んでいます！",
    "checkBackOften" : "新規送信物を頻繁にチェックしてください。",
@@ -24,6 +25,7 @@
    "searchResultsSingle" : "1 件の検索結果",
    "sortBy" : "{columnName} で並べ替え",
    "submissionDate" : "送信日",
+   "submissions": "Submissions",
    "tableTitle" : "コースやツールをまたいだ、受講者からの未評価の送信物リスト",
    "tryAgain" : "もう一度試してください"
 }

--- a/components/d2l-quick-eval/lang/ko.json
+++ b/components/d2l-quick-eval/lang/ko.json
@@ -1,4 +1,5 @@
 {
+   "activities": "Activities",
    "activityName" : "활동 이름",
    "caughtUp" : "거의 따라잡았습니다!",
    "checkBackOften" : "새로운 제출 항목이 있는지 자주 다시 확인하십시오.",
@@ -24,6 +25,7 @@
    "searchResultsSingle" : "1 탐색 결과",
    "sortBy" : "{columnName}으로 정렬",
    "submissionDate" : "제출일",
+   "submissions": "Submissions",
    "tableTitle" : "강의 및 도구 전체의 평가되지 않은 학습자 제출 항목 목록",
    "tryAgain" : "다시 시도"
 }

--- a/components/d2l-quick-eval/lang/nl.json
+++ b/components/d2l-quick-eval/lang/nl.json
@@ -1,4 +1,5 @@
 {
+   "activities": "Activities",
    "activityName" : "Naam activiteit",
    "caughtUp" : "U bent weer helemaal bij!",
    "checkBackOften" : "Kijk regelmatig of er nieuwe indieningen via postvak zijn.",
@@ -24,6 +25,7 @@
    "searchResultsSingle" : "1 zoekresultaat",
    "sortBy" : "Sorteren op {columnName}",
    "submissionDate" : "Datum van indiening via postvak",
+   "submissions": "Submissions",
    "tableTitle" : "Lijst van niet-geëvalueerde indieningen via postvak van cursisten van alle cursussen en tools",
    "tryAgain" : "Probeer het opnieuw"
 }

--- a/components/d2l-quick-eval/lang/pt.json
+++ b/components/d2l-quick-eval/lang/pt.json
@@ -1,4 +1,5 @@
 {
+   "activities": "Activities",
    "activityName" : "Nome da Atividade",
    "caughtUp" : "Você está em dia!",
    "checkBackOften" : "Verifique com frequência se há novos envios.",
@@ -24,6 +25,7 @@
    "searchResultsSingle" : "1 resultado da pesquisa",
    "sortBy" : "Classificar por {columnName}",
    "submissionDate" : "Data do Envio",
+   "submissions": "Submissions",
    "tableTitle" : "Lista de envios de alunos não avaliados de todos os cursos e ferramentas",
    "tryAgain" : "Tentar novamente"
 }

--- a/components/d2l-quick-eval/lang/sv.json
+++ b/components/d2l-quick-eval/lang/sv.json
@@ -1,4 +1,5 @@
 {
+   "activities": "Activities",
    "activityName" : "Aktivitetsnamn",
    "caughtUp" : "Du är ifatt!",
    "checkBackOften" : "Du bör kontrollera om det finns nya inlämningar här med regelbundna intervall.",
@@ -24,6 +25,7 @@
    "searchResultsSingle" : "1 sökresultat",
    "sortBy" : "Sortera efter {columnName}",
    "submissionDate" : "Inlämningsdatum",
+   "submissions": "Submissions",
    "tableTitle" : "Lista över ej utvärderade elevinlämningar från kurser och verktyg",
    "tryAgain" : "Försök på nytt"
 }

--- a/components/d2l-quick-eval/lang/tr.json
+++ b/components/d2l-quick-eval/lang/tr.json
@@ -1,4 +1,5 @@
 {
+   "activities": "Activities",
    "activityName" : "Etkinlik Adı",
    "caughtUp" : "Yetiştin!",
    "checkBackOften" : "Yeni gönderiler için belirli aralıklarla tekrar kontrol edin.",
@@ -24,6 +25,7 @@
    "searchResultsSingle" : "1 Arama Sonucu",
    "sortBy" : "Şuna göre sırala: {columnName}",
    "submissionDate" : "Gönderme Tarihi",
+   "submissions": "Submissions",
    "tableTitle" : "Dersler ve araçlar genelinde değerlendirilmemiş Öğrenci gönderilerinin listesi",
    "tryAgain" : "Tekrar Dene"
 }

--- a/components/d2l-quick-eval/lang/zh-tw.json
+++ b/components/d2l-quick-eval/lang/zh-tw.json
@@ -1,4 +1,5 @@
 {
+   "activities": "Activities",
    "activityName" : "活動名稱",
    "caughtUp" : "您已趕上最新進度！",
    "checkBackOften" : "請經常返回查看新的提交項目。",
@@ -24,6 +25,7 @@
    "searchResultsSingle" : "1 個搜尋結果",
    "sortBy" : "排序方式：{columnName}",
    "submissionDate" : "提交日期",
+   "submissions": "Submissions",
    "tableTitle" : "此清單包含所有課程和工具中未評估的學習者提交項目",
    "tryAgain" : "再試一次"
 }

--- a/components/d2l-quick-eval/lang/zh.json
+++ b/components/d2l-quick-eval/lang/zh.json
@@ -1,4 +1,5 @@
 {
+   "activities": "Activities",
    "activityName" : "活动名称",
    "caughtUp" : "您已跟上进度！",
    "checkBackOften" : "请稍后时常查看新的提交。",
@@ -24,6 +25,7 @@
    "searchResultsSingle" : "个搜索结果",
    "sortBy" : "Sort by {columnName}",
    "submissionDate" : "提交日期",
+   "submissions": "Submissions",
    "tableTitle" : "来自各个课程和工具的未评估学员提交的列表",
    "tryAgain" : "请重试"
 }

--- a/demo/d2l-quick-eval/d2l-quick-eval-view-toggle.html
+++ b/demo/d2l-quick-eval/d2l-quick-eval-view-toggle.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+		<title>d2l-quick-eval-toggle-link demo</title>
+		<script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+
+		<!-- For IE11 -->
+		<script src="../../node_modules/lie/dist/lie.polyfill.min.js"></script>
+		<script type="module" src="../../node_modules/whatwg-fetch/fetch.js"></script>
+		<script type="module" src="../../node_modules/url-polyfill/url-polyfill.js"></script>
+
+		<script type="module">
+			import '@polymer/iron-demo-helpers/demo-pages-shared-styles';
+			import '@polymer/iron-demo-helpers/demo-snippet';
+			import 'd2l-typography/d2l-typography.js';
+			import './update-direction.js';
+			import '../../components/d2l-quick-eval/d2l-quick-eval-view-toggle.js';
+
+			const $_documentContainer = document.createElement('template');
+			$_documentContainer.innerHTML = `
+				<custom-style>
+					<style is="custom-style" include="demo-pages-shared-styles"></style>
+				</custom-style>
+				<custom-style include="d2l-typography">
+					<style is="custom-style" include="d2l-typography"></style>
+				</custom-style>
+				<style>
+					html {
+						font-size: 20px;
+					}
+				</style>
+			`;
+			document.body.appendChild($_documentContainer.content);
+		</script>
+	</head>
+	<body class="d2l-typography">
+		<div class="vertical-section-container fixedSize">
+			<h3>d2l-quick-eval-toggle-link demo</h3>
+			<demo-snippet>
+				<template strip-whitespace>
+					<d2l-quick-eval-view-toggle current-selected="activities"></d2l-quick-eval-view-toggle>
+					<d2l-quick-eval-view-toggle current-selected="submissions"></d2l-quick-eval-view-toggle>
+				</template>
+			</demo-snippet>
+		</div>
+	</body>
+</html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -42,6 +42,7 @@
 				<li><a href="d2l-quick-eval/d2l-quick-eval.html">d2l-quick-eval</a></li>
 				<li><a href="d2l-quick-eval/d2l-quick-eval-activities-list.html">d2l-quick-eval-activities-list</a></li>
 				<li><a href="d2l-quick-eval/d2l-quick-eval-activities-list-empty.html">d2l-quick-eval-activities-list (empty state)</a></li>
+				<li><a href="d2l-quick-eval/d2l-quick-eval-view-toggle.html">d2l-quick-eval-view-toggle</a></li>
 				<h4>Activity Evaluation Icon</h4>
 				<li><a href="d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.html">d2l-activity-evaluation-icon-base</a></li>
 				<li><a href="d2l-activity-evaluation-icon/d2l-activity-evaluation-icon.html">d2l-activity-evaluation-icon</a></li>

--- a/test/d2l-quick-eval/d2l-quick-eval-view-toggle.html
+++ b/test/d2l-quick-eval/d2l-quick-eval-view-toggle.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+		<title>d2l-quick-eval test</title>
+		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+		<script src="../../../wct-browser-legacy/browser.js"></script>
+
+		<!-- For IE11 -->
+		<script src="../../../lie/dist/lie.polyfill.min.js"></script>
+		<script type="module" src="../../../whatwg-fetch/fetch.js"></script>
+		<script type="module" src="../../../url-polyfill/url-polyfill.js"></script>
+		<script type="module" src="../../components/d2l-quick-eval/d2l-quick-eval-view-toggle.js"></script>
+	</head>
+	<body>
+		<test-fixture id="basic">
+			<template strip-whitespace>
+				<d2l-quick-eval-view-toggle></d2l-quick-eval-view-toggle>
+			</template>
+		</test-fixture>
+
+		<script type="module" src="./d2l-quick-eval-view-toggle.js"></script>
+	</body>
+</html>

--- a/test/d2l-quick-eval/d2l-quick-eval-view-toggle.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-view-toggle.js
@@ -1,0 +1,45 @@
+(function() {
+	let toggle;
+	suite('d2l-quick-eval-view-toggle', function() {
+		setup(function() {
+			toggle = fixture('basic');
+		});
+
+		test('instantiating the element works', function() {
+			assert.equal(toggle.tagName.toLowerCase(), 'd2l-quick-eval-view-toggle');
+		});
+
+		test('should fire d2l-quick-eval-view-toggle-changed event when submissions is selected and activities is currently active', function(done) {
+			toggle.currentSelected = 'activities';
+			toggle.addEventListener('d2l-quick-eval-view-toggle-changed', function() {
+				assert.equal('submissions', toggle.currentSelected);
+				done();
+			});
+
+			toggle._selectSubmissions();
+		});
+		test('should fire d2l-quick-eval-view-toggle-changed event when activities is selected and submissions is currently active', function(done) {
+			toggle.currentSelected = 'submissions';
+			toggle.addEventListener('d2l-quick-eval-view-toggle-changed', function() {
+				assert.equal('activities', toggle.currentSelected);
+				done();
+			});
+
+			toggle._selectActivities();
+		});
+		test('should not fire d2l-quick-eval-view-toggle-changed event when activities is selected and activities is currently active', function() {
+			toggle.currentSelected = 'activities';
+			toggle.addEventListener('d2l-quick-eval-view-toggle-changed', function() {
+				assert.fail('d2l-quick-eval-view-toggle-changed should not be fired when selecting the already active button');
+			});
+			toggle._selectActivities();
+		});
+		test('should not fire d2l-quick-eval-view-toggle-changed even when submissions is selected and submissions is currently active', function() {
+			toggle.currentSelected = 'submissions';
+			toggle.addEventListener('d2l-quick-eval-view-toggle-changed', function() {
+				assert.fail('d2l-quick-eval-view-toggle-changed should not be fired when selecting the already active button');
+			});
+			toggle._selectSubmissions();
+		});
+	});
+})();

--- a/test/index.html
+++ b/test/index.html
@@ -35,7 +35,9 @@
 			'd2l-activity-card/d2l-activity-card-test.html?wc-shadydom=true&wc-ce=true',
 			'd2l-activity-card/d2l-activity-card-test.html?dom=shadow',
 			'd2l-quick-eval/d2l-quick-eval-search-results-summary-container.html?wc-shadydom=true&wc-ce=true',
-			'd2l-quick-eval/d2l-quick-eval-search-results-summary-container.html?dom=shadow'
+			'd2l-quick-eval/d2l-quick-eval-search-results-summary-container.html?dom=shadow',
+			'd2l-quick-eval/d2l-quick-eval-view-toggle.html?wc-shadydom=true&wc-ce=true',
+			'd2l-quick-eval/d2l-quick-eval-view-toggle.html?dom=shadow'
 		]);
 	</script>
 </body>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29403611/57377966-b6956d00-7171-11e9-900e-449affe53a6d.png)
Top component:
    Submissions: focused
    Activities: current selected
Bottom component:
    Submissions: current selected
    Activities: hovered

Fires `d2l-quick-eval-view-toggle-changed` event with the new selected view in `event.detail.view`, event is not fired if the currently selected button is pressed.