### PR TITLE
DE34932 - Treat plus as space

### DIFF
--- a/components/d2l-quick-eval/compatability/ie11shims.js
+++ b/components/d2l-quick-eval/compatability/ie11shims.js
@@ -3,6 +3,15 @@ All functions in this file should work across all browsers.
 Initially intended for enabling compatability with IE11, but applies to any browser missing some functionality.
 */
 
+const _urlDecodePlusAsSpace = (str) => {
+	if (!str) {
+		return str;
+	}
+	const strWithPlusAsSpace = str.replace('+', ' ');
+	const strDecoded = window.decodeURIComponent(strWithPlusAsSpace);
+	return strDecoded;
+};
+
 const StringEndsWith = (str, search) => {
 	if (typeof str !== 'string' || typeof search !== 'string') {
 		return false;
@@ -39,10 +48,10 @@ const GetQueryStringParams = (queryString) => {
 
 		validQueryStrings.forEach(function(validQueryString) {
 			const keyValuePair = validQueryString.split('=');
-			const decodedKey = window.decodeURIComponent(keyValuePair[0]);
+			const decodedKey = _urlDecodePlusAsSpace(keyValuePair[0]);
 
 			if (!(decodedKey in query)) {
-				const decodedValue = window.decodeURIComponent(keyValuePair[1]);
+				const decodedValue = _urlDecodePlusAsSpace(keyValuePair[1]);
 				query[decodedKey] = decodedValue;
 			}
 		});

--- a/test/d2l-quick-eval/compatability/ie11shims.js
+++ b/test/d2l-quick-eval/compatability/ie11shims.js
@@ -68,7 +68,9 @@ suite('GetQueryStringParam', () => {
 		{ url: 'https://www.d2l.com/?x=1&y=2', name: 'x', expectedResult: '1' },
 		{ url: 'https://www.d2l.com/?x=1&y=2', name: 'y', expectedResult: '2' },
 		{ url: 'https://www.d2l.com/?x=%3Fencoded%3Dstring%25%26here&y=2', name: 'x', expectedResult: '?encoded=string%&here' },
-		{ url: 'https://www.d2l.com/?%3F%3F=1', name: '??', expectedResult: '1' }
+		{ url: 'https://www.d2l.com/?%3F%3F=1', name: '??', expectedResult: '1' },
+		{ url: 'https://www.d2l.com/?emptyValue=', name: 'emptyValue', expectedResult: '' },
+		{ url: 'https://www.d2l.com/?key+with%2Bplus=value+with%2Bplus', name: 'key with+plus', expectedResult: 'value with+plus' }
 	];
 
 	testCases.forEach(function(testCase) {


### PR DESCRIPTION
> I believe this should be correct. Query params should always be encoded. So if we see a + symbol we know it should be a space. To actually represent a plus symbol it should be represented as %2B.
>We receive a + symbol instead of %20 is because of http://search.dev.d2l/source/xref/Lms/lp/framework/core/D2L/LP/Text/Html/UrlUtility.cs#125


Related:
* https://github.com/BrightspaceHypermediaComponents/common/pull/27

We should fix the polymer behavior at some point instead of maintaining these hacks in three places. Same fix follows here as the related PRs above