### PR TITLE
US106353 - add submissions controller

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -1,0 +1,19 @@
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import './d2l-quick-eval-activities-list.js';
+
+class D2LQuickEvalSubmissions extends PolymerElement {
+	static get template() {
+		const template = html`
+			<d2l-quick-eval-activities-list href="[[href]]" token="[[token]]" logging-endpoint="[[loggingEndpoint]]" master-teacher="[[masterTeacher]]">
+			</d2l-quick-eval-activities-list>
+		`;
+		template.setAttribute('strip-whitespace', 'strip-whitespace');
+		return template;
+	}
+
+	static get is() {
+		return 'd2l-quick-eval-submissions';
+	}
+}
+
+window.customElements.define(D2LQuickEvalSubmissions.is, D2LQuickEvalSubmissions);

--- a/components/d2l-quick-eval/d2l-quick-eval.js
+++ b/components/d2l-quick-eval/d2l-quick-eval.js
@@ -8,10 +8,10 @@ import 'd2l-typography/d2l-typography-shared-styles.js';
 import 'd2l-alert/d2l-alert.js';
 import 'd2l-common/components/d2l-hm-filter/d2l-hm-filter.js';
 import 'd2l-common/components/d2l-hm-search/d2l-hm-search.js';
-import './d2l-quick-eval-activities-list.js';
 import './d2l-quick-eval-search-results-summary-container.js';
 import './d2l-quick-eval-view-toggle.js';
 import './d2l-quick-eval-activities.js';
