### PR TITLE
US106353 - clean up sorting interface pt 2

### DIFF
--- a/components/d2l-quick-eval/behaviors/d2l-hm-sort-behaviour.js
+++ b/components/d2l-quick-eval/behaviors/d2l-hm-sort-behaviour.js
@@ -56,11 +56,6 @@ D2L.PolymerBehaviors.QuickEval.D2LHMSortBehaviourImpl = {
 				}
 				const customParams = this._numberOfActivitiesToShow > 0 ? {pageSize: this._numberOfActivitiesToShow} : undefined;
 				return this._performSirenActionWithQueryParams(action, customParams);
-			}).bind(this))
-			.then((collection => {
-				this.entity = collection;
-				this._dispatchSortUpdatedEvent(collection);
-				return Promise.resolve(collection);
 			}).bind(this));
 	}
 };

--- a/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -403,7 +403,10 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors(
 		});
 
 		if (result) {
-			return result;
+			return result.then(sortedCollection => {
+				this.entity = sortedCollection;
+				this._dispatchSortUpdatedEvent(sortedCollection);
+			});
 		} else {
 			return Promise.reject(new Error(`Could not find sortable header for ${headerId}`));
 		}

--- a/test/d2l-quick-eval/d2l-quick-eval-activities-list-sorting.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activities-list-sorting.js
@@ -238,9 +238,6 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 
 			const followLinkStub = sinon.stub(list, '_followLink');
 			const performActionStub = sinon.stub(list, '_performSirenActionWithQueryParams');
-			const sortUpdatedStub = sinon.stub(list, '_dispatchSortUpdatedEvent');
-			const loadDataStub = sinon.stub(list, '_loadData');
-			const loadSortsStub = sinon.stub(list, '_handleSorts');
 
 			followLinkStub.withArgs(list.entity, Rels.sorts).returns(Promise.resolve({ entity: sorts }));
 			performActionStub.withArgs(sortAction).returns(sorts);
@@ -248,9 +245,6 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 
 			return list._applySortAndFetchData('activity-name', false)
 				.then(actual => {
-					expect(sortUpdatedStub.withArgs(collection).calledOnce).to.be.true;
-					expect(loadDataStub.withArgs(collection).calledOnce).to.be.true;
-					expect(loadSortsStub.withArgs(collection).calledOnce).to.be.true;
 					expect(actual).to.deep.equal(collection);
 				});
 		});


### PR DESCRIPTION
Previous PR: https://github.com/BrightspaceHypermediaComponents/activities/pull/195

This PR: I noticed `d2l-hm-sort-behaviour` still had a dependency on `d2l-quick-eval-activities-list`, namely `_dispatchSortUpdatedEvent`. I moved that last bit over to `list`. The test change reflects this - `_applySortAndFetchData` is no longer coupled with `list` so it won't make the `list` callbacks.

Next PR: Going to create a new layer, `d2l-quick-eval-submission` that will serve as the controller for the submissions view. The new hierarchy will be `d2l-quick-eval` > `d2l-quick-eval-submission` > `d2l-quick-eval-activities-list`