### PR TITLE
Delete filterHref in preparation for adding filter behaviour

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-submissions-table.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions-table.js
@@ -282,10 +282,6 @@ class D2LQuickEvalSubmissionsTable extends QuickEvalLogging(QuickEvalLocalize(Po
 				type: Boolean,
 				value: true
 			},
-			_filterHref: {
-				type: String,
-				value: ''
-			},
 			_pageNextHref: {
 				type: String,
 				value: ''

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -291,7 +291,6 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 			}.bind(this)));
 		}.bind(this));
 
-		this.list._filterHref = this._getFilterHref(entity);
 		this.list._pageNextHref = this._getPageNextHref(entity);
 
 		const result = await Promise.all(promises);


### PR DESCRIPTION
Doing some small cleanup before I add the filter/search behaviour.

In this case, deleting some cruft in the-element-formerly-known-as-list (let's just call it `table` now).

`table` used to care about `filterHref` back when it made decisions but it's no longer used now.