### PR TITLE
Adding responsive layout to activities list.

### DIFF
--- a/components/d2l-quick-eval/activities-list/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/activities-list/d2l-quick-eval-activities-list.js
@@ -16,11 +16,19 @@ class D2LQuickEvalActivitiesList extends QuickEvalLocalize(PolymerElement) {
 			.d2l-quick-eval-activities-list-card-spacer {
 				background: var(--d2l-color-sylvite);
 				height: .3rem;
+				width: 100vw;
+				position: relative;
+				left: 50%;
+				right: 50%;
+				margin-left: -50vw;
+				margin-right: -50vw;
+			}
+			.d2l-quick-eval-activities-list-card-spacer-border {
+				border-top: 1px solid var(--d2l-color-mica);
 			}
 			h2 {
 				margin-bottom: .6rem;
 				margin-top: .9rem;
-				margin-inline-start: .9rem;
 				min-height: .6rem;
 				line-height: .6rem;
 				font-size: .8rem;
@@ -30,7 +38,6 @@ class D2LQuickEvalActivitiesList extends QuickEvalLocalize(PolymerElement) {
 					font-size: 1rem;
 					margin-top: 1.2rem;
 					margin-bottom: .6rem;
-					margin-inline-start: 0;
 					min-height: 1rem;
 					line-height: 1rem;
 				}
@@ -65,7 +72,7 @@ class D2LQuickEvalActivitiesList extends QuickEvalLocalize(PolymerElement) {
 										activity-type="[[localize(a.activityType)]]"
 										activity-name-href="[[a.activityNameHref]]"
 										token="[[token]]"></d2l-quick-eval-activity-card>
-										<div class="d2l-quick-eval-activities-list-card-spacer"></div>
+										<div class="d2l-quick-eval-activities-list-card-spacer d2l-quick-eval-activities-list-card-spacer-border"></div>
 									</li>
 								</template>
 							</dom-repeat>

--- a/components/d2l-quick-eval/activities-list/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/activities-list/d2l-quick-eval-activities-list.js
@@ -1,6 +1,7 @@
 import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
 import {QuickEvalLocalize} from '../QuickEvalLocalize.js';
 import '../activity-card/d2l-quick-eval-activity-card.js';
+import 'd2l-colors/d2l-colors.js';
 
 class D2LQuickEvalActivitiesList extends QuickEvalLocalize(PolymerElement) {
 	static get is() { return 'd2l-quick-eval-activities-list'; }
@@ -12,6 +13,35 @@ class D2LQuickEvalActivitiesList extends QuickEvalLocalize(PolymerElement) {
 				margin: 0;
 				padding: 0;
 			}
+			.d2l-quick-eval-activities-list-card-spacer {
+				background: var(--d2l-color-sylvite);
+				height: .3rem;
+			}
+			h2 {
+				margin-bottom: .6rem;
+				margin-top: .9rem;
+				margin-inline-start: .9rem;
+				min-height: .6rem;
+				line-height: .6rem;
+				font-size: 16px;
+			}
+			@media (min-width: 525px) {
+				h2 {
+					font-size: 1rem;
+					margin-top: 1.2rem;
+					margin-bottom: .6rem;
+					margin-inline-start: 0;
+					min-height: 1rem;
+					line-height: 1rem;
+				}
+				.d2l-quick-eval-activities-list-card-spacer {
+					display: none;
+				}
+				:host ul ul li {
+					margin-top: .6rem;
+					margin-bottom: .6rem;
+				}
+			}
 		</style>
 		<ul class="d2l-quick-eval-activities-list-remove-ul-styling">
 			<dom-repeat items="[[courses]]" as="c">
@@ -22,6 +52,7 @@ class D2LQuickEvalActivitiesList extends QuickEvalLocalize(PolymerElement) {
 							<dom-repeat items="[[c.activities]]" as="a">
 								<template>
 									<li>
+										<div class="d2l-quick-eval-activities-list-card-spacer"></div>
 										<d2l-quick-eval-activity-card
 										assigned="[[a.assigned]]"
 										completed="[[a.completed]]"
@@ -34,6 +65,7 @@ class D2LQuickEvalActivitiesList extends QuickEvalLocalize(PolymerElement) {
 										activity-type="[[localize(a.activityType)]]"
 										activity-name-href="[[a.activityNameHref]]"
 										token="[[token]]"></d2l-quick-eval-activity-card>
+										<div class="d2l-quick-eval-activities-list-card-spacer"></div>
 									</li>
 								</template>
 							</dom-repeat>

--- a/components/d2l-quick-eval/activities-list/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/activities-list/d2l-quick-eval-activities-list.js
@@ -23,7 +23,7 @@ class D2LQuickEvalActivitiesList extends QuickEvalLocalize(PolymerElement) {
 				margin-inline-start: .9rem;
 				min-height: .6rem;
 				line-height: .6rem;
-				font-size: 16px;
+				font-size: .8rem;
 			}
 			@media (min-width: 525px) {
 				h2 {

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
@@ -20,7 +20,6 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 				.d2l-quick-eval-card {
 					padding-bottom: .9rem;
 					padding-top: .6rem;
-					border-bottom: 1px solid var(--d2l-color-mica);
 				}
 				.d2l-quick-eval-card-actions {
 					padding-top: .6rem;

--- a/demo/d2l-quick-eval/d2l-quick-eval-activity-card.html
+++ b/demo/d2l-quick-eval/d2l-quick-eval-activity-card.html
@@ -47,7 +47,7 @@
 			<demo-snippet>
 				<template strip-whitespace>
 					<d2l-quick-eval-activity-card
-						total="20"
+						assigned="20"
 						completed="2"
 						published="3"
 						evaluated="4"
@@ -56,7 +56,7 @@
 						due-date="2019-10-10"
 						activity-type="Quiz"></d2l-quick-eval-activity-card>
 					<d2l-quick-eval-activity-card
-						total="20"
+						assigned="20"
 						completed="2"
 						published="3"
 						evaluated="4"


### PR DESCRIPTION
Adding the responsive css to the activities list - vertical spacing and course name size.

900px+:
![image](https://user-images.githubusercontent.com/29403611/61482260-386ef700-a968-11e9-8b73-c9c51e4c8868.png)

525-899px:
![image](https://user-images.githubusercontent.com/29403611/61482304-47ee4000-a968-11e9-8e8e-9867554751e3.png)

524px-:
![image](https://user-images.githubusercontent.com/29403611/61482330-53416b80-a968-11e9-93de-5968eda0637a.png)

Also included a change to the activity card demo as the property name changed.