### PR TITLE
Cbusman/pass url to activities controller

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval.js
+++ b/components/d2l-quick-eval/d2l-quick-eval.js
@@ -39,8 +39,8 @@ class D2LQuickEval extends PolymerElement {
 				<h1 class="d2l-quick-eval-header" hidden$="[[activitiesViewEnabled]]"">[[headerText]]</h1>
 			</template>
 			<d2l-quick-eval-view-toggle current-selected="submissions" hidden$="[[!activitiesViewEnabled]]" on-d2l-quick-eval-view-toggle-changed="_toggleView"></d2l-quick-eval-view-toggle>
-			<d2l-quick-eval-submissions href="[[href]]" token="[[token]]" logging-endpoint="[[loggingEndpoint]]" hidden$="[[_showActivitiesView]]" master-teacher="[[masterTeacher]]" search-enabled="[[searchEnabled]]"></d2l-quick-eval-submissions>
-			<d2l-quick-eval-activities href="[[href]]" token="[[token]]" logging-endpoint="[[loggingEndpoint]]" hidden$="[[!_showActivitiesView]]"></d2l-quick-eval-activities>
+			<d2l-quick-eval-submissions href="[[_submissionsHref(submissionsHref, href)]]" token="[[token]]" logging-endpoint="[[loggingEndpoint]]" hidden$="[[_showActivitiesView]]" master-teacher="[[masterTeacher]]" search-enabled="[[searchEnabled]]"></d2l-quick-eval-submissions>
+			<d2l-quick-eval-activities href="[[activitiesHref]]" token="[[token]]" logging-endpoint="[[loggingEndpoint]]" hidden$="[[!_showActivitiesView]]"></d2l-quick-eval-activities>
 		`;
 	}
 
@@ -74,6 +74,12 @@ class D2LQuickEval extends PolymerElement {
 			href: {
 				type: String
 			},
+			submissionsHref: {
+				type: String
+			},
+			activitiesHref: {
+				type: String
+			},
 			token: {
 				type: Object,
 			}
@@ -88,6 +94,11 @@ class D2LQuickEval extends PolymerElement {
 		} else {
 			this._showActivitiesView = true;
 		}
+	}
+
+	// Temporary until the LMS has been updated to use the new property
+	_submissionsHref() {
+		return this.submissionsHref || this.href;
 	}
 }
 

--- a/demo/d2l-quick-eval/d2l-quick-eval.html
+++ b/demo/d2l-quick-eval/d2l-quick-eval.html
@@ -62,7 +62,7 @@
 				<h4>Note: Load more button is expected to fail on last click, but should resolve itself when clicking it again</h4>
 				<hr/><br/>
 				<template strip-whitespace>
-					<d2l-quick-eval header-text="Quick Eval" master-teacher search-enabled href="pages/?sort=bydate-a" token="whatever" activities-view-enabled></d2l-quick-eval>
+					<d2l-quick-eval header-text="Quick Eval" master-teacher search-enabled activities-href="pages/?sort=bydate-a" submissions-href="pages/?sort=bydate-a" token="whatever" activities-view-enabled></d2l-quick-eval>
 				</template>
 			</demo-snippet>
 

--- a/test/d2l-quick-eval/d2l-quick-eval.html
+++ b/test/d2l-quick-eval/d2l-quick-eval.html
@@ -122,10 +122,10 @@
 				test('_numberOfActivitiesToShow starts with default value of 20', function() {
 					assert.equal(20, quickEval._numberOfActivitiesToShow);
 				});
-				[ 
+				[
 					{ hrefKey: 'href', child: 'd2l-quick-eval-submissions', expected: 'newValue' },
 					{ hrefKey: 'submissionsHref', child: 'd2l-quick-eval-submissions', expected: 'newValue'},
-					{ hrefKey: 'activitiesHref', child: 'd2l-quick-eval-activities', expected: 'newValue'} 
+					{ hrefKey: 'activitiesHref', child: 'd2l-quick-eval-activities', expected: 'newValue'}
 				].forEach(function(testCase) {
 					test(`Setting ${testCase.hrefKey} gets passed to the href for ${testCase.child}`, function() {
 						quickEval.href = '';

--- a/test/d2l-quick-eval/d2l-quick-eval.html
+++ b/test/d2l-quick-eval/d2l-quick-eval.html
@@ -17,13 +17,21 @@
 	<body>
 		<test-fixture id="basic">
 			<template strip-whitespace>
-				<d2l-quick-eval href="data/unassessedActivities.json" token="whatever"></d2l-quick-eval>
+				<d2l-quick-eval 
+					href="data/unassessedActivities.json" 
+					submission-href="data/unassessedActivities.json" 
+					activities-href="data/unassessedActivitiesCollection.json" 
+					token="whatever"></d2l-quick-eval>
 			</template>
 		</test-fixture>
 
 		<test-fixture id="masterTeacher">
 			<template strip-whitespace>
-				<d2l-quick-eval href="data/unassessedActivities.json" token="whatever" master-teacher></d2l-quick-eval>
+				<d2l-quick-eval 
+					href="data/unassessedActivities.json" 
+					submission-href="data/unassessedActivities.json" 
+					token="whatever" 
+					master-teacher></d2l-quick-eval>
 			</template>
 		</test-fixture>
 
@@ -113,6 +121,21 @@
 				});
 				test('_numberOfActivitiesToShow starts with default value of 20', function() {
 					assert.equal(20, quickEval._numberOfActivitiesToShow);
+				});
+				[ 
+					{ hrefKey: 'href', child: 'd2l-quick-eval-submissions', expected: 'newValue' },
+					{ hrefKey: 'submissionsHref', child: 'd2l-quick-eval-submissions', expected: 'newValue'},
+					{ hrefKey: 'activitiesHref', child: 'd2l-quick-eval-activities', expected: 'newValue'} 
+				].forEach(function(testCase) {
+					test(`Setting ${testCase.hrefKey} gets passed to the href for ${testCase.child}`, function() {
+						quickEval.href = '';
+						quickEval.submissionsHref = '';
+						quickEval.activitiesHref = '';
+
+						quickEval[testCase.hrefKey] = testCase.expected;
+						const component = quickEval.shadowRoot.querySelector(testCase.child);
+						assert.equal(testCase.expected, component.href);
+					});
 				});
 				test('when event "d2l-quick-eval-submissions-table-activities-shown-number-updated" fired, result-size attribute updated on d2l-hm-filter and d2l-hm-search', function(done) {
 					const expectedResultSize = 333;


### PR DESCRIPTION
Leaving `href` and the new `submissions-href` properties both in quick eval as the LMS is passing the url into the `href` property currently.

Next steps are to update BSI version, push new BSI version to LMS and update the quick eval renderer to use the new `submissions-href` attribute (and `activities-href`), then return here to remove the old href property and helper function that will no longer be needed.