### PR TITLE
made sure that the meters look the same on all browsers

### DIFF
--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-items.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-items.js
@@ -18,7 +18,7 @@ class D2LQuickEvalActivityCardItems extends mixinBehaviors([D2L.PolymerBehaviors
 					height: 3rem;
 					text-align: center;
 					display: flex;
-					align-items: center;
+					align-items: flex-start;
 					justify-content: space-around;
 					flex: 1 1 0;
 				}

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
@@ -195,9 +195,15 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 					<div class="d2l-quick-eval-activity-card-items-container">
 						<div class="d2l-quick-eval-card-meters">
 							<d2l-quick-eval-activity-card-items>
+								<div>
 							<d2l-meter-radial value="[[completed]]" max="[[assigned]]" percent$="[[_denominatorOver99(assigned)]]" text="[[localize('completed')]]"></d2l-meter-radial>
+								</div>
+								<div>
 							<d2l-meter-radial value="[[evaluated]]" max="[[assigned]]" percent$="[[_denominatorOver99(assigned)]]" text="[[localize('evaluated')]]"></d2l-meter-radial>
+								</div>
+								<div>
 							<d2l-meter-radial value="[[published]]" max="[[assigned]]" percent$="[[_denominatorOver99(assigned)]]" text="[[localize('published')]]"></d2l-meter-radial>
+								</div>
 							</d2l-quick-eval-activity-card-items>
 						</div>
 						<d2l-quick-eval-activity-card-unread-submissions


### PR DESCRIPTION
on chrome
![Screen Shot 2019-07-23 at 2 29 27 PM](https://user-images.githubusercontent.com/52468201/61737503-5a94ba80-ad56-11e9-9317-730c42a409de.png)
on firefox:
<img width="1162" alt="Screen Shot 2019-07-23 at 2 29 50 PM" src="https://user-images.githubusercontent.com/52468201/61737530-64b6b900-ad56-11e9-98f6-2b3461a0e952.png">
and safari:
<img width="1162" alt="Screen Shot 2019-07-23 at 2 32 50 PM" src="https://user-images.githubusercontent.com/52468201/61737713-ca0aaa00-ad56-11e9-9ef2-3f32bd1851c8.png">
- [x] designer signoff (Erin approved this and bought me Twix bars!)
