### PR TITLE
Updating svg with new version from design.

### DIFF
--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
@@ -181,7 +181,7 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 				button:focus d2l-icon {
 					color: var(--d2l-color-celestine-plus-1);
 				}
-				circle {
+				.d2l-quick-eval-card-indicator circle {
 					stroke: var(--d2l-color-tungsten);
 				}
 			</style>
@@ -230,9 +230,9 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 						</div>
 					</div>
 					<div class="d2l-quick-eval-card-indicator">
-						<svg width="14px" height="28px">
-							<circle cx="7px" cy="7px" r="5px" stroke-width="2px" class="d2l-quick-eval-activity-card-hovered-off"></circle>
-							<circle cx="7px" cy="22px" r="5px" stroke-width="2px" class="d2l-quick-eval-activity-card-hovered-on"></circle>
+						<svg width="12px" height="33px" viewBox="0 0 12 33">
+							<circle class="d2l-quick-eval-activity-card-hovered-off" stroke-width="2" cx="5.5" cy="5.5" r="4.5"></circle>
+							<circle class="d2l-quick-eval-activity-card-hovered-on" stroke-width="2" cx="5.5" cy="26.5" r="4.5"></circle>
 						</svg>
 					</div>
 				</div>


### PR DESCRIPTION
This PR is only to update the svg to look like that provided by design. New click behaviours are not covered. Hover behaviour (indicators switch on hover) should be retained.

New indicators:
![image](https://user-images.githubusercontent.com/29403611/62073224-421d1800-b20e-11e9-8ac9-798c8426b6a5.png)

Received LGTM from Erin.