### PR TITLE
US106353 - move last bit of list-specific code out of sort

### DIFF
--- a/components/d2l-quick-eval/behaviors/d2l-hm-sort-behaviour.js
+++ b/components/d2l-quick-eval/behaviors/d2l-hm-sort-behaviour.js
@@ -26,7 +26,7 @@ D2L.PolymerBehaviors.QuickEval.D2LHMSortBehaviourImpl = {
 			});
 	},
 
-	_applySortAndFetchData: function(sortClass, descending) {
+	_applySortAndFetchData: function(sortClass, descending, customParams) {
 		return this._followSortRel(this.entity)
 			.then((sortsEntity => {
 				if (!sortsEntity || !sortsEntity.entity) {
@@ -54,7 +54,6 @@ D2L.PolymerBehaviors.QuickEval.D2LHMSortBehaviourImpl = {
 				if (!action) {
 					return Promise.reject(new Error(`Could not find apply action in ${sortsEntity}`));
 				}
-				const customParams = this._numberOfActivitiesToShow > 0 ? {pageSize: this._numberOfActivitiesToShow} : undefined;
 				return this._performSirenActionWithQueryParams(action, customParams);
 			}).bind(this));
 	}

--- a/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -394,7 +394,8 @@ class D2LQuickEvalActivitiesList extends mixinBehaviors(
 					this.set(`_headerColumns.${i}.headers.${j}.sorted`, true);
 					this.set(`_headerColumns.${i}.headers.${j}.desc`, descending);
 
-					result = this._applySortAndFetchData(header.sortClass, descending);
+					const customParams = this._numberOfActivitiesToShow > 0 ? {pageSize: this._numberOfActivitiesToShow} : undefined;
+					result = this._applySortAndFetchData(header.sortClass, descending, customParams);
 				}
 				else {
 					this.set(`_headerColumns.${i}.headers.${j}.sorted`, false);

--- a/test/d2l-quick-eval/d2l-quick-eval-activities-list-sorting.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activities-list-sorting.js
@@ -235,15 +235,16 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 			const sortAction = sorts.getSubEntityByClass(appliedSortClass).getActionByName('sort-ascending');
 			const applyAction = sorts.getActionByName('apply');
 			const collection = {};
+			const customParams = { pageSize: 17 };
 
 			const followLinkStub = sinon.stub(list, '_followLink');
 			const performActionStub = sinon.stub(list, '_performSirenActionWithQueryParams');
 
 			followLinkStub.withArgs(list.entity, Rels.sorts).returns(Promise.resolve({ entity: sorts }));
 			performActionStub.withArgs(sortAction).returns(sorts);
-			performActionStub.withArgs(applyAction, sinon.match.any).returns(collection);
+			performActionStub.withArgs(applyAction, customParams).returns(collection);
 
-			return list._applySortAndFetchData('activity-name', false)
+			return list._applySortAndFetchData('activity-name', false, customParams)
 				.then(actual => {
 					expect(actual).to.deep.equal(collection);
 				});


### PR DESCRIPTION
Previous PR: https://github.com/BrightspaceHypermediaComponents/activities/pull/198

This PR: Just noticed one last list-specific thing in sort that should be moved to the outside

Next PR: Since Josh is doing some search/filter stuff, I'm going to focus on moving things up from `list` next.