### PR TITLE
robust switcher rtl styling and tabbing support

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -32,6 +32,9 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 				.d2l-quick-eval-activity-list-modifiers {
 					float: right;
 				}
+				:host(:dir(rtl)) .d2l-quick-eval-activity-list-modifiers {
+					float: left;
+				}
 				.clear {
 					clear: both;
 				}

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -46,6 +46,9 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 				.d2l-quick-eval-submissions-table-modifiers {
 					float: right;
 				}
+				:host(:dir(rtl)) .d2l-quick-eval-submissions-table-modifiers {
+					float: left;
+				}
 				.clear {
 					clear: both;
 				}

--- a/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
@@ -58,11 +58,8 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 					-moz-user-select: none;
 					-ms-user-select: none;
 				}
-				:host button:hover {
+				:host button:hover, :host button:focus {
 					border: 1px solid var(--d2l-color-celestine) !important;
-				}
-				:host button:focus {
-					background-color: var(--d2l-color-gypsum);
 				}
 				:host button.d2l-quick-eval-view-toggle-left[selected], :host button.d2l-quick-eval-view-toggle-right[selected] {
 					background-color: var(--d2l-color-tungsten);

--- a/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
@@ -12,22 +12,25 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 		const toggleTemplate = html`
 			<style>
 				:host button.d2l-quick-eval-view-toggle-left,
-				:host(:dir(rtl)) :host button.d2l-quick-eval-view-toggle-right {
-					border-top-left-radius: 0.3em;
-					border-bottom-left-radius: 0.3em;
+				:host(:dir(rtl)) button.d2l-quick-eval-view-toggle-right {
+					border-top-left-radius: 0.3rem;
+					border-bottom-left-radius: 0.3rem;
 					border-right-color: transparent;
+					border-top-right-radius: 0rem;
+					border-bottom-right-radius: 0;
+					border-left-color: var(--d2l-color-mica);
 				}
 				:host button.d2l-quick-eval-view-toggle-left {
-					margin-left: 0.9rem;
-				}
-				:host(:dir(rtl)) button.d2l-quick-eval-view-toggle-left {
-					margin-right: 0.9rem;
+					margin-inline-start: 0.9rem;
 				}
 				:host button.d2l-quick-eval-view-toggle-right,
-				:host(:dir(rtl)) :host button.d2l-quick-eval-view-toggle-left {
-					border-top-right-radius: 0.3em;
-					border-bottom-right-radius: 0.3em;
+				:host(:dir(rtl)) button.d2l-quick-eval-view-toggle-left {
+					border-top-right-radius: 0.3rem;
+					border-bottom-right-radius: 0.3rem;
 					border-left-color: transparent;
+					border-top-left-radius: 0rem;
+					border-bottom-left-radius: 0rem;
+					border-right-color: var(--d2l-color-mica);
 				}
 				:host button {
 					background-color: var(--d2l-color-sylvite);
@@ -58,7 +61,10 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 				:host button:hover {
 					border: 1px solid var(--d2l-color-celestine) !important;
 				}
-				:host button[selected] {
+				:host button:focus {
+					background-color: #e6eaf0;
+				}
+				:host button.d2l-quick-eval-view-toggle-left[selected], :host button.d2l-quick-eval-view-toggle-right[selected] {
 					background-color: var(--d2l-color-tungsten);
 					border-color: var(--d2l-color-tungsten);
 					color: var(--d2l-color-white);

--- a/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
@@ -62,7 +62,7 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 					border: 1px solid var(--d2l-color-celestine) !important;
 				}
 				:host button:focus {
-					background-color: #e6eaf0;
+					background-color: var(--d2l-color-gypsum);
 				}
 				:host button.d2l-quick-eval-view-toggle-left[selected], :host button.d2l-quick-eval-view-toggle-right[selected] {
 					background-color: var(--d2l-color-tungsten);

--- a/components/d2l-quick-eval/d2l-quick-eval.js
+++ b/components/d2l-quick-eval/d2l-quick-eval.js
@@ -1,4 +1,5 @@
 import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
+import {QuickEvalLocalize} from './QuickEvalLocalize.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
 import './d2l-quick-eval-view-toggle.js';
 import './d2l-quick-eval-activities.js';
@@ -8,7 +9,7 @@ import './d2l-quick-eval-submissions.js';
  * @customElement
  * @polymer
  */
-class D2LQuickEval extends PolymerElement {
+class D2LQuickEval extends  QuickEvalLocalize(PolymerElement) {
 	static get template() {
 		return html`
 			<style>
@@ -26,6 +27,10 @@ class D2LQuickEval extends PolymerElement {
 				.d2l-quick-eval-header {
 					float: left;
 				}
+				:host(:dir(rtl)) d2l-quick-eval-view-toggle,
+				:host(:dir(rtl)) .d2l-quick-eval-header-with-toggle {
+					float: right;
+				}
 				.d2l-quick-eval-header-with-toggle {
 					float: left;
 					padding-bottom: 1.2rem;
@@ -35,7 +40,7 @@ class D2LQuickEval extends PolymerElement {
 				}
 			</style>
 			<template is="dom-if" if="[[headerText]]">
-				<h1 class="d2l-quick-eval-header-with-toggle" hidden$="[[!activitiesViewEnabled]]"">[[headerText]]</h1>
+				<h1 class="d2l-quick-eval-header-with-toggle" hidden$="[[!activitiesViewEnabled]]">[[headerText]]</h1>
 				<h1 class="d2l-quick-eval-header" hidden$="[[activitiesViewEnabled]]"">[[headerText]]</h1>
 			</template>
 			<d2l-quick-eval-view-toggle current-selected="[[toggleState]]" toggle-href="[[toggleHref]]" hidden$="[[!activitiesViewEnabled]]" on-d2l-quick-eval-view-toggle-changed="_toggleView"></d2l-quick-eval-view-toggle>


### PR DESCRIPTION
Fixes some of the issues noted in testing.

this is what it looks like in in RTL:
![Screen Shot 2019-07-17 at 6 44 02 PM](https://user-images.githubusercontent.com/52468201/61416861-2f781a00-a8c3-11e9-8b12-c5ddff00f3d7.png)
and this is what it looks like when the submissions is tabbed (You can barely see a difference):
![Screen Shot 2019-07-17 at 6 45 14 PM 1](https://user-images.githubusercontent.com/52468201/61416885-474f9e00-a8c3-11e9-9cf7-b89385ef1726.png)
 