### PR TITLE
Added a wrapper for activity-name

### DIFF
--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
@@ -141,6 +141,11 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 					.d2l-quick-eval-card-titles {
 						min-height: 3rem;
 					}
+					.d2l-activity-name-wrapper {
+						font-size: 0.95rem;
+						font-weight: 400;
+						margin: 0;
+					}
 					.d2l-quick-eval-card-subtitle {
 						font-size: .7rem;
 						line-height: .7rem;
@@ -187,7 +192,9 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 			</style>
 			<div class="d2l-quick-eval-card d2l-visible-on-ancestor-target">
 				<div class="d2l-quick-eval-card-titles">
-					<d2l-activity-name href="[[activityNameHref]]" token="[[token]]"></d2l-activity-name>
+					<h3 class="d2l-activity-name-wrapper">
+						<d2l-activity-name href="[[activityNameHref]]" token="[[token]]"></d2l-activity-name>
+					</h3>
 					<div class="d2l-quick-eval-card-subtitle"><span>[[localize(activityType)]]</span> <span hidden$="[[!formattedDueDate]]"> &bull; [[localize('due', 'date', formattedDueDate)]]</span></div>
 				</div>
 				<div class="d2l-quick-eval-card-right">

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
@@ -9,6 +9,7 @@ import '@brightspace-ui/core/components/meter/meter-radial.js';
 import './d2l-quick-eval-activity-card-items.js';
 import './d2l-quick-eval-activity-card-unread-submissions.js';
 import './d2l-quick-eval-activity-card-action-button.js';
+import 'd2l-typography/d2l-typography-shared-styles.js';
 
 class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 	static get is() { return 'd2l-quick-eval-activity-card'; }
@@ -142,8 +143,7 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 						min-height: 3rem;
 					}
 					.d2l-activity-name-wrapper {
-						font-size: 0.95rem;
-						font-weight: 400;
+						@apply --d2l-body-standard-text;
 						margin: 0;
 					}
 					.d2l-quick-eval-card-subtitle {


### PR DESCRIPTION
Should look exactly the same, but now the screen reader can tab through it, which i was able to do successfully.