### PR TITLE
Adding toggle button to main quick-eval component, defaulting to off.

### DIFF
--- a/components/d2l-quick-eval/build/lang/ar.js
+++ b/components/d2l-quick-eval/build/lang/ar.js
@@ -35,7 +35,8 @@ const LangArImpl = (superClass) => class extends superClass {
 			'submissionDate': 'تاريخ الإرسال',
 			'submissions': 'Submissions',
 			'tableTitle': 'قائمة بعمليات إرسال المتعلّم غير المقيّمة من المقررات التعليمية والأدوات',
-			'tryAgain': 'المحاولة مرة أخرى'
+			'tryAgain': 'المحاولة مرة أخرى',
+			'viewBy': 'View by:'
 		};
 	}
 };

--- a/components/d2l-quick-eval/build/lang/da-dk.js
+++ b/components/d2l-quick-eval/build/lang/da-dk.js
@@ -35,7 +35,8 @@ const LangDadkImpl = (superClass) => class extends superClass {
 			'submissionDate': 'Afleveringsdato',
 			'submissions': 'Submissions',
 			'tableTitle': 'Liste over ikke-evaluerede elevafleveringer på tværs af kurser og værktøjer',
-			'tryAgain': 'Prøv igen'
+			'tryAgain': 'Prøv igen',
+			'viewBy': 'View by:'
 		};
 	}
 };

--- a/components/d2l-quick-eval/build/lang/de.js
+++ b/components/d2l-quick-eval/build/lang/de.js
@@ -35,7 +35,8 @@ const LangDeImpl = (superClass) => class extends superClass {
 			'submissionDate': 'Abgabedatum',
 			'submissions': 'Submissions',
 			'tableTitle': 'Liste nicht bewerteter Abgaben von Lernern in allen Kursen und Tools',
-			'tryAgain': 'Erneut versuchen'
+			'tryAgain': 'Erneut versuchen',
+			'viewBy': 'View by:'
 		};
 	}
 };

--- a/components/d2l-quick-eval/build/lang/en.js
+++ b/components/d2l-quick-eval/build/lang/en.js
@@ -35,7 +35,8 @@ const LangEnImpl = (superClass) => class extends superClass {
 			'submissionDate': 'Submission Date',
 			'submissions': 'Submissions',
 			'tableTitle': 'List of unevaluated Learner submissions from across courses and tools',
-			'tryAgain': 'Try Again'
+			'tryAgain': 'Try Again',
+			'viewBy': 'View by:'
 		};
 	}
 };

--- a/components/d2l-quick-eval/build/lang/es.js
+++ b/components/d2l-quick-eval/build/lang/es.js
@@ -35,7 +35,8 @@ const LangEsImpl = (superClass) => class extends superClass {
 			'submissionDate': 'Fecha del material enviado',
 			'submissions': 'Submissions',
 			'tableTitle': 'Lista de envíos no evaluados del estudiante de todos los cursos y herramientas',
-			'tryAgain': 'Volver a intentarlo'
+			'tryAgain': 'Volver a intentarlo',
+			'viewBy': 'View by:'
 		};
 	}
 };

--- a/components/d2l-quick-eval/build/lang/fi.js
+++ b/components/d2l-quick-eval/build/lang/fi.js
@@ -35,7 +35,8 @@ const LangFiImpl = (superClass) => class extends superClass {
 			'submissionDate': 'Submission Date',
 			'submissions': 'Submissions',
 			'tableTitle': 'List of unevaluated Learner submissions from across courses and tools',
-			'tryAgain': 'Try Again'
+			'tryAgain': 'Try Again',
+			'viewBy': 'View by:'
 		};
 	}
 };

--- a/components/d2l-quick-eval/build/lang/fr-fr.js
+++ b/components/d2l-quick-eval/build/lang/fr-fr.js
@@ -35,7 +35,8 @@ const LangFrfrImpl = (superClass) => class extends superClass {
 			'submissionDate': 'Date de la soumission',
 			'submissions': 'Submissions',
 			'tableTitle': 'Liste des soumissions non évaluées de l’apprenant dans l’ensemble des cours et des outils',
-			'tryAgain': 'Réessayez'
+			'tryAgain': 'Réessayez',
+			'viewBy': 'View by:'
 		};
 	}
 };

