### PR TITLE
Separating unread items into its own component.

### DIFF
--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-items.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-items.js
@@ -23,6 +23,9 @@ class D2LQuickEvalActivityCardItems extends mixinBehaviors([D2L.PolymerBehaviors
 					align-items: center;
 					justify-content: space-around;
 				}
+				::slotted(*:first-child) {
+					border-left-width: 1px;
+				}
 			</style>
 			<div class="d2l-quick-eval-activity-card-items-container">
 				<slot></slot>

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-unread-submissions.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-unread-submissions.js
@@ -1,0 +1,41 @@
+import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
+import {QuickEvalLocalize} from '../QuickEvalLocalize.js';
+import 'd2l-tooltip/d2l-tooltip.js';
+
+class D2LQuickEvalActivityCardUnreadSubmissions extends QuickEvalLocalize(PolymerElement) {
+	static get is() { return 'd2l-quick-eval-activity-card-unread-submissions'; }
+	static get template() {
+		return html`
+			<style>
+				#d2l-quick-eval-activity-card-submissions {
+					text-align: center;
+					align-items: center;
+				}
+			</style>
+			<div id="d2l-quick-eval-activity-card-submissions">[[_getNewSubmissionsText(unread, resubmitted)]]</div>
+			<d2l-tooltip for="d2l-quick-eval-activity-card-submissions" position="bottom">[[_getSubmissionTooltipText(unread, resubmitted)]]</d2l-tooltip>
+		`;
+	}
+	static get properties() {
+		return {
+			unread: {
+				type: Number,
+				value: 0
+			},
+			resubmitted: {
+				type: Number,
+				value: 0
+			}
+		};
+	}
+
+	_getNewSubmissionsText() {
+		return this.localize('unreadSubmissions', 'num', this.unread + this.resubmitted);
+	}
+
+	_getSubmissionTooltipText() {
+		return this.localize('unreadSubmissionsDetail', 'unread', this.unread, 'resub', this.resubmitted);
+	}
+}
+
+window.customElements.define(D2LQuickEvalActivityCardUnreadSubmissions.is, D2LQuickEvalActivityCardUnreadSubmissions);

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-unread-submissions.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-unread-submissions.js
@@ -10,6 +10,8 @@ class D2LQuickEvalActivityCardUnreadSubmissions extends QuickEvalLocalize(Polyme
 				#d2l-quick-eval-activity-card-submissions {
 					text-align: center;
 					align-items: center;
+					display: flex;
+					justify-content: space-around;
 				}
 			</style>
 			<div id="d2l-quick-eval-activity-card-submissions">[[_getNewSubmissionsText(unread, resubmitted)]]</div>

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
@@ -154,8 +154,8 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 		this._focused = !this._focused;
 	}
 
-	_showUnreadSubmissions() {
-		return this.unread || this.resubmitted;
+	_showUnreadSubmissions(unread, resubmitted) {
+		return (unread > 0) || (resubmitted > 0);
 	}
 }
 

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
@@ -4,9 +4,9 @@ import '../../d2l-activity-name/d2l-activity-name.js';
 import 'd2l-colors/d2l-colors.js';
 import 'd2l-icons/d2l-icon.js';
 import 'd2l-icons/tier3-icons.js';
-import 'd2l-tooltip/d2l-tooltip.js';
 import 'd2l-polymer-behaviors/d2l-visible-on-ancestor-behavior.js';
 import './d2l-quick-eval-activity-card-items.js';
+import './d2l-quick-eval-activity-card-unread-submissions.js';
 
 class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 	static get is() { return 'd2l-quick-eval-activity-card'; }
@@ -25,13 +25,10 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 					border-color: var(--d2l-color-celestine-plus-1);
 					outline: none;
 				}
