### PR TITLE
US106353 - clean up sorting interface

### DIFF
--- a/components/d2l-quick-eval/behaviors/d2l-hm-sort-behaviour.js
+++ b/components/d2l-quick-eval/behaviors/d2l-hm-sort-behaviour.js
@@ -11,74 +11,23 @@ window.D2L.PolymerBehaviors.QuickEval = window.D2L.PolymerBehaviors.QuickEval ||
 */
 D2L.PolymerBehaviors.QuickEval.D2LHMSortBehaviourImpl = {
 
-	_getSortsPromise: function(entity) {
+	_followSortRel: function(entity) {
 		return this._followLink(entity, Rels.sorts);
 	},
 
 	_loadSorts: function(entity) {
-		// entity is null on initial load
-		if (!entity) {
-			return Promise.resolve();
-		}
-
-		return this._getSortsPromise(entity)
+		return this._followSortRel(entity)
 			.then(sortsEntity => {
 				if (!sortsEntity || !sortsEntity.entity) {
 					return Promise.reject(new Error('Could not load sorts endpoint'));
 				}
 
-				this._headerColumns.forEach((headerColumn, i) => {
-					headerColumn.headers.forEach((header, j) => {
-						if (header.sortClass) {
-							const sort = sortsEntity.entity.getSubEntityByClass(header.sortClass);
-							if (sort) {
-								this.set(`_headerColumns.${i}.headers.${j}.canSort`, true);
-								if (sort.properties && sort.properties.applied && (sort.properties.priority === 0)) {
-									const descending = sort.properties.direction === 'descending';
-									this.set(`_headerColumns.${i}.headers.${j}.sorted`, true);
-									this.set(`_headerColumns.${i}.headers.${j}.desc`, descending);
-
-								} else {
-									this.set(`_headerColumns.${i}.headers.${j}.sorted`, false);
-									this.set(`_headerColumns.${i}.headers.${j}.desc`, false);
-								}
-							}
-						}
-					});
-				});
-				return Promise.resolve();
+				return Promise.resolve(sortsEntity.entity);
 			});
 	},
 
-	_updateSortState: function(event) {
-
-		let result;
-		const headerId = event.currentTarget.id;
-
-		this._headerColumns.forEach((headerColumn, i) => {
-			headerColumn.headers.forEach((header, j) => {
-				if ((header.key === headerId) && header.canSort) {
-					const descending = header.sorted && !header.desc;
-					this.set(`_headerColumns.${i}.headers.${j}.sorted`, true);
-					this.set(`_headerColumns.${i}.headers.${j}.desc`, descending);
-
-					result = this._fetchSortedData(header.sortClass, descending);
-				}
-				else {
-					this.set(`_headerColumns.${i}.headers.${j}.sorted`, false);
-				}
-			});
-		});
-
-		if (result) {
-			return result;
-		} else {
-			return Promise.reject(new Error(`Could not find sortable header for ${headerId}`));
-		}
-	},
-
-	_fetchSortedData: function(sortClass, descending) {
-		return this._getSortsPromise(this.entity)
+	_applySortAndFetchData: function(sortClass, descending) {
+		return this._followSortRel(this.entity)
 			.then((sortsEntity => {
 				if (!sortsEntity || !sortsEntity.entity) {
 					return Promise.reject(new Error('Could not load sorts endpoint'));

--- a/demo/d2l-quick-eval/d2l-quick-eval-activities-list.html
+++ b/demo/d2l-quick-eval/d2l-quick-eval-activities-list.html
@@ -17,13 +17,6 @@
 			import '@polymer/iron-demo-helpers/demo-snippet';
 			import 'd2l-typography/d2l-typography.js';
 			import './update-direction.js';
-			import startMockServer from './interceptor';
-			import mappingsParser from './demo-data-parser';
-			import data from './table';
-
-			const mappings = mappingsParser(data);
-			// Parameters: data, network logging, api request delay
-			startMockServer(mappings, true, 100);
 
 			// For IE11, we need to import the component after we've started the mock observer
 			import '../../components/d2l-quick-eval/d2l-quick-eval-activities-list.js';
@@ -49,17 +42,8 @@
 		<div class="vertical-section-container fixedSize">
 			<h3>Basic d2l-quick-eval-activities-list demo</h3>
 			<demo-snippet>
-				<h4>Note: Load more button is expected to fail on last click, but should resolve itself when clicking it again</h4>
-				<hr/><br/>
 				<template strip-whitespace>
-					<d2l-quick-eval-activities-list href="pages/?sort=bydate-a" token="whatever"></d2l-quick-eval-activities-list>
-				</template>
-			</demo-snippet>
-			<demo-snippet>
-				<h4>Note: This will always show an error. It demonstrates how the component looks when failing to load data</h4>
-				<hr/><br/>
-				<template strip-whitespace>
-					<d2l-quick-eval-activities-list href="invalid" token="whatever"></d2l-quick-eval-activities-list>
+					<d2l-quick-eval-activities-list href="https://ea8ffd34-b879-4df6-939d-5ded43c88037.activities.api.dev.brightspace.com/my-unassessed-activities" token="eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImMzZDIzYmM5LWEyMzctNGRjMi04NGY4LWIwZjk3ODQzNTUwNCJ9.eyJzdWIiOiIzMTY3MSIsInRlbmFudGlkIjoiZWE4ZmZkMzQtYjg3OS00ZGY2LTkzOWQtNWRlZDQzYzg4MDM3Iiwic2NvcGUiOiIqOio6KiIsImp0aSI6ImNmNDkyYzQ0LWQyMDItNGFjMi1hNTc1LTY5YjA0OTIyNGZlNiIsImlzcyI6Imh0dHBzOi8vYXBpLmJyaWdodHNwYWNlLmNvbS9hdXRoIiwiYXVkIjoiaHR0cHM6Ly9hcGkuYnJpZ2h0c3BhY2UuY29tL2F1dGgvdG9rZW4iLCJleHAiOjE1NTc4NTMyNjgsIm5iZiI6MTU1Nzg0OTY2OH0.Xcirg7CwNZAr1T9PnugudRNSuqw8UykDtjFG0FFTdoPV5W56eL-8TVwMCaGYfrjYgd1B3Xx9sNkxnflD20hE7SbwTpycyhBCIeDCQkAxyWSp-vY2vECCaWeImXkRYiP0wMJHkKJfiDNLPWbNdfMQg5KEcOQ00SozOIcwdRZDH_vcYeK_4B-k-jXvk-c7YbTSoj7ECWg43EAdCpaoxCQUAwxrsk-pegvhlLYZfz25_1gWr5_H654mU4_2VxN-JOccDmGkqvgAMNbCHTVaBur7_xMSBoz-yacBFMc-4BGmjzVptKLe1JLSk5zIIx2XyDBE653Uiveh8rYySBnDYacokg"></d2l-quick-eval-activities-list>
 				</template>
 			</demo-snippet>
 		</div>

--- a/demo/d2l-quick-eval/d2l-quick-eval-activities-list.html
+++ b/demo/d2l-quick-eval/d2l-quick-eval-activities-list.html
@@ -17,6 +17,13 @@
 			import '@polymer/iron-demo-helpers/demo-snippet';
 			import 'd2l-typography/d2l-typography.js';
 			import './update-direction.js';
+			import startMockServer from './interceptor';
+			import mappingsParser from './demo-data-parser';
+			import data from './table';
+
+			const mappings = mappingsParser(data);
+			// Parameters: data, network logging, api request delay
+			startMockServer(mappings, true, 100);
 
 			// For IE11, we need to import the component after we've started the mock observer
 			import '../../components/d2l-quick-eval/d2l-quick-eval-activities-list.js';
@@ -42,8 +49,17 @@
 		<div class="vertical-section-container fixedSize">
 			<h3>Basic d2l-quick-eval-activities-list demo</h3>
 			<demo-snippet>
+				<h4>Note: Load more button is expected to fail on last click, but should resolve itself when clicking it again</h4>
+				<hr/><br/>
 				<template strip-whitespace>
-					<d2l-quick-eval-activities-list href="https://ea8ffd34-b879-4df6-939d-5ded43c88037.activities.api.dev.brightspace.com/my-unassessed-activities" token="eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImMzZDIzYmM5LWEyMzctNGRjMi04NGY4LWIwZjk3ODQzNTUwNCJ9.eyJzdWIiOiIzMTY3MSIsInRlbmFudGlkIjoiZWE4ZmZkMzQtYjg3OS00ZGY2LTkzOWQtNWRlZDQzYzg4MDM3Iiwic2NvcGUiOiIqOio6KiIsImp0aSI6ImNmNDkyYzQ0LWQyMDItNGFjMi1hNTc1LTY5YjA0OTIyNGZlNiIsImlzcyI6Imh0dHBzOi8vYXBpLmJyaWdodHNwYWNlLmNvbS9hdXRoIiwiYXVkIjoiaHR0cHM6Ly9hcGkuYnJpZ2h0c3BhY2UuY29tL2F1dGgvdG9rZW4iLCJleHAiOjE1NTc4NTMyNjgsIm5iZiI6MTU1Nzg0OTY2OH0.Xcirg7CwNZAr1T9PnugudRNSuqw8UykDtjFG0FFTdoPV5W56eL-8TVwMCaGYfrjYgd1B3Xx9sNkxnflD20hE7SbwTpycyhBCIeDCQkAxyWSp-vY2vECCaWeImXkRYiP0wMJHkKJfiDNLPWbNdfMQg5KEcOQ00SozOIcwdRZDH_vcYeK_4B-k-jXvk-c7YbTSoj7ECWg43EAdCpaoxCQUAwxrsk-pegvhlLYZfz25_1gWr5_H654mU4_2VxN-JOccDmGkqvgAMNbCHTVaBur7_xMSBoz-yacBFMc-4BGmjzVptKLe1JLSk5zIIx2XyDBE653Uiveh8rYySBnDYacokg"></d2l-quick-eval-activities-list>
+					<d2l-quick-eval-activities-list href="pages/?sort=bydate-a" token="whatever"></d2l-quick-eval-activities-list>
+				</template>
+			</demo-snippet>
+			<demo-snippet>
+				<h4>Note: This will always show an error. It demonstrates how the component looks when failing to load data</h4>
+				<hr/><br/>
+				<template strip-whitespace>
+					<d2l-quick-eval-activities-list href="invalid" token="whatever"></d2l-quick-eval-activities-list>
 				</template>
 			</demo-snippet>
 		</div>

--- a/test/d2l-quick-eval/d2l-quick-eval-activities-list-sorting.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activities-list-sorting.js
@@ -57,16 +57,16 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 		expect(keyToSortClassHeaderMappings).to.deep.equal(expectedKeyToSortClassHeaderMappings);
 	});
 
-	suite('_loadSorts', () => {
-		test('_loadSorts does not call _followLink on null entity', () => {
+	suite('_handleSorts', () => {
+		test('_handleSorts does not call _followLink on null entity', () => {
 			const stub = sinon.stub(list, '_followLink');
-			return list._loadSorts(null)
+			return list._handleSorts(null)
 				.then(() => {
 					expect(stub.notCalled).to.be.true;
 				});
 		});
 
-		suite('_loadSorts error cases', () => {
+		suite('_handleSorts error cases', () => {
 			const testData = [
 				{
 					name: 'null sortEntity',
@@ -83,16 +83,16 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 			];
 
 			testData.forEach(testCase => {
-				test('_loadSorts rejects on ' + testCase.name, (done) => {
+				test('_handleSorts rejects on ' + testCase.name, (done) => {
 					const stub = sinon.stub(list, '_followLink');
 					const entity = {};
 
 					stub.withArgs(entity, Rels.sorts)
 						.returns(testCase.sortEntity);
 
-					list._loadSorts(entity)
+					list._handleSorts(entity)
 						.then(() => {
-							done('_loadSorts should have rejected');
+							done('_handleSorts should have rejected');
 						})
 						.catch(() => {
 							done();
@@ -101,13 +101,13 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 			});
 		});
 
-		test('_loadSorts determines which headers are sortable', () => {
+		test('_handleSorts determines which headers are sortable', () => {
 			const enabledSortClasses = [{ className:'activity-name' }, {className: 'course-name' }];
 			const entity = {};
 
 			stubLoadSorts(list, entity, enabledSortClasses);
 
-			return list._loadSorts(entity)
+			return list._handleSorts(entity)
 				.then(() => {
 					const enabledSorts = list._headerColumns
 						.map(column => column.headers)
@@ -118,7 +118,7 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 					expect(enabledSorts).to.have.same.members(enabledSortClasses.map(x => x.className));
 				});
 		});
-		test('_loadSorts only sets the primary sort header to sorted', () => {
+		test('_handleSorts only sets the primary sort header to sorted', () => {
 			const enabledSortClasses = [
 				{ className: 'first-name', applied: true, direction: 'descending', priority: 0 },
 				{ className: 'completion-date', applied: true, direction: 'ascending', priority: 1 },
@@ -128,7 +128,7 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 
 			stubLoadSorts(list, entity, enabledSortClasses);
 
-			return list._loadSorts(entity)
+			return list._handleSorts(entity)
 				.then(() => {
 					const activeSorts = list._headerColumns
 						.map(column => column.headers)
@@ -142,8 +142,8 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 		});
 	});
 
-	suite('_updateSortState', () => {
-		suite('_updateSortState error cases', () => {
+	suite('_sortClickHandler', () => {
+		suite('_sortClickHandler error cases', () => {
 			const testData = [
 				{
 					name: 'header not found',
@@ -156,19 +156,19 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 			];
 			testData.forEach(testCase => {
 				test(testCase.name, (done) => {
-					var stub = sinon.stub(list, '_fetchSortedData');
+					var stub = sinon.stub(list, '_applySortAndFetchData');
 					const e = {
 						currentTarget: {
 							id: testCase.id
 						}
 					};
 
-					list._updateSortState(e)
+					list._sortClickHandler(e)
 						.then(() => {
-							done('_updateSortState should have rejected');
+							done('_sortClickHandler should have rejected');
 						})
 						.catch(() => {
-							expect(stub.notCalled, '_fetchSortedData should not be called').to.be.true;
+							expect(stub.notCalled, '_applySortAndFetchData should not be called').to.be.true;
 							done();
 						})
 						.catch((err) => {
@@ -178,7 +178,7 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 			});
 		});
 
-		suite('_updateSortState only sets sortable header to sorted', () => {
+		suite('_sortClickHandler only sets sortable header to sorted', () => {
 			const testData = [
 				{
 					name: 'ascending',
@@ -193,7 +193,7 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 			testData.forEach(testCase => {
 				test(testCase.name, () => {
 					const activeSortKey = 'activityName';
-					const stub = sinon.stub(list, '_fetchSortedData', () => Promise.resolve());
+					const stub = sinon.stub(list, '_applySortAndFetchData', () => Promise.resolve());
 					const e = {
 						currentTarget: {
 							id: activeSortKey
@@ -210,7 +210,7 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 						});
 					});
 
-					return list._updateSortState(e)
+					return list._sortClickHandler(e)
 						.then(() => {
 							const activeSorts = list._headerColumns
 								.map(column => column.headers)
@@ -227,8 +227,8 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 		});
 	});
 
-	suite('_fetchSortedData', () => {
-		test('_fetchSortedData correctly fetches data', () => {
+	suite('_applySortAndFetchData', () => {
+		test('_applySortAndFetchData correctly fetches data', () => {
 			const appliedSortClass = 'activity-name';
 			const activityNameSort = formatSort(appliedSortClass);
 			const sorts = SirenParse(formatSimpleSorts([activityNameSort]));
@@ -240,13 +240,13 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 			const performActionStub = sinon.stub(list, '_performSirenActionWithQueryParams');
 			const sortUpdatedStub = sinon.stub(list, '_dispatchSortUpdatedEvent');
 			const loadDataStub = sinon.stub(list, '_loadData');
-			const loadSortsStub = sinon.stub(list, '_loadSorts');
+			const loadSortsStub = sinon.stub(list, '_handleSorts');
 
 			followLinkStub.withArgs(list.entity, Rels.sorts).returns(Promise.resolve({ entity: sorts }));
 			performActionStub.withArgs(sortAction).returns(sorts);
 			performActionStub.withArgs(applyAction, sinon.match.any).returns(collection);
 
-			return list._fetchSortedData('activity-name', false)
+			return list._applySortAndFetchData('activity-name', false)
 				.then(actual => {
 					expect(sortUpdatedStub.withArgs(collection).calledOnce).to.be.true;
 					expect(loadDataStub.withArgs(collection).calledOnce).to.be.true;


### PR DESCRIPTION
Previous PR: https://github.com/BrightspaceHypermediaComponents/activities/pull/190

This PR: Tried to get the quick-eval specific things into `list` and keep the generic sorting stuff in the behaviour. I originally tried to have a complete sorting solution, but I couldn't figure out a good way to bind the sort headers to the sort behaviour. In the interest of time, I went with this smaller refactor.

Next PR: Going to create a new layer, `d2l-quick-eval-submission` that will serve as the controller for the submissions view. The new hierarchy will be `d2l-quick-eval` > `d2l-quick-eval-submission` > `d2l-quick-eval-activities-list`