### PR TITLE
Us107663 toggle styling

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
@@ -38,6 +38,8 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 					cursor: pointer;
 					display: inline;
 					font-family: inherit;
+			    font-size: .7rem;
+			    font-weight: 700;
 					margin: 0;
 					min-height: calc(2rem + 2px);
 					outline: none;

--- a/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
@@ -30,7 +30,7 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 					border-width: 1px 1px 1px 0;
 				}
 				:host button {
-					background-color: var(--d2l-color-regolith);
+					background-color: var(--d2l-color-sylvite);
 					border-color: var(--d2l-color-mica);
 					border-style: solid;
 					box-sizing: border-box;
@@ -52,9 +52,12 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 					-moz-user-select: none;
 					-ms-user-select: none;
 				}
-				:host button:hover,
+				:host button:hover {
+					border-color: var(--d2l-color-celestine);
+				}
 				:host button[selected] {
-					background-color: var(--d2l-color-gypsum);
+					background-color: var(--d2l-color-tungsten);
+					color: var(--d2l-color-white);
 				}
 				:host button:focus-within {
 					box-shadow: 0 0 0 4px rgba(0, 111, 191, 0.3);

--- a/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
@@ -61,10 +61,6 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 					background-color: var(--d2l-color-tungsten);
 					color: var(--d2l-color-white);
 				}
-				:host button:focus-within {
-					box-shadow: 0 0 0 4px rgba(0, 111, 191, 0.3);
-					position: relative;
-				}
 			</style>
 			<div>
 				<label id="d2l-quick-eval-view-toggle-label">[[localize('viewBy')]]</label>

--- a/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
@@ -38,8 +38,8 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 					cursor: pointer;
 					display: inline;
 					font-family: inherit;
-			    font-size: .7rem;
-			    font-weight: 700;
+					font-size: .7rem;
+					font-weight: 700;
 					margin: 0;
 					min-height: calc(2rem + 2px);
 					outline: none;

--- a/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
@@ -11,11 +11,11 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 	static get template() {
 		const toggleTemplate = html`
 			<style>
-				.d2l-quick-eval-view-toggle-left,
-				:host(:dir(rtl)) .d2l-quick-eval-view-toggle-right {
+				:host button.d2l-quick-eval-view-toggle-left,
+				:host(:dir(rtl)) :host button.d2l-quick-eval-view-toggle-right {
 					border-top-left-radius: 0.3em;
 					border-bottom-left-radius: 0.3em;
-					border-width: 1px;
+					border-right-color: transparent;
 				}
 				:host button.d2l-quick-eval-view-toggle-left {
 					margin-left: 0.9rem;
@@ -23,16 +23,17 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 				:host(:dir(rtl)) button.d2l-quick-eval-view-toggle-left {
 					margin-right: 0.9rem;
 				}
-				.d2l-quick-eval-view-toggle-right,
-				:host(:dir(rtl)) .d2l-quick-eval-view-toggle-left {
+				:host button.d2l-quick-eval-view-toggle-right,
+				:host(:dir(rtl)) :host button.d2l-quick-eval-view-toggle-left {
 					border-top-right-radius: 0.3em;
 					border-bottom-right-radius: 0.3em;
-					border-width: 1px 1px 1px 0;
+					border-left-color: transparent;
 				}
 				:host button {
 					background-color: var(--d2l-color-sylvite);
 					border-color: var(--d2l-color-mica);
 					border-style: solid;
+					border-width: 1px;
 					box-sizing: border-box;
 					color: var(--d2l-color-ferrite);
 					cursor: pointer;
@@ -55,10 +56,11 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 					-ms-user-select: none;
 				}
 				:host button:hover {
-					border-color: var(--d2l-color-celestine);
+					border: 1px solid var(--d2l-color-celestine) !important;
 				}
 				:host button[selected] {
 					background-color: var(--d2l-color-tungsten);
+					border-color: var(--d2l-color-tungsten);
 					color: var(--d2l-color-white);
 				}
 			</style>


### PR DESCRIPTION
So this is an image of the switcher in its default state:
![Screen Shot 2019-07-10 at 3 25 56 PM](https://user-images.githubusercontent.com/52468201/60998497-0ede1c00-a327-11e9-8d7a-95acd166ff30.png)

And here it is when hovered:
![Screen Shot 2019-07-10 at 3 25 48 PM](https://user-images.githubusercontent.com/52468201/60998530-18678400-a327-11e9-9a54-f14602631915.png)

Also the designers wanted to make the switcher look identical to the ones on the calendar page, so I attached a photo below:
![Screen Shot 2019-07-10 at 1 30 10 PM](https://user-images.githubusercontent.com/52468201/60990778-27ded100-a317-11e9-92cb-e5a4d169b0d7.png)
