### PR TITLE
Maboelsoudd2l/us108335

### DIFF
--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
@@ -5,6 +5,7 @@ import 'd2l-colors/d2l-colors.js';
 import 'd2l-icons/d2l-icon.js';
 import 'd2l-icons/tier3-icons.js';
 import 'd2l-polymer-behaviors/d2l-visible-on-ancestor-behavior.js';
+import '@brightspace-ui/core/components/meter/meter-radial.js';
 import './d2l-quick-eval-activity-card-items.js';
 import './d2l-quick-eval-activity-card-unread-submissions.js';
 
@@ -80,9 +81,9 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 					<d2l-quick-eval-activity-card-unread-submissions unread="[[unread]]" resubmitted="[[resubmitted]]" hidden$="[[!_showUnreadSubmissions(unread, resubmitted)]]"></d2l-quick-eval-activity-card-unread-submissions>
 					<div class="d2l-quick-eval-activity-card-items-container">
 						<d2l-quick-eval-activity-card-items>
-							<span>[[completed]]/[[assigned]] [[localize('completed')]]</span>
-							<span>[[evaluated]]/[[assigned]] [[localize('evaluated')]]</span>
-							<span>[[published]]/[[assigned]] [[localize('published')]]</span>
+							<d2l-meter-radial value="[[completed]]" max="[[assigned]]" percent$="[[_denominatorOver100(assigned)]]" text="[[localize('completed')]]"></d2l-meter-radial>
+							<d2l-meter-radial value="[[evaluated]]" max="[[assigned]]" percent$="[[_denominatorOver100(assigned)]]" text="[[localize('evaluated')]]"></d2l-meter-radial>
+							<d2l-meter-radial value="[[published]]" max="[[assigned]]" percent$="[[_denominatorOver100(assigned)]]" text="[[localize('published')]]"></d2l-meter-radial>
 						</d2l-quick-eval-activity-card-items>
 						<d2l-quick-eval-activity-card-items visible-on-ancestor>
 							<button class="d2l-quick-eval-activity-card-item"><d2l-icon icon="d2l-tier3:evaluate-all"></d2l-icon>[[localize('evaluateAll')]]</button>
@@ -156,6 +157,10 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 
 	_showUnreadSubmissions(unread, resubmitted) {
 		return (unread > 0) || (resubmitted > 0);
+	}
+
+	_denominatorOver100(num) {
+		return num > 99;
 	}
 }
 

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
@@ -81,9 +81,9 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 					<d2l-quick-eval-activity-card-unread-submissions unread="[[unread]]" resubmitted="[[resubmitted]]" hidden$="[[!_showUnreadSubmissions(unread, resubmitted)]]"></d2l-quick-eval-activity-card-unread-submissions>
 					<div class="d2l-quick-eval-activity-card-items-container">
 						<d2l-quick-eval-activity-card-items>
-							<d2l-meter-radial value="[[completed]]" max="[[assigned]]" percent$="[[_denominatorOver100(assigned)]]" text="[[localize('completed')]]"></d2l-meter-radial>
-							<d2l-meter-radial value="[[evaluated]]" max="[[assigned]]" percent$="[[_denominatorOver100(assigned)]]" text="[[localize('evaluated')]]"></d2l-meter-radial>
-							<d2l-meter-radial value="[[published]]" max="[[assigned]]" percent$="[[_denominatorOver100(assigned)]]" text="[[localize('published')]]"></d2l-meter-radial>
+							<d2l-meter-radial value="[[completed]]" max="[[assigned]]" percent$="[[_denominatorOver99(assigned)]]" text="[[localize('completed')]]"></d2l-meter-radial>
+							<d2l-meter-radial value="[[evaluated]]" max="[[assigned]]" percent$="[[_denominatorOver99(assigned)]]" text="[[localize('evaluated')]]"></d2l-meter-radial>
+							<d2l-meter-radial value="[[published]]" max="[[assigned]]" percent$="[[_denominatorOver99(assigned)]]" text="[[localize('published')]]"></d2l-meter-radial>
 						</d2l-quick-eval-activity-card-items>
 						<d2l-quick-eval-activity-card-items visible-on-ancestor>
 							<button class="d2l-quick-eval-activity-card-item"><d2l-icon icon="d2l-tier3:evaluate-all"></d2l-icon>[[localize('evaluateAll')]]</button>
@@ -159,7 +159,7 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 		return (unread > 0) || (resubmitted > 0);
 	}
 
-	_denominatorOver100(num) {
+	_denominatorOver99(num) {
 		return num > 99;
 	}
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 	},
 	"main": "d2l-activities.js",
 	"dependencies": {
+		"@brightspace-ui/core": "BrightspaceUI/core#semver:^0",
 		"@polymer/iron-resizable-behavior": "^3.0.0",
 		"@polymer/polymer": "^3.0.0",
 		"d2l-alert": "BrightspaceUI/alert#semver:^4",

--- a/test/d2l-quick-eval/d2l-quick-eval-activity-card.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activity-card.js
@@ -8,5 +8,12 @@
 		test('instantiating the element works', function() {
 			assert.equal(toggle.tagName.toLowerCase(), 'd2l-quick-eval-activity-card');
 		});
+
+		test('_denominatorOver99 works', function() {
+			assert.isFalse(toggle._denominatorOver99(50));
+			assert.isFalse(toggle._denominatorOver99(99));
+			assert.isTrue(toggle._denominatorOver99(100));
+			assert.isTrue(toggle._denominatorOver99(200));
+		});
 	});
 })();


### PR DESCRIPTION
Should look like this:
![image](https://user-images.githubusercontent.com/52468201/61324135-b358d600-a7df-11e9-8bd4-2b69547c6aee.png)

When the denominator goes above 99, it switches into percentage (no image shown cause quad data doesn't have that right now. But I have tested the functionality with other numbers).