--- a/components/d2l-quick-eval/build/lang/fr.js
+++ b/components/d2l-quick-eval/build/lang/fr.js
@@ -35,7 +35,8 @@ const LangFrImpl = (superClass) => class extends superClass {
 			'submissionDate': 'Date de soumission',
 			'submissions': 'Submissions',
 			'tableTitle': 'Liste des soumissions des apprenants non évaluées provenant des cours et des outils',
-			'tryAgain': 'Réessayer'
+			'tryAgain': 'Réessayer',
+			'viewBy': 'View by:'
 		};
 	}
 };

--- a/components/d2l-quick-eval/build/lang/ja.js
+++ b/components/d2l-quick-eval/build/lang/ja.js
@@ -35,7 +35,8 @@ const LangJaImpl = (superClass) => class extends superClass {
 			'submissionDate': '送信日',
 			'submissions': 'Submissions',
 			'tableTitle': 'コースやツールをまたいだ、受講者からの未評価の送信物リスト',
-			'tryAgain': 'もう一度試してください'
+			'tryAgain': 'もう一度試してください',
+			'viewBy': 'View by:'
 		};
 	}
 };

--- a/components/d2l-quick-eval/build/lang/ko.js
+++ b/components/d2l-quick-eval/build/lang/ko.js
@@ -35,7 +35,8 @@ const LangKoImpl = (superClass) => class extends superClass {
 			'submissionDate': '제출일',
 			'submissions': 'Submissions',
 			'tableTitle': '강의 및 도구 전체의 평가되지 않은 학습자 제출 항목 목록',
-			'tryAgain': '다시 시도'
+			'tryAgain': '다시 시도',
+			'viewBy': 'View by:'
 		};
 	}
 };

--- a/components/d2l-quick-eval/build/lang/nl.js
+++ b/components/d2l-quick-eval/build/lang/nl.js
@@ -35,7 +35,8 @@ const LangNlImpl = (superClass) => class extends superClass {
 			'submissionDate': 'Datum van indiening via postvak',
 			'submissions': 'Submissions',
 			'tableTitle': 'Lijst van niet-geëvalueerde indieningen via postvak van cursisten van alle cursussen en tools',
-			'tryAgain': 'Probeer het opnieuw'
+			'tryAgain': 'Probeer het opnieuw',
+			'viewBy': 'View by:'
 		};
 	}
 };

--- a/components/d2l-quick-eval/build/lang/pt.js
+++ b/components/d2l-quick-eval/build/lang/pt.js
@@ -35,7 +35,8 @@ const LangPtImpl = (superClass) => class extends superClass {
 			'submissionDate': 'Data do Envio',
 			'submissions': 'Submissions',
 			'tableTitle': 'Lista de envios de alunos não avaliados de todos os cursos e ferramentas',
-			'tryAgain': 'Tentar novamente'
+			'tryAgain': 'Tentar novamente',
+			'viewBy': 'View by:'
 		};
 	}
 };

--- a/components/d2l-quick-eval/build/lang/sv.js
+++ b/components/d2l-quick-eval/build/lang/sv.js
@@ -35,7 +35,8 @@ const LangSvImpl = (superClass) => class extends superClass {
 			'submissionDate': 'Inlämningsdatum',
 			'submissions': 'Submissions',
 			'tableTitle': 'Lista över ej utvärderade elevinlämningar från kurser och verktyg',
-			'tryAgain': 'Försök på nytt'
+			'tryAgain': 'Försök på nytt',
+			'viewBy': 'View by:'
 		};
 	}
 };

--- a/components/d2l-quick-eval/build/lang/tr.js
+++ b/components/d2l-quick-eval/build/lang/tr.js
@@ -35,7 +35,8 @@ const LangTrImpl = (superClass) => class extends superClass {
 			'submissionDate': 'Gönderme Tarihi',
 			'submissions': 'Submissions',
 			'tableTitle': 'Dersler ve araçlar genelinde değerlendirilmemiş Öğrenci gönderilerinin listesi',
-			'tryAgain': 'Tekrar Dene'
+			'tryAgain': 'Tekrar Dene',
+			'viewBy': 'View by:'
 		};
 	}
 };