-				#d2l-quick-eval-activity-card-submissions {
-					border-right: 1px solid var(--d2l-color-tungsten);
+				d2l-quick-eval-activity-card-unread-submissions {
 					width: 7.5rem;
 					height: 3rem;
-					text-align: center;
 					display: flex;
-					align-items: center;
 					justify-content: space-around;
 				}
 				button.d2l-quick-eval-activity-card-item {
@@ -72,6 +69,9 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 				circle {
 					stroke: var(--d2l-color-tungsten);
 				}
+				[hidden] {
+					display: none;
+				}
 			</style>
 			<div class="d2l-quick-eval-card d2l-visible-on-ancestor-target" on-click="_clicked" tabindex="-1">
 				<div>
@@ -79,8 +79,7 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 					<div>[[activityType]] &bull; [[localize('due', 'date', dueDate)]]</div>
 				</div>
 				<div class="d2l-quick-eval-card-right">
-					<div id="d2l-quick-eval-activity-card-submissions">[[_getNewSubmissionsText()]]</div>
-					<d2l-tooltip for="d2l-quick-eval-activity-card-submissions" position="bottom">[[_getSubmissionTooltipText()]]</d2l-tooltip>
+					<d2l-quick-eval-activity-card-unread-submissions unread="[[unread]]" resubmitted="[[resubmitted]]" hidden$="[[!_showUnreadSubmissions(unread, resubmitted)]]"></d2l-quick-eval-activity-card-unread-submissions>
 					<div class="d2l-quick-eval-activity-card-items-container">
 						<d2l-quick-eval-activity-card-items>
 							<span>[[completed]]/[[assigned]] [[localize('completed')]]</span>
@@ -88,9 +87,9 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 							<span>[[published]]/[[assigned]] [[localize('published')]]</span>
 						</d2l-quick-eval-activity-card-items>
 						<d2l-quick-eval-activity-card-items visible-on-ancestor>
-							<button class="d2l-quick-eval-activity-card-item"><d2l-icon icon="d2l-tier3:quizzing"></d2l-icon>[[localize('evaluateAll')]]</button>
-							<button class="d2l-quick-eval-activity-card-item"><d2l-icon icon="d2l-tier3:preview"></d2l-icon>[[localize('submissionList')]]</button>
-							<button class="d2l-quick-eval-activity-card-item"><d2l-icon icon="d2l-tier3:grade"></d2l-icon>[[localize('publishAll')]]</button>
+							<button class="d2l-quick-eval-activity-card-item"><d2l-icon icon="d2l-tier3:evaluate-all"></d2l-icon>[[localize('evaluateAll')]]</button>
+							<button class="d2l-quick-eval-activity-card-item"><d2l-icon icon="d2l-tier3:view-submission-list"></d2l-icon>[[localize('submissionList')]]</button>
+							<button class="d2l-quick-eval-activity-card-item"><d2l-icon icon="d2l-tier3:publish-all"></d2l-icon>[[localize('publishAll')]]</button>
 						</d2l-quick-eval-activity-card-items>
 					</div>
 					<svg width=".7rem" height="1.4rem">
@@ -157,12 +156,8 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 		this._focused = !this._focused;
 	}
 
-	_getNewSubmissionsText() {
-		return this.localize('unreadSubmissions', 'num', this.unread + this.resubmitted);
-	}
-
-	_getSubmissionTooltipText() {
-		return this.localize('unreadSubmissionsDetail', 'unread', this.unread, 'resub', this.resubmitted);
+	_showUnreadSubmissions() {
+		return this.unread || this.resubmitted;
 	}
 }
 

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
@@ -28,8 +28,6 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 				d2l-quick-eval-activity-card-unread-submissions {
 					width: 7.5rem;
 					height: 3rem;
-					display: flex;
-					justify-content: space-around;
 				}
 				button.d2l-quick-eval-activity-card-item {
 					width: 7.55rem;


### PR DESCRIPTION
Looking ahead at the responsive layouts, it will be easier if this section and its styling is in its own component, since it moves around and changes.

Also updated the action buttons with the new icons.

There should be no visual change to the # of unread section:

![image](https://user-images.githubusercontent.com/29403611/60722974-5f591200-9f00-11e9-9835-e1568d9ed340.png)
