### PR TITLE
Move health into controller

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-submissions-table.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions-table.js
@@ -317,18 +317,6 @@ class D2LQuickEvalSubmissionsTable extends QuickEvalLogging(QuickEvalLocalize(Po
 		return !dataLength && !isLoading && isHealthy && (filterApplied || searchApplied);
 	}
 
-	_clearAlerts() {
-		this.set('_health', { isHealthy: true, errorMessage: '' });
-	}
-
-	_handleLoadMoreFailure() {
-		this.set('_health', { isHealthy: false, errorMessage: 'failedToLoadMore' });
-	}
-
-	_handleFullLoadFailure() {
-		this.set('_health', { isHealthy: false, errorMessage: 'failedToLoadData' });
-	}
-
 	_localizeSortText(columnName) {
 		const localizedColumnName = this.localize(columnName);
 		return this.localize('sortBy', 'columnName', localizedColumnName);

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -95,6 +95,7 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 				_loading="[[_loading]]"
 				_full-list-loading="[[_fullListLoading]]"
 				show-load-more="[[_showLoadMore]]"
+				_health="[[_health]]"
 				on-d2l-quick-eval-submissions-table-load-more="_loadMore"
 				on-d2l-quick-eval-submissions-table-sort-requested="_handleSortRequested">
 			</d2l-quick-eval-submissions-table>
@@ -198,6 +199,13 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 			_showLoadMore: {
 				type: Boolean,
 				computed: '_computeShowLoadMore(_pageNextHref, _loading)'
+			},
+			_health: {
+				type: Object,
+				value: {
+					isHealthy: true,
+					errorMessage: ''
+				}
 			}
 		};
 	}
@@ -228,11 +236,10 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 				this._data = [];
 				this._pageNextHref = undefined;
 			}
-			this.list._clearAlerts();
-
+			this._clearAlerts();
 		} catch (e) {
 			this._logError(e, {developerMessage: 'Unable to load activities from entity.'});
-			this.list._handleFullLoadFailure();
+			this._handleFullLoadFailure();
 			return Promise.reject(e);
 		} finally {
 			this._fullListLoading = false;
@@ -269,11 +276,11 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 						}
 					}
 				}.bind(this))
-				.then(this.list._clearAlerts.bind(this.list))
+				.then(this._clearAlerts.bind(this))
 				.catch(function(e) {
 					this._logError(e, {developerMessage: 'Unable to load more.'});
 					this._loading = false;
-					this.list._handleLoadMoreFailure();
+					this._handleLoadMoreFailure();
 				}.bind(this));
 		}
 	}
@@ -477,12 +484,24 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 		return _pageNextHref && !_loading;
 	}
 
+	_clearAlerts() {
+		this.set('_health', { isHealthy: true, errorMessage: '' });
+	}
+
+	_handleLoadMoreFailure() {
+		this.set('_health', { isHealthy: false, errorMessage: 'failedToLoadMore' });
+	}
+
+	_handleFullLoadFailure() {
+		this.set('_health', { isHealthy: false, errorMessage: 'failedToLoadData' });
+	}
+
 	ready() {
 		super.ready();
 		this.addEventListener('d2l-siren-entity-error', function() {
 			this._fullListLoading = false;
 			this._loading = false;
-			this.list._handleFullLoadFailure();
+			this._handleFullLoadFailure();
 		}.bind(this));
 	}
 }

--- a/test/d2l-quick-eval/d2l-quick-eval-submissions-table.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-submissions-table.js
@@ -337,13 +337,13 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			});
 		});
 		test('when handling load more failure, alert should pop up and alert should hide when alerts cleared', (done) => {
-			list._handleLoadMoreFailure();
+			list._health = { isHealthy: false, errorMessage: 'failedToLoadMore' };
 
 			flush(function() {
 				var alert = list.shadowRoot.querySelector('#list-alert');
 				assert.equal(false, alert.hasAttribute('hidden'));
 
-				list._clearAlerts();
+				list._health = { isHealthy: true, errorMessage: '' };
 				flush(function() {
 					assert.equal(true, alert.hasAttribute('hidden'));
 					done();
@@ -352,13 +352,13 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			});
 		});
 		test('when handling initial load failure, alert should pop up and alert should hide when alerts cleared', (done) => {
-			list._handleFullLoadFailure();
+			list._health = { isHealthy: false, errorMessage: 'failedToLoadData' };
 
 			flush(function() {
 				var alert = list.shadowRoot.querySelector('#list-alert');
 				assert.equal(false, alert.hasAttribute('hidden'));
 
-				list._clearAlerts();
+				list._health = { isHealthy: true, errorMessage: '' };
 				flush(function() {
 					assert.equal(true, alert.hasAttribute('hidden'));
 					done();


### PR DESCRIPTION
Moving more decision making to the controller part 3. `table` should just be told what the health is, rather than keep track of it itself.