### PR TITLE
Fix for US108137: Setting initial filterError value to null

### DIFF
--- a/components/d2l-quick-eval/behaviors/d2l-hm-filter-behavior.js
+++ b/components/d2l-quick-eval/behaviors/d2l-hm-filter-behavior.js
@@ -21,7 +21,8 @@ D2L.PolymerBehaviors.QuickEval.D2LHMFilterBehaviourImpl = {
 			value: false
 		},
 		filterError: {
-			type: Object
+			type: Object,
+			value: null
 		},
 		filtersLoading: {
 			type: Boolean,


### PR DESCRIPTION
A bug was introduced by #226 in regression, where an error message appears while loading. 
The reason this kept happening was that in #226, the `filterError` property type was changed from a boolean to an object, without a default value. The default value `filterError` is then initialized to undefined. This then breaks the view in `components/d2l-quick-eval/d2l-quick-eval-submissions.js` line 73, where `hidden$="[[!filterError]]"` evaluates to `false` when `filterError` is `undefined`  but `true` when `filterError` is `null`. The most likely explanation of this is that Polymer is known to misbehave when a property is `undefined` (see https://github.com/Polymer/polymer/issues/1813). There are a number of fixes for this (e.g. changing the template, changing `filterError` back to a boolean, adding more testing). But none of these fixes are better at preventing this bug from occurring again, but add extra complexity and I thought might delay the team's progress. Therefore I chose the least intrusive solution. This fix simply initializes the `filterError` property to null, which then gets evaluated to a "falsy" value, which makes `hidden$="[[!filterError]]"` evaluates to true, which is the expected behaviour. However, I think moving forward we should be wary of:
1. The initial value of any properties we define (i.e don't let properties initialize to `undefined`)
2. How we bind properties (i.e don't bind properties that could evaluate to `undefined`).

Also, I don't know of an easy way for us to test for binding bugs like this one, other than comparing Dom nodes (and even if we do so, the alert only appears briefly, so there might be a chance that we miss that in testing as well). Moreover, this bug seemed to be missed in our existing tests.