--- a/components/d2l-quick-eval/build/lang/zh-tw.js
+++ b/components/d2l-quick-eval/build/lang/zh-tw.js
@@ -35,7 +35,8 @@ const LangZhtwImpl = (superClass) => class extends superClass {
 			'submissionDate': '提交日期',
 			'submissions': 'Submissions',
 			'tableTitle': '此清單包含所有課程和工具中未評估的學習者提交項目',
-			'tryAgain': '再試一次'
+			'tryAgain': '再試一次',
+			'viewBy': 'View by:'
 		};
 	}
 };

--- a/components/d2l-quick-eval/build/lang/zh.js
+++ b/components/d2l-quick-eval/build/lang/zh.js
@@ -35,7 +35,8 @@ const LangZhImpl = (superClass) => class extends superClass {
 			'submissionDate': '提交日期',
 			'submissions': 'Submissions',
 			'tableTitle': '来自各个课程和工具的未评估学员提交的列表',
-			'tryAgain': '请重试'
+			'tryAgain': '请重试',
+			'viewBy': 'View by:'
 		};
 	}
 };

--- a/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
@@ -17,6 +17,12 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 					border-bottom-left-radius: 0.3em;
 					border-width: 1px;
 				}
+				:host button.d2l-quick-eval-view-toggle-left {
+					margin-left: 0.9rem;
+				}
+				:host(:dir(rtl)) button.d2l-quick-eval-view-toggle-left {
+					margin-right: 0.9rem;
+				}
 				.d2l-quick-eval-view-toggle-right,
 				:host(:dir(rtl)) .d2l-quick-eval-view-toggle-left {
 					border-top-right-radius: 0.3em;
@@ -55,6 +61,7 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 				}
 			</style>
 			<div>
+				[[localize('viewBy')]]
 				<button class="d2l-quick-eval-view-toggle-left" on-click="_selectSubmissions" selected$="[[_isSelected(_viewTypes.submissions, currentSelected)]]">[[localize('submissions')]]</button>
 				<button class="d2l-quick-eval-view-toggle-right" on-click="_selectActivities" selected$="[[_isSelected(_viewTypes.activities, currentSelected)]]">[[localize('activities')]]</button>
 			<div>

--- a/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
@@ -37,6 +37,7 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 					color: var(--d2l-color-ferrite);
 					cursor: pointer;
 					display: inline;
+					font-family: inherit;
 					margin: 0;
 					min-height: calc(2rem + 2px);
 					outline: none;
@@ -61,9 +62,19 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 				}
 			</style>
 			<div>