+import './d2l-quick-eval-submissions.js';
 
 /**
  * @customElement
@@ -47,7 +47,7 @@ class D2LQuickEval extends mixinBehaviors(
 					float: left;
 					padding-bottom: 1.2rem;
 				}
-				d2l-quick-eval-activities-list {
+				d2l-quick-eval-submissions {
 					display: block;
 					padding-top: 1rem;
 				}
@@ -104,7 +104,7 @@ class D2LQuickEval extends mixinBehaviors(
 					more-results="[[_moreSearchResults]]"
 					hidden$="[[!_searchResultsMessageEnabled(_showSearchResultSummary, searchEnabled)]]">
 				</d2l-quick-eval-search-results-summary-container>
-				<d2l-quick-eval-activities-list href="[[href]]" token="[[token]]" logging-endpoint="[[loggingEndpoint]]" master-teacher="[[masterTeacher]]"></d2l-quick-eval-activities-list>
+				<d2l-quick-eval-submissions href="[[href]]" token="[[token]]" logging-endpoint="[[loggingEndpoint]]" master-teacher="[[masterTeacher]]"></d2l-quick-eval-submissions>
 			</div>
 			<d2l-quick-eval-activities hidden$="[[!_showActivitiesView]]"></d2l-quick-eval-activities>
 		`;
@@ -253,19 +253,19 @@ class D2LQuickEval extends mixinBehaviors(
 	}
 
 	_filtersLoaded(e) {
-		const list = this.shadowRoot.querySelector('d2l-quick-eval-activities-list');
+		const list = this.shadowRoot.querySelector('d2l-quick-eval-submissions').shadowRoot.querySelector('d2l-quick-eval-activities-list');
 		list.filterApplied = e.detail.totalSelectedFilters > 0;
 		this._showFilterError = false;
 	}
 
 	_filtersUpdating() {
-		const list = this.shadowRoot.querySelector('d2l-quick-eval-activities-list');
+		const list = this.shadowRoot.querySelector('d2l-quick-eval-submissions').shadowRoot.querySelector('d2l-quick-eval-activities-list');
 		list.setLoadingState(true);
 		this._clearErrors();
 	}
 
 	_filtersChanged(e) {
-		const list = this.shadowRoot.querySelector('d2l-quick-eval-activities-list');
+		const list = this.shadowRoot.querySelector('d2l-quick-eval-submissions').shadowRoot.querySelector('d2l-quick-eval-activities-list');
 		list.entity = e.detail.filteredActivities;
 		this.entity = e.detail.filteredActivities;
 
@@ -277,7 +277,7 @@ class D2LQuickEval extends mixinBehaviors(
 
 	_filterError(evt) {
 		this._logError(evt.detail.error, {developerMessage: 'Failed to retrieve filter results'});
-		const list = this.shadowRoot.querySelector('d2l-quick-eval-activities-list');
+		const list = this.shadowRoot.querySelector('d2l-quick-eval-submissions').shadowRoot.querySelector('d2l-quick-eval-activities-list');
 		list.setLoadingState(false);
 		this._showFilterError = true;
 	}
@@ -287,13 +287,13 @@ class D2LQuickEval extends mixinBehaviors(
 	}
 
 	_searchResultsLoading() {
-		const list = this.shadowRoot.querySelector('d2l-quick-eval-activities-list');
+		const list = this.shadowRoot.querySelector('d2l-quick-eval-submissions').shadowRoot.querySelector('d2l-quick-eval-activities-list');
 		list.setLoadingState(true);
 		this._clearErrors();
 	}
 
 	_searchResultsLoaded(e) {
-		const list = this.shadowRoot.querySelector('d2l-quick-eval-activities-list');
+		const list = this.shadowRoot.querySelector('d2l-quick-eval-submissions').shadowRoot.querySelector('d2l-quick-eval-activities-list');
 		list.entity = e.detail.results;
 		this.entity = e.detail.results;
 		this._showSearchResultSummary = !e.detail.searchIsCleared;
@@ -314,7 +314,7 @@ class D2LQuickEval extends mixinBehaviors(
 
 	_searchError(evt) {
 		this._logError(evt.detail.error, {developerMessage: 'Failed to retrieve search results.'});
-		const list = this.shadowRoot.querySelector('d2l-quick-eval-activities-list');
+		const list = this.shadowRoot.querySelector('d2l-quick-eval-submissions').shadowRoot.querySelector('d2l-quick-eval-activities-list');
 		list.setLoadingState(false);
 		this._showSearchError = true;
 	}
@@ -327,7 +327,7 @@ class D2LQuickEval extends mixinBehaviors(
 	_updateSearchResultsCount(count) {
 		this._searchResultsCount = count;
 
-		const list = this.shadowRoot.querySelector('d2l-quick-eval-activities-list');
+		const list = this.shadowRoot.querySelector('d2l-quick-eval-submissions').shadowRoot.querySelector('d2l-quick-eval-activities-list');
 		if (list._pageNextHref) {
 			this._moreSearchResults = true;
 		} else {

--- a/test/d2l-quick-eval/d2l-quick-eval.html
+++ b/test/d2l-quick-eval/d2l-quick-eval.html
@@ -5,10 +5,13 @@
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 
 		<title>d2l-quick-eval test</title>
-
-		<script src="../../../@babel/polyfill/browser.js"></script>
 		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script src="../../../wct-browser-legacy/browser.js"></script>
+
+		<!-- For IE11 -->
+		<script src="../../../lie/dist/lie.polyfill.min.js"></script>
+		<script type="module" src="../../../whatwg-fetch/fetch.js"></script>
+		<script type="module" src="../../../url-polyfill/url-polyfill.js"></script>
 		<script type="module" src="../../components/d2l-quick-eval/d2l-quick-eval.js"></script>
 	</head>
 	<body>
@@ -99,7 +102,7 @@
 					quickEval = fixture('basic');
 					filter = quickEval.shadowRoot.querySelector('d2l-hm-filter');
 					filterDropdown = filter.shadowRoot.querySelector('d2l-filter-dropdown');
-					list = quickEval.shadowRoot.querySelector('d2l-quick-eval-activities-list');
+					list = quickEval.shadowRoot.querySelector('d2l-quick-eval-submissions').shadowRoot.querySelector('d2l-quick-eval-activities-list');
 					search = quickEval.shadowRoot.querySelector('d2l-hm-search');
 					toggle = quickEval.shadowRoot.querySelector('d2l-quick-eval-view-toggle');
 				});
@@ -380,7 +383,7 @@
 					quickEval = fixture('masterTeacher');
 					filter = quickEval.shadowRoot.querySelector('d2l-hm-filter');
 					filterDropdown = filter.shadowRoot.querySelector('d2l-filter-dropdown');
-					list = quickEval.shadowRoot.querySelector('d2l-quick-eval-activities-list');
+					list = quickEval.shadowRoot.querySelector('d2l-quick-eval-submissions').shadowRoot.querySelector('d2l-quick-eval-activities-list');
 				});
 				test('instantiating the element works', function() {
 					assert.equal(quickEval.tagName.toLowerCase(), 'd2l-quick-eval');


### PR DESCRIPTION
Previous PR: https://github.com/BrightspaceHypermediaComponents/activities/pull/196

This PR: Adding a middle class called `d2l-quick-eval-submissions` that right now does nothing. This will be the controller for the submissions portion of the application. The plan is to slowly move functionality from above (quick-eval) and below (quick-eval-activities-list) until this follows the flux pattern.

Next PR: Since Josh is doing some search/filter stuff, I'm going to focus on moving things up from `list` next.