### PR TITLE
US108986

### DIFF
--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-items.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-items.js
@@ -26,7 +26,7 @@ class D2LQuickEvalActivityCardItems extends mixinBehaviors([D2L.PolymerBehaviors
 					::slotted(*) {
 						border-width: 0 1px 0 0;
 						border-style: solid;
-						border-color: var(--d2l-color-tungsten);
+						border-color: var(--d2l-color-mica);
 					}
 					::slotted(*:last-child) {
 						border-right-width: 0;
@@ -39,7 +39,7 @@ class D2LQuickEvalActivityCardItems extends mixinBehaviors([D2L.PolymerBehaviors
 					:host([small]) ::slotted(*) {
 						border-width: 0 1px 0 0;
 						border-style: solid;
-						border-color: var(--d2l-color-tungsten);
+						border-color: var(--d2l-color-mica);
 					}
 					:host([small]) ::slotted(*:first-child),
 					::slotted(*:first-child) {

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
@@ -54,8 +54,8 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 						display: inline;
 					}
 					.d2l-quick-eval-card {
-						border: 3px solid var(--d2l-color-ferrite);
-						border-radius: 10px;
+						border: 1px solid var(--d2l-color-galena);
+						border-radius: 6px;
 						padding: .9rem;
 					}
 					.d2l-quick-eval-card-actions {


### PR DESCRIPTION
Before:

<img width="1378" alt="Screen Shot 2019-07-30 at 11 11 36 AM" src="https://user-images.githubusercontent.com/4844376/62144398-bf549580-b2bf-11e9-8945-fcca976f2515.png">

After:
<img width="1376" alt="Screen Shot 2019-07-30 at 11 24 40 AM" src="https://user-images.githubusercontent.com/4844376/62144405-c24f8600-b2bf-11e9-8308-717a4bc9f42f.png">

Spec - [link](https://d2lmail.sharepoint.com/sites/uxteam/Shared%20Documents/Forms/AllItems.aspx?id=%2Fsites%2Fuxteam%2FShared%20Documents%2FAssessment%20%2D%20Quick%20Eval%20and%20More%2FQuick%20Eval%20%2D%20Design%20Resources%2FSpecs%2FUI%5FSpecs%2Epng&parent=%2Fsites%2Fuxteam%2FShared%20Documents%2FAssessment%20%2D%20Quick%20Eval%20and%20More%2FQuick%20Eval%20%2D%20Design%20Resources%2FSpecs&p=true&cid=39925d3f-06e1-4f35-8f3e-cbac882430bf)
Change: Old value of Mica was #D3D9E3 it is #CDD5DC now (Daylight colors - [link](http://design.d2l/style/colour/))

 
- [x] Confirmed with Design (Erin)