-				[[localize('viewBy')]]
-				<button class="d2l-quick-eval-view-toggle-left" on-click="_selectSubmissions" selected$="[[_isSelected(_viewTypes.submissions, currentSelected)]]">[[localize('submissions')]]</button>
-				<button class="d2l-quick-eval-view-toggle-right" on-click="_selectActivities" selected$="[[_isSelected(_viewTypes.activities, currentSelected)]]">[[localize('activities')]]</button>
+				<label id="d2l-quick-eval-view-toggle-label">[[localize('viewBy')]]</label>
+				<button 
+					class="d2l-quick-eval-view-toggle-left" 
+					on-click="_selectSubmissions" 
+					selected$="[[_isSelected(_viewTypes.submissions, currentSelected)]]"
+					aria-labelledby="d2l-quick-eval-view-toggle-label"
+				>[[localize('submissions')]]</button>
+				<button 
+					class="d2l-quick-eval-view-toggle-right" 
+					on-click="_selectActivities" 
+					selected$="[[_isSelected(_viewTypes.activities, currentSelected)]]"
+					aria-labelledby="d2l-quick-eval-view-toggle-label"
+				>[[localize('activities')]]</button>
 			<div>
 		`;
 		toggleTemplate.setAttribute('strip-whitespace', 'strip-whitespace');

--- a/components/d2l-quick-eval/d2l-quick-eval.js
+++ b/components/d2l-quick-eval/d2l-quick-eval.js
@@ -9,6 +9,7 @@ import 'd2l-common/components/d2l-hm-filter/d2l-hm-filter.js';
 import 'd2l-common/components/d2l-hm-search/d2l-hm-search.js';
 import './d2l-quick-eval-activities-list.js';
 import './d2l-quick-eval-search-results-summary-container.js';
+import './d2l-quick-eval-view-toggle.js';
 
 /**
  * @customElement
@@ -53,11 +54,19 @@ class D2LQuickEval extends mixinBehaviors([D2L.PolymerBehaviors.Siren.EntityBeha
 				[hidden] {
 					display: none;
 				}
+				.flex-break {
+					flex-basis: 100%;
+					width: 0px;
+					height: 36px;
+					overflow: hidden;
+				}
 			</style>
 			<div class="d2l-quick-eval-top-bar">
 				<template is="dom-if" if="[[headerText]]">
 					<h1>[[headerText]]</h1>
 				</template>
+				<div class="flex-break" hidden$="[[!toggleEnabled]]"></div>
+				<d2l-quick-eval-view-toggle hidden$="[[!toggleEnabled]]"></d2l-quick-eval-view-toggle>
 				<div class="d2l-quick-eval-activity-list-modifiers">
 					<d2l-hm-filter
 						href="[[_filterHref]]"
@@ -101,6 +110,11 @@ class D2LQuickEval extends mixinBehaviors([D2L.PolymerBehaviors.Siren.EntityBeha
 				reflectToAttribute: true
 			},
 			searchEnabled: {
+				type: Boolean,
+				value: false,
+				reflectToAttribute: true
+			},
+			toggleEnabled: {
 				type: Boolean,
 				value: false,
 				reflectToAttribute: true

--- a/components/d2l-quick-eval/lang/ar.json
+++ b/components/d2l-quick-eval/lang/ar.json
@@ -27,5 +27,6 @@
    "submissionDate" : "تاريخ الإرسال",
    "submissions": "Submissions",
    "tableTitle" : "قائمة بعمليات إرسال المتعلّم غير المقيّمة من المقررات التعليمية والأدوات",
-   "tryAgain" : "المحاولة مرة أخرى"
+   "tryAgain" : "المحاولة مرة أخرى",
+   "viewBy": "View by:"
 }

--- a/components/d2l-quick-eval/lang/da-dk.json
+++ b/components/d2l-quick-eval/lang/da-dk.json
@@ -27,5 +27,6 @@
    "submissionDate" : "Afleveringsdato",
    "submissions": "Submissions",
    "tableTitle" : "Liste over ikke-evaluerede elevafleveringer på tværs af kurser og værktøjer",
-   "tryAgain" : "Prøv igen"
+   "tryAgain" : "Prøv igen",
+   "viewBy": "View by:"
 }

--- a/components/d2l-quick-eval/lang/de.json
+++ b/components/d2l-quick-eval/lang/de.json
@@ -27,5 +27,6 @@
    "submissionDate" : "Abgabedatum",
    "submissions": "Submissions",
    "tableTitle" : "Liste nicht bewerteter Abgaben von Lernern in allen Kursen und Tools",
-   "tryAgain" : "Erneut versuchen"
+   "tryAgain" : "Erneut versuchen",
+   "viewBy": "View by:"
 }

--- a/components/d2l-quick-eval/lang/en.json
+++ b/components/d2l-quick-eval/lang/en.json
@@ -27,5 +27,6 @@
   "submissionDate": "Submission Date",
   "submissions": "Submissions",
   "tableTitle": "List of unevaluated Learner submissions from across courses and tools",
-  "tryAgain": "Try Again"
+  "tryAgain": "Try Again",
+  "viewBy": "View by:"
 }

--- a/components/d2l-quick-eval/lang/es.json
+++ b/components/d2l-quick-eval/lang/es.json
@@ -27,5 +27,6 @@
    "submissionDate" : "Fecha del material enviado",
    "submissions": "Submissions",
    "tableTitle" : "Lista de envíos no evaluados del estudiante de todos los cursos y herramientas",
-   "tryAgain" : "Volver a intentarlo"
+   "tryAgain" : "Volver a intentarlo",
+   "viewBy": "View by:"
 }

--- a/components/d2l-quick-eval/lang/fi.json
+++ b/components/d2l-quick-eval/lang/fi.json
@@ -27,5 +27,6 @@
   "submissionDate": "Submission Date",
   "submissions": "Submissions",
   "tableTitle": "List of unevaluated Learner submissions from across courses and tools",
-  "tryAgain": "Try Again"
+  "tryAgain": "Try Again",
+  "viewBy": "View by:"
 }

--- a/components/d2l-quick-eval/lang/fr-fr.json
+++ b/components/d2l-quick-eval/lang/fr-fr.json
@@ -27,5 +27,6 @@
    "submissionDate" : "Date de la soumission",
    "submissions": "Submissions",
    "tableTitle" : "Liste des soumissions non évaluées de l’apprenant dans l’ensemble des cours et des outils",
-   "tryAgain" : "Réessayez"
+   "tryAgain" : "Réessayez",
+   "viewBy": "View by:"
 }

--- a/components/d2l-quick-eval/lang/fr.json
+++ b/components/d2l-quick-eval/lang/fr.json
@@ -27,5 +27,6 @@
    "submissionDate" : "Date de soumission",
    "submissions": "Submissions",
    "tableTitle" : "Liste des soumissions des apprenants non évaluées provenant des cours et des outils",
-   "tryAgain" : "Réessayer"
+   "tryAgain" : "Réessayer",
+   "viewBy": "View by:"
 }

--- a/components/d2l-quick-eval/lang/ja.json
+++ b/components/d2l-quick-eval/lang/ja.json
@@ -27,5 +27,6 @@
    "submissionDate" : "送信日",
    "submissions": "Submissions",
    "tableTitle" : "コースやツールをまたいだ、受講者からの未評価の送信物リスト",
-   "tryAgain" : "もう一度試してください"
+   "tryAgain" : "もう一度試してください",
+   "viewBy": "View by:"
 }

--- a/components/d2l-quick-eval/lang/ko.json
+++ b/components/d2l-quick-eval/lang/ko.json
@@ -27,5 +27,6 @@
    "submissionDate" : "제출일",
    "submissions": "Submissions",
    "tableTitle" : "강의 및 도구 전체의 평가되지 않은 학습자 제출 항목 목록",
-   "tryAgain" : "다시 시도"
+   "tryAgain" : "다시 시도",
+   "viewBy": "View by:"
 }

--- a/components/d2l-quick-eval/lang/nl.json
+++ b/components/d2l-quick-eval/lang/nl.json
@@ -27,5 +27,6 @@
    "submissionDate" : "Datum van indiening via postvak",
    "submissions": "Submissions",
    "tableTitle" : "Lijst van niet-geëvalueerde indieningen via postvak van cursisten van alle cursussen en tools",
-   "tryAgain" : "Probeer het opnieuw"
+   "tryAgain" : "Probeer het opnieuw",
+   "viewBy": "View by:"
 }

--- a/components/d2l-quick-eval/lang/pt.json
+++ b/components/d2l-quick-eval/lang/pt.json
@@ -27,5 +27,6 @@
    "submissionDate" : "Data do Envio",
    "submissions": "Submissions",
    "tableTitle" : "Lista de envios de alunos não avaliados de todos os cursos e ferramentas",
-   "tryAgain" : "Tentar novamente"
+   "tryAgain" : "Tentar novamente",
+   "viewBy": "View by:"
 }

--- a/components/d2l-quick-eval/lang/sv.json
+++ b/components/d2l-quick-eval/lang/sv.json
@@ -27,5 +27,6 @@
    "submissionDate" : "Inlämningsdatum",
    "submissions": "Submissions",
    "tableTitle" : "Lista över ej utvärderade elevinlämningar från kurser och verktyg",
-   "tryAgain" : "Försök på nytt"
+   "tryAgain" : "Försök på nytt",
+   "viewBy": "View by:"
 }

--- a/components/d2l-quick-eval/lang/tr.json
+++ b/components/d2l-quick-eval/lang/tr.json
@@ -27,5 +27,6 @@
    "submissionDate" : "Gönderme Tarihi",
    "submissions": "Submissions",
    "tableTitle" : "Dersler ve araçlar genelinde değerlendirilmemiş Öğrenci gönderilerinin listesi",
-   "tryAgain" : "Tekrar Dene"
+   "tryAgain" : "Tekrar Dene",
+   "viewBy": "View by:"
 }

--- a/components/d2l-quick-eval/lang/zh-tw.json
+++ b/components/d2l-quick-eval/lang/zh-tw.json
@@ -27,5 +27,6 @@
    "submissionDate" : "提交日期",
    "submissions": "Submissions",
    "tableTitle" : "此清單包含所有課程和工具中未評估的學習者提交項目",
-   "tryAgain" : "再試一次"
+   "tryAgain" : "再試一次",
+   "viewBy": "View by:"
 }

--- a/components/d2l-quick-eval/lang/zh.json
+++ b/components/d2l-quick-eval/lang/zh.json
@@ -27,5 +27,6 @@
    "submissionDate" : "提交日期",
    "submissions": "Submissions",
    "tableTitle" : "来自各个课程和工具的未评估学员提交的列表",
-   "tryAgain" : "请重试"
+   "tryAgain" : "请重试",
+   "viewBy": "View by:"
 }

--- a/test/d2l-quick-eval/d2l-quick-eval.html
+++ b/test/d2l-quick-eval/d2l-quick-eval.html
@@ -27,7 +27,7 @@
 		<script type="module">
 			import '@polymer/iron-test-helpers/mock-interactions.js';
 
-			var quickEval, filter, filterDropdown, list, search;
+			var quickEval, filter, filterDropdown, list, search, toggle;
 
 			var expectedFirstCellData = 'Special User Name';
 			var expectedFilters = ['Activity Name', 'Course', 'Date'];
@@ -101,6 +101,7 @@
 					filterDropdown = filter.shadowRoot.querySelector('d2l-filter-dropdown');
 					list = quickEval.shadowRoot.querySelector('d2l-quick-eval-activities-list');
 					search = quickEval.shadowRoot.querySelector('d2l-hm-search');
+					toggle = quickEval.shadowRoot.querySelector('d2l-quick-eval-view-toggle');
 				});
 				test('instantiating the element works', function() {
 					assert.equal(quickEval.tagName.toLowerCase(), 'd2l-quick-eval');
@@ -126,7 +127,8 @@
 						)
 					);
 				});
-				test('the filter, search, and list exist', function() {
+				test('the toggle, filter, search, and list exist', function() {
+					assert.isNotNull(toggle);
 					assert.isNotNull(filter);
 					assert.isNotNull(search);
 					assert.isNotNull(list);

--- a/test/d2l-quick-eval/d2l-quick-eval.html
+++ b/test/d2l-quick-eval/d2l-quick-eval.html
@@ -366,6 +366,15 @@
 						performSearch('test');
 					});
 				});
+				test('toggle and flex-break are hidden when toggleEnabled is false', function() {
+					assert.isTrue(toggle.hidden);
+					assert.isTrue(quickEval.shadowRoot.querySelector('.flex-break').hidden);
+				});
+				test('toggle and flex-break are not hidden when toggleEnabled is true', function() {
+					quickEval.toggleEnabled = true;
+					assert.isFalse(toggle.hidden);
+					assert.isFalse(quickEval.shadowRoot.querySelector('.flex-break').hidden);
+				});
 			});
 
 			suite('d2l-quick-eval with master-teacher', function() {


### PR DESCRIPTION
There should be no change when `toggleEnabled` is `false`:
![image](https://user-images.githubusercontent.com/29403611/57465170-0cd6de80-724c-11e9-885b-479b9b381f9a.png)
Toggle and filter/search should be on the next line below the QE title when `toggleEnabled` is `true`:
![image](https://user-images.githubusercontent.com/29403611/57465238-31cb5180-724c-11e9-96c5-557fa6db4b10.png)
