### PR TITLE
US106353 - move sorting to controller

### DIFF
--- a/components/d2l-quick-eval/behaviors/d2l-quick-eval-siren-helper-behavior.js
+++ b/components/d2l-quick-eval/behaviors/d2l-quick-eval-siren-helper-behavior.js
@@ -128,6 +128,15 @@ D2L.PolymerBehaviors.QuickEval.D2LQuickEvalSirenHelperBehaviorImpl = {
 		}
 		return '';
 	},
+
+	_determineIfActivityIsDraft: function(activity) {
+		const evaluation = this._getEvaluation(activity);
+		if (evaluation && evaluation.properties && evaluation.properties.state === 'Draft') {
+			return true;
+		}
+
+		return false;
+	}
 };
 
 /** @polymerBehavior */

--- a/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -267,11 +267,6 @@ class D2LQuickEvalActivitiesList extends QuickEvalLogging(QuickEvalLocalize(Poly
 				type: Array,
 				value: [ ]
 			},
-			_numberOfActivitiesToShow: {
-				type: Number,
-				computed: '_computeNumberOfActivitiesToShow(_data, _numberOfActivitiesToShow)',
-				value: 20
-			},
 			_numberOfActivitiesShownInSearchResults: {
 				type: Number,
 				computed: '_computeNumberOfActivitiesShownInSearchResults(_data)'
@@ -304,7 +299,7 @@ class D2LQuickEvalActivitiesList extends QuickEvalLogging(QuickEvalLocalize(Poly
 	static get observers() {
 		return [
 			'_handleNameSwap(_headerColumns.0.headers.*)',
-			'_dispatchPageSizeEvent(_numberOfActivitiesToShow)',
+
 			'_dispatchActivitiesShownInSearchResultsEvent(_numberOfActivitiesShownInSearchResults)'
 		];
 	}
@@ -316,10 +311,6 @@ class D2LQuickEvalActivitiesList extends QuickEvalLogging(QuickEvalLocalize(Poly
 
 	_isLoadingMore(fullListLoading, isLoading) {
 		return !fullListLoading && isLoading;
-	}
-
-	_computeNumberOfActivitiesToShow(data, currentNumberOfActivitiesShown) {
-		return Math.max(data.length, currentNumberOfActivitiesShown);
 	}
 
 	_computeNumberOfActivitiesShownInSearchResults(data) {
@@ -457,21 +448,6 @@ class D2LQuickEvalActivitiesList extends QuickEvalLogging(QuickEvalLocalize(Poly
 				{
 					detail: {
 						headerId: headerId
-					},
-					composed: true,
-					bubbles: true
-				}
-			)
-		);
-	}
-
-	_dispatchPageSizeEvent(numberOfActivitiesToShow) {
-		this.dispatchEvent(
-			new CustomEvent(
-				'd2l-quick-eval-activities-list-activities-shown-number-updated',
-				{
-					detail: {
-						count: numberOfActivitiesToShow
 					},
 					composed: true,
 					bubbles: true

--- a/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -299,7 +299,6 @@ class D2LQuickEvalActivitiesList extends QuickEvalLogging(QuickEvalLocalize(Poly
 	static get observers() {
 		return [
 			'_handleNameSwap(_headerColumns.0.headers.*)',
-
 			'_dispatchActivitiesShownInSearchResultsEvent(_numberOfActivitiesShownInSearchResults)'
 		];
 	}

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -68,14 +68,20 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 						headers: [{ key: 'masterTeacher', sortClass: 'primary-facilitator', canSort: false, sorted: false, desc: false }]
 					}
 				]
-			}
+			},
+			_numberOfActivitiesToShow: {
+				type: Number,
+				computed: '_computeNumberOfActivitiesToShow(_data, _numberOfActivitiesToShow)',
+				value: 20
+			},
 		};
 	}
 
 	static get observers() {
 		return [
 			'_loadData(entity)',
-			'_handleSorts(entity)'
+			'_handleSorts(entity)',
+			'_dispatchPageSizeEvent(_numberOfActivitiesToShow)'
 		];
 	}
 
@@ -225,7 +231,6 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 					this.set(`_headerColumns.${i}.headers.${j}.sorted`, true);
 					this.set(`_headerColumns.${i}.headers.${j}.desc`, descending);
 
-					// bedley fixme _numberOfActivitiesToShow
 					const customParams = this._numberOfActivitiesToShow > 0 ? { pageSize: this._numberOfActivitiesToShow } : undefined;
 					result = this._applySortAndFetchData(header.sortClass, descending, customParams);
 				}
@@ -252,6 +257,25 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 				{
 					detail: {
 						sortedActivities: sorted
+					},
+					composed: true,
+					bubbles: true
+				}
+			)
+		);
+	}
+
+	_computeNumberOfActivitiesToShow(data, currentNumberOfActivitiesShown) {
+		return Math.max(data.length, currentNumberOfActivitiesShown);
+	}
+
+	_dispatchPageSizeEvent(numberOfActivitiesToShow) {
+		this.dispatchEvent(
+			new CustomEvent(
+				'd2l-quick-eval-activities-list-activities-shown-number-updated',
+				{
+					detail: {
+						count: numberOfActivitiesToShow
 					},
 					composed: true,
 					bubbles: true

--- a/components/d2l-quick-eval/d2l-quick-eval.js
+++ b/components/d2l-quick-eval/d2l-quick-eval.js
@@ -266,9 +266,7 @@ class D2LQuickEval extends mixinBehaviors(
 
 	_filtersChanged(e) {
 		const submissions = this.shadowRoot.querySelector('d2l-quick-eval-submissions');
-		const list = submissions.shadowRoot.querySelector('d2l-quick-eval-activities-list');
 		submissions.entity = e.detail.filteredActivities;
-		list.entity = e.detail.filteredActivities;
 		this.entity = e.detail.filteredActivities;
 
 		if (this.entity && this.entity.entities) {
@@ -299,7 +297,6 @@ class D2LQuickEval extends mixinBehaviors(
 		const list = submissions.shadowRoot.querySelector('d2l-quick-eval-activities-list');
 
 		submissions.entity = e.detail.results;
-		list.entity = e.detail.results;
 		this.entity = e.detail.results;
 		this._showSearchResultSummary = !e.detail.searchIsCleared;
 		list.searchApplied = !e.detail.searchIsCleared;

--- a/test/d2l-quick-eval/d2l-quick-eval-activities-list-sorting.html
+++ b/test/d2l-quick-eval/d2l-quick-eval-activities-list-sorting.html
@@ -12,12 +12,12 @@
 		<script src="../../../lie/dist/lie.polyfill.min.js"></script>
 		<script type="module" src="../../../whatwg-fetch/fetch.js"></script>
 		<script type="module" src="../../../url-polyfill/url-polyfill.js"></script>
-		<script type="module" src="../../components/d2l-quick-eval/d2l-quick-eval-activities-list.js"></script>
+		<script type="module" src="../../components/d2l-quick-eval/d2l-quick-eval-submissions.js"></script>
 	</head>
 	<body>
 		<test-fixture id="basic">
 			<template strip-whitespace>
-				<d2l-quick-eval-activities-list></d2l-quick-eval-activities-list>
+				<d2l-quick-eval-submissions></d2l-quick-eval-submissions>
 			</template>
 		</test-fixture>
 

--- a/test/d2l-quick-eval/d2l-quick-eval-activities-list-sorting.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activities-list-sorting.js
@@ -142,8 +142,8 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 		});
 	});
 
-	suite('_sortClickHandler', () => {
-		suite('_sortClickHandler error cases', () => {
+	suite('_handleSortRequested', () => {
+		suite('_handleSortRequested error cases', () => {
 			const testData = [
 				{
 					name: 'header not found',
@@ -158,14 +158,14 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 				test(testCase.name, (done) => {
 					var stub = sinon.stub(list, '_applySortAndFetchData');
 					const e = {
-						currentTarget: {
-							id: testCase.id
+						detail: {
+							headerId: testCase.id
 						}
 					};
 
-					list._sortClickHandler(e)
+					list._handleSortRequested(e)
 						.then(() => {
-							done('_sortClickHandler should have rejected');
+							done('_handleSortRequested should have rejected');
 						})
 						.catch(() => {
 							expect(stub.notCalled, '_applySortAndFetchData should not be called').to.be.true;
@@ -178,7 +178,7 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 			});
 		});
 
-		suite('_sortClickHandler only sets sortable header to sorted', () => {
+		suite('_handleSortRequested only sets sortable header to sorted', () => {
 			const testData = [
 				{
 					name: 'ascending',
@@ -195,8 +195,8 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 					const activeSortKey = 'activityName';
 					const stub = sinon.stub(list, '_applySortAndFetchData', () => Promise.resolve());
 					const e = {
-						currentTarget: {
-							id: activeSortKey
+						detail: {
+							headerId: activeSortKey
 						}
 					};
 
@@ -210,7 +210,7 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 						});
 					});
 
-					return list._sortClickHandler(e)
+					return list._handleSortRequested(e)
 						.then(() => {
 							const activeSorts = list._headerColumns
 								.map(column => column.headers)

--- a/test/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -145,7 +145,8 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 		['First Name', 'Last Name'],
 		['Activity Name'],
 		['Course'],
-		['Submission Date']
+		['Submission Date'],
+		['Teacher']
 	];
 	var expectedColumnHeadersWithMasterTeacher = expectedColumnHeaders.concat([['Teacher']]);
 
@@ -156,39 +157,9 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 		test('instantiating the element works', function() {
 			assert.equal(list.tagName.toLowerCase(), 'd2l-quick-eval-activities-list');
 		});
-		test('_numberOfActivitiesToShow starts with default value of 20', function() {
-			assert.equal(20, list._numberOfActivitiesToShow);
-		});
-		test('attributes are set correctly', function() {
-			assert.equal(list.href, 'blah');
-			assert.equal(list.token, 't');
-		});
 		test('no alert displayed when healthy', function() {
 			const alert = list.shadowRoot.querySelector('#list-alert');
 			assert.equal(true, alert.hasAttribute('hidden'));
-		});
-		test('when _updateNumberOfActivitiesToShow updated, event "d2l-quick-eval-activities-list-activities-shown-number-updated" fires', function(done) {
-			const expectedNumberOfActivitiesToShow = 50;
-
-			list.addEventListener('d2l-quick-eval-activities-list-activities-shown-number-updated', function(e) {
-				assert.equal(expectedNumberOfActivitiesToShow, e.detail.count);
-				done();
-			});
-
-			list._numberOfActivitiesToShow = expectedNumberOfActivitiesToShow;
-		});
-		test('when data size increased, _numberOfActivitiesToShow matches size and event is triggered', function(done) {
-			const expectedNumberOfActivitiesToShow = 100;
-			const fakeData = new Array(expectedNumberOfActivitiesToShow);
-
-			list.addEventListener('d2l-quick-eval-activities-list-activities-shown-number-updated', function(e) {
-				assert.equal(expectedNumberOfActivitiesToShow, list._numberOfActivitiesToShow);
-				assert.equal(expectedNumberOfActivitiesToShow, e.detail.count);
-				list._data = [];
-				done();
-			});
-
-			list._data = fakeData;
 		});
 		test('_fullListLoading and _loading are set to true before data is loaded, and loading-skeleton is present', () => {
 			var loadingskeleton = list.shadowRoot.querySelector('d2l-quick-eval-skeleton');
@@ -306,36 +277,6 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 					assert.equal(noCriteriaResultsComponent.style.display, 'none');
 					done();
 				});
-			});
-		});
-		test('headers display correctly', function(done) {
-			flush(function() {
-				var headers = list.shadowRoot.querySelectorAll('d2l-th');
-
-				assert.equal(expectedColumnHeaders.length, headers.length);
-
-				for (var i = 0; i < expectedColumnHeaders.length; i++) {
-					expectedColumnHeaders[i].forEach(function(expectedHeader) {
-						assert.include(headers[i].innerHTML, expectedHeader);
-					});
-				}
-				done();
-			});
-		});
-		test('headers include master teacher when toggled on, and is display correctly', function(done) {
-			list.setAttribute('master-teacher', '');
-
-			flush(function() {
-
-				var headers = list.shadowRoot.querySelectorAll('d2l-th');
-				assert.equal(expectedColumnHeadersWithMasterTeacher.length, headers.length);
-
-				for (var i = 0; i < expectedColumnHeadersWithMasterTeacher.length; i++) {
-					expectedColumnHeadersWithMasterTeacher[i].forEach(function(expectedHeader) {
-						assert.include(headers[i].innerHTML, expectedHeader);
-					});
-				}
-				done();
 			});
 		});
 		test.skip('data is imported correctly', (done) => {
@@ -534,52 +475,6 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 				}
 			);
 			assert.equal(expectedDisplayName, displayName);
-		});
-
-		test('firstName begins before lastName, clicking lastName puts it before firstName and clicking firstName puts it before lastName', (done) => {
-
-			var nameHeaders = list._headerColumns[0].headers;
-			assert.equal('firstName', nameHeaders[0].key);
-
-			list._headerColumns[0].headers[0].canSort = true;
-			list._headerColumns[0].headers[1].canSort = true;
-
-			flush(function() {
-				var lastNameHeader = list.shadowRoot.querySelector('#lastName');
-
-				var verifyFirstNameNameFirst = function() {
-					assert.equal('firstName', nameHeaders[0].key);
-					assert.equal(',', nameHeaders[0].suffix);
-					assert.equal('', nameHeaders[1].suffix);
-
-					done();
-				};
-
-				var verifyLastNameFirst = function() {
-					assert.equal('lastName', nameHeaders[0].key);
-					assert.equal(',', nameHeaders[0].suffix);
-					assert.equal('', nameHeaders[1].suffix);
-
-					lastNameHeader.removeEventListener('click', verifyLastNameFirst);
-
-					var firstNameHeader = list.shadowRoot.querySelector('#firstName');
-					firstNameHeader.addEventListener('click', verifyFirstNameNameFirst);
-
-					MockInteractions.tap(firstNameHeader);
-				};
-
-				lastNameHeader.addEventListener('click', verifyLastNameFirst);
-				MockInteractions.tap(lastNameHeader);
-
-			});
-		});
-
-		test('_computeNumberOfActivitiesToShow returns max of data length, and previously shown number of activities', function() {
-			const numberOfActivitiesToShowWhenDataLarger = list._computeNumberOfActivitiesToShow([1, 2, 3, 4], 1);
-			assert.equal(4, numberOfActivitiesToShowWhenDataLarger);
-
-			const numberOfActivitiesToShowWhenPreviousLarger = list._computeNumberOfActivitiesToShow([1], 5);
-			assert.equal(5, numberOfActivitiesToShowWhenPreviousLarger);
 		});
 
 		test.skip('_loadData sets _pageNextHref to empty string when no entities present on entity', function() {

--- a/test/d2l-quick-eval/d2l-quick-eval-activities-list.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activities-list.js
@@ -141,14 +141,6 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			isDraft: false
 		}
 	];
-	var expectedColumnHeaders = [
-		['First Name', 'Last Name'],
-		['Activity Name'],
-		['Course'],
-		['Submission Date'],
-		['Teacher']
-	];
-	var expectedColumnHeadersWithMasterTeacher = expectedColumnHeaders.concat([['Teacher']]);
 
 	suite('d2l-quick-eval-activities-list', function() {
 		setup(function() {

--- a/test/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -1,3 +1,5 @@
+import '@polymer/iron-test-helpers/mock-interactions.js';
+
 suite('d2l-quick-eval-submissions', function() {
 
 	let submissions;
@@ -8,5 +10,134 @@ suite('d2l-quick-eval-submissions', function() {
 
 	test('instantiating the element works', function() {
 		assert.equal(submissions.tagName.toLowerCase(), 'd2l-quick-eval-submissions');
+	});
+
+	test('_numberOfActivitiesToShow starts with default value of 20', function() {
+		assert.equal(20, submissions._numberOfActivitiesToShow);
+	});
+
+	test('attributes are set correctly', function() {
+		assert.equal(submissions.href, 'blah');
+		assert.equal(submissions.token, 't');
+	});
+
+	test('when _updateNumberOfActivitiesToShow updated, event "d2l-quick-eval-activities-list-activities-shown-number-updated" fires', function(done) {
+		const expectedNumberOfActivitiesToShow = 50;
+
+		submissions.addEventListener('d2l-quick-eval-activities-list-activities-shown-number-updated', function(e) {
+			assert.equal(expectedNumberOfActivitiesToShow, e.detail.count);
+			done();
+		});
+
+		submissions._numberOfActivitiesToShow = expectedNumberOfActivitiesToShow;
+	});
+
+	test('when data size increased, _numberOfActivitiesToShow matches size and event is triggered', function(done) {
+		const expectedNumberOfActivitiesToShow = 100;
+		const fakeData = new Array(expectedNumberOfActivitiesToShow);
+
+		submissions.addEventListener('d2l-quick-eval-activities-list-activities-shown-number-updated', function(e) {
+			assert.equal(expectedNumberOfActivitiesToShow, submissions._numberOfActivitiesToShow);
+			assert.equal(expectedNumberOfActivitiesToShow, e.detail.count);
+			submissions._data = [];
+			done();
+		});
+
+		submissions._data = fakeData;
+	});
+
+	test('headers display correctly', function(done) {
+		var expectedColumnHeaders = [
+			['First Name', 'Last Name'],
+			['Activity Name'],
+			['Course'],
+			['Submission Date']
+		];
+
+		flush(function() {
+			var headers = submissions.shadowRoot.querySelector('d2l-quick-eval-activities-list').shadowRoot.querySelectorAll('d2l-th');
+
+			assert.equal(expectedColumnHeaders.length, headers.length);
+
+			for (var i = 0; i < expectedColumnHeaders.length; i++) {
+				expectedColumnHeaders[i].forEach(function(expectedHeader) {
+					assert.include(headers[i].innerHTML, expectedHeader);
+				});
+			}
+			done();
+		});
+	});
+
+	test('headers include master teacher when toggled on, and is display correctly', function(done) {
+		var expectedColumnHeadersWithMasterTeacher = [
+			['First Name', 'Last Name'],
+			['Activity Name'],
+			['Course'],
+			['Submission Date'],
+			['Teacher']
+		];
+		const list = submissions.shadowRoot.querySelector('d2l-quick-eval-activities-list')
+		list.setAttribute('master-teacher', '');
+
+		flush(function() {
+
+			var headers = list.shadowRoot.querySelectorAll('d2l-th');
+			assert.equal(expectedColumnHeadersWithMasterTeacher.length, headers.length);
+
+			for (var i = 0; i < expectedColumnHeadersWithMasterTeacher.length; i++) {
+				expectedColumnHeadersWithMasterTeacher[i].forEach(function(expectedHeader) {
+					assert.include(headers[i].innerHTML, expectedHeader);
+				});
+			}
+			done();
+		});
+	});
+
+	test('firstName begins before lastName, clicking lastName puts it before firstName and clicking firstName puts it before lastName', (done) => {
+
+		var nameHeaders = submissions._headerColumns[0].headers;
+		assert.equal('firstName', nameHeaders[0].key);
+
+		submissions._headerColumns[0].headers[0].canSort = true;
+		submissions._headerColumns[0].headers[1].canSort = true;
+
+		const list = submissions.shadowRoot.querySelector('d2l-quick-eval-activities-list')
+
+		flush(function() {
+			var lastNameHeader = list.shadowRoot.querySelector('#lastName');
+
+			var verifyFirstNameNameFirst = function() {
+				assert.equal('firstName', nameHeaders[0].key);
+				assert.equal(',', nameHeaders[0].suffix);
+				assert.equal('', nameHeaders[1].suffix);
+
+				done();
+			};
+
+			var verifyLastNameFirst = function() {
+				assert.equal('lastName', nameHeaders[0].key);
+				assert.equal(',', nameHeaders[0].suffix);
+				assert.equal('', nameHeaders[1].suffix);
+
+				lastNameHeader.removeEventListener('click', verifyLastNameFirst);
+
+				var firstNameHeader = list.shadowRoot.querySelector('#firstName');
+				firstNameHeader.addEventListener('click', verifyFirstNameNameFirst);
+
+				MockInteractions.tap(firstNameHeader);
+			};
+
+			lastNameHeader.addEventListener('click', verifyLastNameFirst);
+			MockInteractions.tap(lastNameHeader);
+
+		});
+	});
+
+	test('_computeNumberOfActivitiesToShow returns max of data length, and previously shown number of activities', function() {
+		const numberOfActivitiesToShowWhenDataLarger = submissions._computeNumberOfActivitiesToShow([1, 2, 3, 4], 1);
+		assert.equal(4, numberOfActivitiesToShowWhenDataLarger);
+
+		const numberOfActivitiesToShowWhenPreviousLarger = submissions._computeNumberOfActivitiesToShow([1], 5);
+		assert.equal(5, numberOfActivitiesToShowWhenPreviousLarger);
 	});
 });

--- a/test/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -76,7 +76,7 @@ suite('d2l-quick-eval-submissions', function() {
 			['Submission Date'],
 			['Teacher']
 		];
-		const list = submissions.shadowRoot.querySelector('d2l-quick-eval-activities-list')
+		const list = submissions.shadowRoot.querySelector('d2l-quick-eval-activities-list');
 		list.setAttribute('master-teacher', '');
 
 		flush(function() {
@@ -101,7 +101,7 @@ suite('d2l-quick-eval-submissions', function() {
 		submissions._headerColumns[0].headers[0].canSort = true;
 		submissions._headerColumns[0].headers[1].canSort = true;
 
-		const list = submissions.shadowRoot.querySelector('d2l-quick-eval-activities-list')
+		const list = submissions.shadowRoot.querySelector('d2l-quick-eval-activities-list');
 
 		flush(function() {
 			var lastNameHeader = list.shadowRoot.querySelector('#lastName');

--- a/test/d2l-quick-eval/d2l-quick-eval.html
+++ b/test/d2l-quick-eval/d2l-quick-eval.html
@@ -30,7 +30,7 @@
 		<script type="module">
 			import '@polymer/iron-test-helpers/mock-interactions.js';
 
-			var quickEval, filter, filterDropdown, list, search, toggle;
+			var quickEval, filter, filterDropdown, list, search, toggle, submissions;
 
 			var expectedFirstCellData = 'Special User Name';
 			var expectedFilters = ['Activity Name', 'Course', 'Date'];
@@ -102,7 +102,8 @@
 					quickEval = fixture('basic');
 					filter = quickEval.shadowRoot.querySelector('d2l-hm-filter');
 					filterDropdown = filter.shadowRoot.querySelector('d2l-filter-dropdown');
-					list = quickEval.shadowRoot.querySelector('d2l-quick-eval-submissions').shadowRoot.querySelector('d2l-quick-eval-activities-list');
+					submissions = quickEval.shadowRoot.querySelector('d2l-quick-eval-submissions');
+					list = submissions.shadowRoot.querySelector('d2l-quick-eval-activities-list');
 					search = quickEval.shadowRoot.querySelector('d2l-hm-search');
 					toggle = quickEval.shadowRoot.querySelector('d2l-quick-eval-view-toggle');
 				});
@@ -218,7 +219,7 @@
 
 					quickEval.addEventListener('d2l-hm-filter-filters-updated', function(e) {
 						var dropdownButton = filterDropdown.shadowRoot.querySelector('d2l-dropdown-button-subtle').shadowRoot.querySelector('d2l-button-subtle');
-						assert.deepEqual(e.detail.filteredActivities, list.entity);
+						assert.deepEqual(e.detail.filteredActivities, submissions.entity);
 						if (add === 1) {
 							assert.equal(dropdownButton.text, 'Filter: 1 Filter');
 							assert.equal(e.detail.totalSelectedFilters, 1);
@@ -238,7 +239,7 @@
 
 					quickEval.addEventListener('d2l-hm-filter-filters-updated', function(e) {
 						var dropdownButton = filterDropdown.shadowRoot.querySelector('d2l-dropdown-button-subtle').shadowRoot.querySelector('d2l-button-subtle');
-						assert.deepEqual(e.detail.filteredActivities, list.entity);
+						assert.deepEqual(e.detail.filteredActivities, submissions.entity);
 						if (add === 2) {
 							assert.equal(dropdownButton.text, 'Filter: 1 Filter');
 							assert.equal(e.detail.totalSelectedFilters, 1);
@@ -304,7 +305,7 @@
 					quickEval.addEventListener('d2l-hm-search-results-loaded', function(e) {
 						assert.equal(list.searchApplied, true);
 						assert.equal(quickEval._moreSearchResults, true);
-						assert.deepEqual(e.detail.results, list.entity);
+						assert.deepEqual(e.detail.results, submissions.entity);
 						done();
 					});
 

--- a/test/d2l-quick-eval/d2l-quick-eval.html
+++ b/test/d2l-quick-eval/d2l-quick-eval.html
@@ -315,7 +315,7 @@
 				});
 				test('clearing search causes event to fire', function(done) {
 					quickEval.addEventListener('d2l-hm-search-results-loaded', function(e) {
-						assert.deepEqual(e.detail.results, list.entity);
+						assert.deepEqual(e.detail.results, submissions.entity);
 						done();
 					});
 


### PR DESCRIPTION
Builds off of https://github.com/BrightspaceHypermediaComponents/activities/pull/204

In this PR I made `d2l-quick-eval-activities-list.js` no longer extend `D2LQuickEvalSirenHelperBehavior` and `D2LHMSortBehaviour`, effectively removing all the controller code from `d2l-quick-eval-activities-list.js`. There's still some weirdness in the interface where `list` makes decisions, but I'm pretty happy with the current state of `list` now.

* Remove siren/sort behaviours from `list`
* Move `_handleSorts` and `_sortClickHandler` to the controller
  * Now we have to emit an event, `d2l-quick-eval-submissions-table-sort-requested`, when the sort button is pressed and the controller handles it
  * This also means that the source of truth for `_headerColumns` needs to be in the controller
* Remove list entity stuff from `quick-eval` (Josh this was your comment on the previous PR)
* `_determineIfActivityIsDraft` was a holdout from Carol's refactor months ago. Just moving that into our QE siren behaviour.

TODO:

* [x] fix `_numberOfActivitiesToShow `
* [x] Update `quick-eval` and `d2l-quick-eval-activities-list` tests
