### PR TITLE
Refactor loading to prepare for behaviours

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-submissions-table.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions-table.js
@@ -132,7 +132,7 @@ class D2LQuickEvalSubmissionsTable extends QuickEvalLogging(QuickEvalLocalize(Po
 				}
 			</style>
 			<d2l-offscreen id="d2l-quick-eval-submissions-table-table-summary">[[localize('tableTitle')]]</d2l-offscreen>
-			<d2l-table class="d2l-quick-eval-table" type="light" hidden$="[[_fullListLoading]]" aria-describedby$="d2l-quick-eval-submissions-table-table-summary" aria-colcount$="[[_headerColumns.length]]" aria-rowcount$="[[_data.length]]">
+			<d2l-table class="d2l-quick-eval-table" type="light" hidden$="[[showLoadingSkeleton]]" aria-describedby$="d2l-quick-eval-submissions-table-table-summary" aria-colcount$="[[_headerColumns.length]]" aria-rowcount$="[[_data.length]]">
 				<d2l-thead>
 					<d2l-tr>
 						<dom-repeat items="[[_headerColumns]]" as="headerColumn">
@@ -214,9 +214,9 @@ class D2LQuickEvalSubmissionsTable extends QuickEvalLogging(QuickEvalLocalize(Po
 			<d2l-alert id="list-alert" type="critical" hidden$="[[_health.isHealthy]]">
 				[[localize(_health.errorMessage)]]
 			</d2l-alert>
-			<d2l-offscreen role="alert" aria-live="aggressive" hidden$="[[!_loading]]">[[localize('loading')]]</d2l-offscreen>
-			<d2l-quick-eval-skeleton hidden$="[[!_fullListLoading]]"></d2l-quick-eval-skeleton>
-	     	<d2l-loading-spinner size="80" hidden$="[[!_isLoadingMore(_fullListLoading,_loading)]]"></d2l-loading-spinner>
+			<d2l-offscreen role="alert" aria-live="aggressive" hidden$="[[!isLoading]]">[[localize('loading')]]</d2l-offscreen>
+			<d2l-quick-eval-skeleton hidden$="[[!showLoadingSkeleton]]"></d2l-quick-eval-skeleton>
+	     	<d2l-loading-spinner size="80" hidden$="[[!showLoadingSpinner]]"></d2l-loading-spinner>
 
 			<template is="dom-if" if="[[showLoadMore]]">
 				<div class="d2l-quick-eval-submissions-table-load-more-container">
@@ -259,7 +259,7 @@ class D2LQuickEvalSubmissionsTable extends QuickEvalLogging(QuickEvalLocalize(Po
 				type: Array,
 				value: [ ]
 			},
-			_fullListLoading: {
+			showLoadingSkeleton: {
 				type: Boolean,
 				value: true
 			},
@@ -270,9 +270,9 @@ class D2LQuickEvalSubmissionsTable extends QuickEvalLogging(QuickEvalLocalize(Po
 					errorMessage: ''
 				}
 			},
-			_loading: {
+			showLoadingSpinner: {
 				type: Boolean,
-				value: true
+				value: false
 			},
 			showLoadMore: {
 				type: Boolean,
@@ -286,6 +286,10 @@ class D2LQuickEvalSubmissionsTable extends QuickEvalLogging(QuickEvalLocalize(Po
 				type: Boolean,
 				value: false
 			},
+			isLoading: {
+				type: Boolean,
+				computed: '_computeIsLoading(showLoadingSpinner, showLoadingSkeleton)'
+			}
 		};
 	}
 	static get observers() {
@@ -294,8 +298,8 @@ class D2LQuickEvalSubmissionsTable extends QuickEvalLogging(QuickEvalLocalize(Po
 		];
 	}
 
-	_isLoadingMore(fullListLoading, isLoading) {
-		return !fullListLoading && isLoading;
+	_computeIsLoading(showLoadingSpinner, showLoadingSkeleton) {
+		return showLoadingSpinner || showLoadingSkeleton;
 	}
 
 	_handleNameSwap(entry) {

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -272,7 +272,7 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 	}
 
 	_loadMore() {
-		if (this._pageNextHref) {
+		if (this._pageNextHref && !this._loadingMore) {
 			this._loadingMore = true;
 			this._followHref(this._pageNextHref)
 				.then(async function(u) {
@@ -535,6 +535,7 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 		super.ready();
 		this.addEventListener('d2l-siren-entity-error', function() {
 			this._loading = false;
+			this._loadingMore = false;
 			this._handleFullLoadFailure();
 		}.bind(this));
 	}

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -92,8 +92,8 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 				master-teacher="[[masterTeacher]]"
 				_data="[[_data]]"
 				_header-columns="[[_headerColumns]]"
-				_loading="[[_loading]]"
-				_full-list-loading="[[_fullListLoading]]"
+				show-loading-spinner="[[_showLoadingSpinner]]"
+				show-loading-skeleton="[[_showLoadingSkeleton]]"
 				show-load-more="[[_showLoadMore]]"
 				_health="[[_health]]"
 				show-no-submissions="[[_showNoSubmissions]]"
@@ -187,20 +187,12 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 				type: Boolean,
 				value: false
 			},
-			_loading: {
-				type: Boolean,
-				value: true
-			},
-			_fullListLoading: {
-				type: Boolean,
-				value: true
-			},
 			_pageNextHref: {
 				type: String,
 			},
 			_showLoadMore: {
 				type: Boolean,
-				computed: '_computeShowLoadMore(_pageNextHref, _loading)'
+				computed: '_computeShowLoadMore(_pageNextHref, _showLoadingSpinner, _showLoadingSkeleton)'
 			},
 			_health: {
 				type: Object,
@@ -211,11 +203,11 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 			},
 			_showNoSubmissions: {
 				type: Boolean,
-				computed: '_computeShowNoSubmissions(_data, _loading, _health, _filterApplied, _searchApplied)'
+				computed: '_computeShowNoSubmissions(_data, _loading, _loadingMore, _health, _filterApplied, _searchApplied)'
 			},
 			_showNoCriteria: {
 				type: Boolean,
-				computed: '_computeShowNoCriteria(_data, _loading, _health, _filterApplied, _searchApplied)'
+				computed: '_computeShowNoCriteria(_data, _loading, _loadingMore, _health, _filterApplied, _searchApplied)'
 			},
 			_filterApplied: {
 				type: Boolean,
@@ -228,6 +220,22 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 			masterTeacher: {
 				type: Boolean,
 				value: false
+			},
+			_loading: {
+				type: Boolean,
+				value: true
+			},
+			_loadingMore: {
+				type: Boolean,
+				value: false
+			},
+			_showLoadingSpinner: {
+				type: Boolean,
+				computed: '_computeShowLoadingSpinner(_loadingMore)'
+			},
+			_showLoadingSkeleton: {
+				type: Boolean,
+				computed: '_computeShowLoadingSkeleton(_loading)'
 			}
 		};
 	}
@@ -244,7 +252,6 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 			return Promise.resolve();
 		}
 		this._loading = true;
-		this._fullListLoading = true;
 
 		try {
 			if (entity.entities) {
@@ -260,14 +267,13 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 			this._handleFullLoadFailure();
 			return Promise.reject(e);
 		} finally {
-			this._fullListLoading = false;
 			this._loading = false;
 		}
 	}
 
 	_loadMore() {
-		if (this._pageNextHref && !this._loading) {
-			this._loading = true;
+		if (this._pageNextHref) {
+			this._loadingMore = true;
 			this._followHref(this._pageNextHref)
 				.then(async function(u) {
 					if (u && u.entity) {
@@ -284,7 +290,7 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 						// Unable to load more activities from entity.
 							throw e;
 						} finally {
-							this._loading = false;
+							this._loadingMore = false;
 							window.requestAnimationFrame(function() {
 								const newElementToFocus = D2L.Dom.Focus.getNextFocusable(lastFocusableTableElement, false);
 								if (newElementToFocus) {
@@ -297,7 +303,7 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 				.then(this._clearAlerts.bind(this))
 				.catch(function(e) {
 					this._logError(e, {developerMessage: 'Unable to load more.'});
-					this._loading = false;
+					this._loadingMore = false;
 					this._handleLoadMoreFailure();
 				}.bind(this));
 		}
@@ -391,7 +397,6 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 
 		if (result) {
 			this._loading = true;
-			this._fullListLoading = true;
 			return result.then(sortedCollection => {
 				this.entity = sortedCollection;
 			});
@@ -407,7 +412,6 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 
 	_filtersUpdating() {
 		this._loading = true;
-		this._fullListLoading = true;
 		this._clearErrors();
 	}
 
@@ -423,7 +427,6 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 	_filterError(e) {
 		this._logError(e.detail.error, { developerMessage: 'Failed to retrieve filter results' });
 		this._loading = false;
-		this._fullListLoading = false;
 		this._showFilterError = true;
 	}
 
@@ -457,7 +460,6 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 
 	_searchResultsLoading() {
 		this._loading = true;
-		this._fullListLoading = true;
 		this._clearErrors();
 	}
 
@@ -477,7 +479,6 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 	_searchError(e) {
 		this._logError(e.detail.error, { developerMessage: 'Failed to retrieve search results.' });
 		this._loading = false;
-		this._fullListLoading = false;
 		this._showSearchError = true;
 	}
 
@@ -498,8 +499,8 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 		return this._getAction(entity, 'search');
 	}
 
-	_computeShowLoadMore(_pageNextHref, _loading) {
-		return _pageNextHref && !_loading;
+	_computeShowLoadMore(_pageNextHref, _showLoadingSpinner, _showLoadingSkeleton) {
+		return _pageNextHref && !_showLoadingSpinner && !_showLoadingSkeleton;
 	}
 
 	_clearAlerts() {
@@ -514,18 +515,25 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 		this.set('_health', { isHealthy: false, errorMessage: 'failedToLoadData' });
 	}
 
-	_computeShowNoSubmissions(_data, _loading, _health, _filterApplied, _searchApplied) {
-		return !_data.length && !_loading && _health.isHealthy && !(_filterApplied || _searchApplied);
+	_computeShowNoSubmissions(_data, _loading, _loadingMore, _health, _filterApplied, _searchApplied) {
+		return !_data.length && !_loading && !_loadingMore && _health.isHealthy && !(_filterApplied || _searchApplied);
 	}
 
-	_computeShowNoCriteria(_data, _loading, _health, _filterApplied, _searchApplied) {
-		return !_data.length && !_loading && _health.isHealthy && (_filterApplied || _searchApplied);
+	_computeShowNoCriteria(_data, _loading, _loadingMore, _health, _filterApplied, _searchApplied) {
+		return !_data.length && !_loading && !_loadingMore && _health.isHealthy && (_filterApplied || _searchApplied);
+	}
+
+	_computeShowLoadingSpinner(_loadingMore) {
+		return _loadingMore;
+	}
+
+	_computeShowLoadingSkeleton(_loading) {
+		return _loading;
 	}
 
 	ready() {
 		super.ready();
 		this.addEventListener('d2l-siren-entity-error', function() {
-			this._fullListLoading = false;
 			this._loading = false;
 			this._handleFullLoadFailure();
 		}.bind(this));

--- a/test/d2l-quick-eval/d2l-quick-eval-submissions-table.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-submissions-table.js
@@ -153,11 +153,11 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			const alert = list.shadowRoot.querySelector('#list-alert');
 			assert.equal(true, alert.hasAttribute('hidden'));
 		});
-		test('_fullListLoading and _loading are set to true before data is loaded, and loading-skeleton is present', () => {
+		test('showLoadingSkeleton is set to true, showLoadingSpinner is set to false before data is loaded, and loading-skeleton is present', () => {
 			var loadingskeleton = list.shadowRoot.querySelector('d2l-quick-eval-skeleton');
 			assert.equal(loadingskeleton.hidden, false);
-			assert.equal(list._fullListLoading, true);
-			assert.equal(list._loading, true);
+			assert.isFalse(list.showLoadingSpinner);
+			assert.isTrue(list.showLoadingSkeleton);
 		});
 		test.skip('_fullListLoading and _loading is set to false after data is loaded and the loading skeleton is hidden', (done) => {
 			var loadingskeleton = list.shadowRoot.querySelector('d2l-quick-eval-skeleton');
@@ -202,7 +202,7 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			var noCriteriaResultsComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-criteria-results');
 			assert.equal(noSubmissionComponent, null);
 			assert.equal(noCriteriaResultsComponent, null);
-			assert.equal(list._loading, true);
+			assert.isTrue(list.showLoadingSkeleton);
 		});
 		test.skip('if there is no data in the list, d2l-quick-eval-no-submissions-image is shown', (done) => {
 			loadPromise('data/emptyUnassessedActivities.json').then(function() {


### PR DESCRIPTION
This PR originally came from this comment (I was hoping we didn't have to do it but it makes sense to do it now): https://github.com/BrightspaceHypermediaComponents/activities/pull/218#discussion_r291725739

I got halfway through adding the filter/search behaviours but I encountered a problem around loading, specifically the default values. The default value for `_loading` is `true`, we assume the initial state will be to fetch the data. However the initial value for `filtersLoading` and `searchLoading` is `false`, because at first we are neither filtering or searching. But since they share a single loading state, `_loading`, there's no good way to differentiate "on the first load" and while it could be bandaided with more loading booleans, it felt like we were heading down the wrong design path.

This PR includes a bit of cleanup in the table: I changed the variables names to denote their exact purpose (`showLoadingSkeleton`, `showLoadingSpinner`). I also made the loading variables distinct (so we aren't setting both of them at the same time all the time). Lastly, I left some scaffolding for my behaviour change (the compute methods).

**Before:**

* `_loading` - denotes if the app is currently waiting for an http request to return
* `_fullListLoading` - exactly the same as `_loading` except in the case where we load more, this wasn't used.

Essentially the absence of `_fullListLoading` was used to determine if we should display the spinner or the skeleton and I found it a bit confusing that we had 2 variables that do pretty much the exact same thing.

**This PR:**

* `_loading` - denotes if the app is currently loading via initial load, search, sort, or filtering. Controls `showLoadingSkeleton`.
* `_loadingMore` - denotes if the app is currently loading via load more. Controls `showLoadingSpinner`.

Note that there is no case where these will both be `true` anymore (since we only allow 1 request at the same time).

**In the future:**

Each behaviour (sort, filter, search) will maintain it's own loading state. These will be coalesced in the controller under `showLoadingSkeleton`. This will allow us to write behaviours more naturally, but still provide a convenient interface to work with.

As usual, happy to swing by your desk to give a better walkthrough