### PR TITLE
US108701 - update count after publish all

### DIFF
--- a/components/d2l-quick-eval/behaviors/d2l-quick-eval-siren-helper-behavior.js
+++ b/components/d2l-quick-eval/behaviors/d2l-quick-eval-siren-helper-behavior.js
@@ -77,6 +77,10 @@ D2L.PolymerBehaviors.QuickEval.D2LQuickEvalSirenHelperBehaviorImpl = {
 		return subEntity.properties.name;
 	},
 
+	getEvaluationStatusHref: function(entity) {
+		return entity.getLinkByRel(Rels.Activities.evaluationStatus).href;
+	},
+
 	_getEvaluationStatusPromise: async function(entity) {
 		return this._followLink(entity, Rels.Activities.evaluationStatus)
 			.then(function(e) {

--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -200,6 +200,7 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 		const result = await Promise.all(entity.entities.map(async function(activity) {
 			const evalStatus = await this._getEvaluationStatusPromise(activity);
 			const courseName = await this._getCourseNamePromise(activity);
+			const id = this.getEvaluationStatusHref(activity);
 			return {
 				courseName: courseName,
 				assigned: evalStatus.assigned,
@@ -213,7 +214,8 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 				key: this._getOrgHref(activity),
 				dueDate: this._getActivityDueDate(activity),
 				activityType: this._getActivityType(activity),
-				activityNameHref: this._getActivityNameHref(activity)
+				activityNameHref: this._getActivityNameHref(activity),
+				id: id
 			};
 		}.bind(this)));
 		return this._groupByCourse(result);
@@ -280,7 +282,11 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 		confirmEvent.AddListener(
 			(result) => {
 				if (result) {
-					this.performSirenAction(evt.detail.publishAll);
+					this.performSirenAction(evt.detail.publishAll)
+						.then(evalStatusEntity => {
+							const id = this.getEvaluationStatusHref(evalStatusEntity);
+							this._updateEvaluationStatus(id, evalStatusEntity.properties);
+						});
 				}
 			}
 		);
@@ -298,6 +304,24 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 
 	_setWindowLocationHref(href) {
 		window.location.href = href;
+	}
+
+	_updateEvaluationStatus(id, evalStatus) {
+		for (let i = 0; i < this._data.length; i++) {
+			for (let j = 0; j < this._data[i].activities.length; j++) {
+
+				if (this._data[i].activities[j].id === id) {
+					this.set(`_data.${i}.activities.${j}.assigned`, evalStatus.assigned);
+					this.set(`_data.${i}.activities.${j}.completed`, evalStatus.completed);
+					this.set(`_data.${i}.activities.${j}.published`, evalStatus.published);
+					this.set(`_data.${i}.activities.${j}.evaluated`, evalStatus.evaluated);
+					this.set(`_data.${i}.activities.${j}.unread`, evalStatus.newsubmissions);
+					this.set(`_data.${i}.activities.${j}.resubmitted`, evalStatus.resubmissions);
+					return true;
+				}
+			}
+		}
+		return false;
 	}
 }
 window.customElements.define(D2LQuickEvalActivities.is, D2LQuickEvalActivities);

--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -200,7 +200,7 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 		const result = await Promise.all(entity.entities.map(async function(activity) {
 			const evalStatus = await this._getEvaluationStatusPromise(activity);
 			const courseName = await this._getCourseNamePromise(activity);
-			const id = this.getEvaluationStatusHref(activity);
+			const evaluationStatusHref = this.getEvaluationStatusHref(activity);
 			return {
 				courseName: courseName,
 				assigned: evalStatus.assigned,
@@ -215,7 +215,7 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 				dueDate: this._getActivityDueDate(activity),
 				activityType: this._getActivityType(activity),
 				activityNameHref: this._getActivityNameHref(activity),
-				id: id
+				evaluationStatusHref: evaluationStatusHref
 			};
 		}.bind(this)));
 		return this._groupByCourse(result);
@@ -284,8 +284,8 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 				if (result) {
 					this.performSirenAction(evt.detail.publishAll)
 						.then(evalStatusEntity => {
-							const id = this.getEvaluationStatusHref(evalStatusEntity);
-							this._updateEvaluationStatus(id, evalStatusEntity.properties);
+							const evaluationStatusHref = this.getEvaluationStatusHref(evalStatusEntity);
+							this._updateEvaluationStatus(evaluationStatusHref, evalStatusEntity.properties);
 						});
 				}
 			}
@@ -306,11 +306,11 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 		window.location.href = href;
 	}
 
-	_updateEvaluationStatus(id, evalStatus) {
+	_updateEvaluationStatus(evaluationStatusHref, evalStatus) {
 		for (let i = 0; i < this._data.length; i++) {
 			for (let j = 0; j < this._data[i].activities.length; j++) {
 
-				if (this._data[i].activities[j].id === id) {
+				if (this._data[i].activities[j].evaluationStatusHref === evaluationStatusHref) {
 					this.set(`_data.${i}.activities.${j}.assigned`, evalStatus.assigned);
 					this.set(`_data.${i}.activities.${j}.completed`, evalStatus.completed);
 					this.set(`_data.${i}.activities.${j}.published`, evalStatus.published);


### PR DESCRIPTION
Problem: After clicking publish all, the activity view displays incorrect information about the evaluation status
Solution: Update the activity view to display current data