### PR TITLE
Do not prevent the default behaviour of a ctrl click or meta key (com…

### DIFF
--- a/components/d2l-activity-card/d2l-activity-card.js
+++ b/components/d2l-activity-card/d2l-activity-card.js
@@ -268,7 +268,7 @@ class D2lActivityCard extends EntityMixin(PolymerElement) {
 		this._imageLoading = false;
 	}
 	_sendClickEvent(event) {
-		if (!this.sendEventOnClick || !this._activityHomepage) {
+		if (!this.sendEventOnClick || !this._activityHomepage || event.ctrlKey || event.metaKey) {
 			return;
 		}
 

--- a/components/d2l-activity-list-item/d2l-activity-list-item.js
+++ b/components/d2l-activity-list-item/d2l-activity-list-item.js
@@ -510,6 +510,8 @@ class D2lActivityListItem extends mixinBehaviors([
 	_onLinkTrigger(event) {
 		if (!this.sendOnTriggerEvent ||
 			!this._activityHomepage ||
+			event.ctrlKey ||
+			event.metaKey ||
 			(event.type === 'keydown' && event.keyCode !== 13 && event.keyCode !== 32)) {
 			return;
 		}


### PR DESCRIPTION
…mand on MAC) click on the d2l-activity-card and d2l-activity-list-item.

Not sending the event will also allow the the FRA to stay on the same page when the user performs a ctrl/cmd click on the component.

Story: https://rally1.rallydev.com/#/39602890252d/detail/defect/302900683632