### PR TITLE
Format date using the same method as submissions view

### DIFF
--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
@@ -189,7 +189,7 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 			<div class="d2l-quick-eval-card d2l-visible-on-ancestor-target" on-click="_clicked" tabindex="-1">
 				<div class="d2l-quick-eval-card-titles">
 					<d2l-activity-name href="[[activityNameHref]]" token="[[token]]"></d2l-activity-name>
-					<div class="d2l-quick-eval-card-subtitle"><span>[[activityType]]</span> <span hidden$="[[!dueDate]]"> &bull; [[localize('due', 'date', formattedDueDate)]]</span></div>
+					<div class="d2l-quick-eval-card-subtitle"><span>[[activityType]]</span> <span hidden$="[[!formattedDueDate]]"> &bull; [[localize('due', 'date', formattedDueDate)]]</span></div>
 				</div>
 				<div class="d2l-quick-eval-card-right">
 					<div class="d2l-quick-eval-activity-card-items-container">

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
@@ -266,7 +266,7 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 			},
 			formattedDueDate: {
 				type: String,
-				computed: '_computeFormattedDate(dueDate)'
+				computed: '_computeFormattedDueDate(dueDate)'
 			},
 			publishAll: {
 				type: Object
@@ -337,7 +337,7 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 		return num > 99;
 	}
 
-	_computeFormattedDate(dueDate) {
+	_computeFormattedDueDate(dueDate) {
 		if (dueDate) {
 			return this.formatDateTime(new Date(dueDate));
 		}

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
@@ -189,7 +189,7 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 			<div class="d2l-quick-eval-card d2l-visible-on-ancestor-target" on-click="_clicked" tabindex="-1">
 				<div class="d2l-quick-eval-card-titles">
 					<d2l-activity-name href="[[activityNameHref]]" token="[[token]]"></d2l-activity-name>
-					<div class="d2l-quick-eval-card-subtitle"><span>[[activityType]]</span> <span hidden$="[[!dueDate]]"> &bull; [[localize('due', 'date', dueDate)]]</span></div>
+					<div class="d2l-quick-eval-card-subtitle"><span>[[activityType]]</span> <span hidden$="[[!dueDate]]"> &bull; [[localize('due', 'date', formattedDueDate)]]</span></div>
 				</div>
 				<div class="d2l-quick-eval-card-right">
 					<div class="d2l-quick-eval-activity-card-items-container">
@@ -264,6 +264,10 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 				type: String,
 				value: ''
 			},
+			formattedDueDate: {
+				type: String,
+				computed: '_computeFormattedDate(dueDate)'
+			},
 			publishAll: {
 				type: Object
 			},
@@ -331,6 +335,13 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 
 	_denominatorOver99(num) {
 		return num > 99;
+	}
+
+	_computeFormattedDate(dueDate) {
+		if (dueDate) {
+			return this.formatDateTime(new Date(dueDate));
+		}
+		return '';
 	}
 }
 

--- a/test/d2l-quick-eval/d2l-quick-eval-activity-card.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activity-card.js
@@ -1,19 +1,33 @@
 (function() {
-	let toggle;
-	suite('d2l-quick-eval-view-toggle', function() {
+	let qeActivityCard;
+	suite('d2l-quick-eval-activity-card', function() {
 		setup(function() {
-			toggle = fixture('basic');
+			qeActivityCard = fixture('basic');
 		});
 
 		test('instantiating the element works', function() {
-			assert.equal(toggle.tagName.toLowerCase(), 'd2l-quick-eval-activity-card');
+			assert.equal(qeActivityCard.tagName.toLowerCase(), 'd2l-quick-eval-activity-card');
 		});
 
 		test('_denominatorOver99 works', function() {
-			assert.isFalse(toggle._denominatorOver99(50));
-			assert.isFalse(toggle._denominatorOver99(99));
-			assert.isTrue(toggle._denominatorOver99(100));
-			assert.isTrue(toggle._denominatorOver99(200));
+			assert.isFalse(qeActivityCard._denominatorOver99(50));
+			assert.isFalse(qeActivityCard._denominatorOver99(99));
+			assert.isTrue(qeActivityCard._denominatorOver99(100));
+			assert.isTrue(qeActivityCard._denominatorOver99(200));
+		});
+
+		test('_computeFormattedDate works as intended when activity has valid dueDate', function() {
+			const dueDate = '2012-09-01T17:00:00.000Z';
+			const expectedFormattedDate = '9/1/2012 1:00 PM';
+
+			assert.equal(qeActivityCard._computeFormattedDate(dueDate), expectedFormattedDate);
+		});
+
+		test('_computeFormattedDate works as intended when activity does not have dueDate', function() {
+			const dueDate = '';
+			const expectedFormattedDate = '';
+
+			assert.equal(qeActivityCard._computeFormattedDate(dueDate), expectedFormattedDate);
 		});
 	});
 })();

--- a/test/d2l-quick-eval/d2l-quick-eval-activity-card.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activity-card.js
@@ -16,18 +16,27 @@
 			assert.isTrue(qeActivityCard._denominatorOver99(200));
 		});
 
-		test('_computeFormattedDate works as intended when activity has valid dueDate', function() {
+		test('_computeFormattedDueDate works as intended when activity has valid dueDate', function() {
 			const dueDate = '2012-09-01T13:00:00.000';
 			const expectedFormattedDate = '9/1/2012 1:00 PM';
 
-			assert.equal(qeActivityCard._computeFormattedDate(dueDate), expectedFormattedDate);
+			assert.equal(qeActivityCard._computeFormattedDueDate(dueDate), expectedFormattedDate);
 		});
 
-		test('_computeFormattedDate works as intended when activity does not have dueDate', function() {
+		test('_computeFormattedDueDate works as intended when activity does not have dueDate', function() {
 			const dueDate = '';
 			const expectedFormattedDate = '';
 
-			assert.equal(qeActivityCard._computeFormattedDate(dueDate), expectedFormattedDate);
+			assert.equal(qeActivityCard._computeFormattedDueDate(dueDate), expectedFormattedDate);
+		});
+
+		test('when dueDate changes, formattedDueDate also changes', function() {
+			let dueDate = '';
+			assert.equal(qeActivityCard._computeFormattedDueDate(dueDate), dueDate);
+
+			dueDate = '2016-03-07T00:20:00.000';
+			const expectedFormattedDate = '3/7/2016 12:20 AM';
+			assert.equal(qeActivityCard._computeFormattedDueDate(dueDate), expectedFormattedDate);
 		});
 	});
 })();

--- a/test/d2l-quick-eval/d2l-quick-eval-activity-card.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activity-card.js
@@ -17,7 +17,7 @@
 		});
 
 		test('_computeFormattedDate works as intended when activity has valid dueDate', function() {
-			const dueDate = '2012-09-01T17:00:00.000Z';
+			const dueDate = '2012-09-01T13:00:00.000';
 			const expectedFormattedDate = '9/1/2012 1:00 PM';
 
 			assert.equal(qeActivityCard._computeFormattedDate(dueDate), expectedFormattedDate);


### PR DESCRIPTION
[US108296](https://rally1.rallydev.com/#/detail/userstory/318899088768?fdp=true)

Here is a screenshot of two activity cards using data from Quad, one without a due date, one with:

![formatted_due_date](https://user-images.githubusercontent.com/11618509/61463158-dac7b400-a941-11e9-8f67-85c7791649aa.PNG)
