### PR TITLE
Remove store from activities.

### DIFF
--- a/components/d2l-activity-card/d2l-activity-card.js
+++ b/components/d2l-activity-card/d2l-activity-card.js
@@ -91,6 +91,7 @@ class D2lActivityCard extends PolymerElement {
 				type: String,
 				observer: '_onHrefChange'
 			},
+			token: String,
 			entity: {
 				type: Object,
 				value: function() {

--- a/components/d2l-activity-card/d2l-activity-card.js
+++ b/components/d2l-activity-card/d2l-activity-card.js
@@ -1,6 +1,5 @@
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { Classes, Rels } from 'd2l-hypermedia-constants';
-import { EntityMixin } from 'siren-sdk/mixin/entity-mixin.js';
 import 'fastdom/fastdom.min.js';
 import 'd2l-card/d2l-card.js';
 import 'd2l-card/d2l-card-content-meta.js';
@@ -15,7 +14,7 @@ import SirenParse from 'siren-parser';
  * @customElement
  * @polymer
  */
-class D2lActivityCard extends EntityMixin(PolymerElement) {
+class D2lActivityCard extends PolymerElement {
 	static get template() {
 		return html`
 			<style include="d2l-typography-shared-styles">

--- a/components/d2l-activity-list-item/d2l-activity-list-item.js
+++ b/components/d2l-activity-list-item/d2l-activity-list-item.js
@@ -18,7 +18,6 @@ import './d2l-activity-list-item-enroll.js';
 import SirenParse from 'siren-parser';
 import {ActivityListItemResponsiveConstants} from './ActivityListItemResponsiveConstants.js';
 import 'd2l-colors/d2l-colors.js';
-import 'd2l-polymer-siren-behaviors/store/entity-behavior.js';
 
 /**
  * @customElement
@@ -26,7 +25,6 @@ import 'd2l-polymer-siren-behaviors/store/entity-behavior.js';
  */
 class D2lActivityListItem extends mixinBehaviors([
 	IronResizableBehavior,
-	D2L.PolymerBehaviors.Siren.EntityBehavior,
 	D2L.PolymerBehaviors.FocusableBehavior], ActivityListItemResponsiveConstants(MutableData(PolymerElement))) {
 	static get template() {
 		return html`
@@ -301,6 +299,7 @@ class D2lActivityListItem extends mixinBehaviors([
 				type: String,
 				observer: '_onHrefChange'
 			},
+			token: String,
 			entity: {
 				type: Object,
 				value: function() {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
 		"del": "^3.0.0",
 		"fastdom": "^1.0.8",
 		"merge-stream": "^1.0.1",
-		"require-dir": "^1.2.0"
-	}
+    "require-dir": "^1.2.0"
+  }
 }


### PR DESCRIPTION
The store doesn't work nicely with the way I allowed embedded HM entities to be added. The siren-sdk will fix this issue! So YAY!

The issue that was caused was because the href was changed when adding the entity that entity would be fetched again. This would cause a fetch call to our outside service and fail it since there was too many.  Eek.

So this PR is here to fix this for cert and isn't a long term fix.