### PR TITLE
Maboelsoudd2l/toggle different sizes

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -32,10 +32,9 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 		const quickEvalActivitiesTemplate = html`
 			<style>
 				.d2l-quick-eval-activity-list-modifiers {
-					float: right;
-				}
-				:host(:dir(rtl)) .d2l-quick-eval-activity-list-modifiers {
-					float: left;
+					display: flex;
+					margin-top: 18px;
+					width: 100%;
 				}
 				.clear {
 					clear: both;
@@ -44,6 +43,7 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 					display: inline-block;
 					width: 250px;
 					margin-left: .25rem;
+					flex: 1;
 				}
 				.d2l-quick-eval-no-submissions,
 				.d2l-quick-eval-no-criteria-results {
@@ -85,9 +85,9 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 				.d2l-body-standard {
 					@apply --d2l-body-compact-text;
 				}
-				@media (max-width: 900px) {
+				@media (min-width: 525px) {
 					.d2l-quick-eval-activity-list-modifiers {
-						margin-top: 18px;
+						width: auto;
 						float: left;
 						clear: both;
 					}
@@ -95,13 +95,14 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 						float: right;
 					}
 				}
-				@media (max-width: 525px) {
+				@media (min-width: 900px) {
 					.d2l-quick-eval-activity-list-modifiers {
-						width: 100%;
-						display: flex;
+						float: right;
+						margin-top: 0;
+						clear: none;
 					}
-					d2l-hm-search {
-						flex: 1;
+					:host(:dir(rtl)) .d2l-quick-eval-activity-list-modifiers {
+						float: left;
 					}
 				}
 			</style>

--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -85,6 +85,25 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 				.d2l-body-standard {
 					@apply --d2l-body-compact-text;
 				}
+				@media (max-width: 900px) {
+					.d2l-quick-eval-activity-list-modifiers {
+						margin-top: 18px;
+						float: left;
+						clear: both;
+					}
+					:host(:dir(rtl)) .d2l-quick-eval-activity-list-modifiers {
+						float: right;
+					}
+				}
+				@media (max-width: 525px) {
+					.d2l-quick-eval-activity-list-modifiers {
+						width: 100%;
+						display: flex;
+					}
+					d2l-hm-search {
+						flex: 1;
+					}
+				}
 			</style>
 			<div class="d2l-quick-eval-activity-list-modifiers">
 				<d2l-hm-filter

--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -33,8 +33,16 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 			<style>
 				.d2l-quick-eval-activity-list-modifiers {
 					display: flex;
-					margin-top: 18px;
+					margin-top: 0.9rem;
 					width: 100%;
+				}
+				d2l-hm-filter {
+					margin-left: -0.7rem;
+					margin-right: .25rem;
+				}
+				:host(:dir(rtl)) d2l-hm-filter {
+					margin-left: .25rem;
+					margin-right: -0.7rem;
 				}
 				.clear {
 					clear: both;
@@ -42,7 +50,6 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 				d2l-hm-search {
 					display: inline-block;
 					width: 250px;
-					margin-left: .25rem;
 					flex: 1;
 				}
 				.d2l-quick-eval-no-submissions,

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -26,10 +26,16 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 	static get template() {
 		const template = html`
 			<style>
+				.d2l-quick-eval-submissions-table-modifiers {
+					display: flex;
+					margin-top: 18px;
+					width: 100%;
+				}
 				d2l-hm-search {
 					display: inline-block;
 					width: 250px;
 					margin-left: .25rem;
+					flex: 1;
 				}
 				d2l-alert {
 					margin: auto;
@@ -56,9 +62,9 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 					display: block;
 					padding-top: 1rem;
 				}
-				@media (max-width: 900px) {
+				@media (min-width: 525px) {
 					.d2l-quick-eval-submissions-table-modifiers {
-						margin-top: 18px;
+						width: auto;
 						float: left;
 						clear: both;
 					}
@@ -66,13 +72,14 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 						float: right;
 					}
 				}
-				@media (max-width: 525px) {
+				@media (min-width: 900px) {
 					.d2l-quick-eval-submissions-table-modifiers {
-						width: 100%;
-						display: flex;
+						float: right;
+						margin-top: 0;
+						clear: none;
 					}
-					d2l-hm-search {
-						flex: 1;
+					:host(:dir(rtl)) .d2l-quick-eval-submissions-table-modifiers {
+						float: left;
 					}
 				}
 			</style>

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -56,6 +56,25 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 					display: block;
 					padding-top: 1rem;
 				}
+				@media (max-width: 900px) {
+					.d2l-quick-eval-submissions-table-modifiers {
+						margin-top: 18px;
+						float: left;
+						clear: both;
+					}
+					:host(:dir(rtl)) .d2l-quick-eval-submissions-table-modifiers {
+						float: right;
+					}
+				}
+				@media (max-width: 525px) {
+					.d2l-quick-eval-submissions-table-modifiers {
+						width: 100%;
+						display: flex;
+					}
+					d2l-hm-search {
+						flex: 1;
+					}
+				}
 			</style>
 			<div class="d2l-quick-eval-submissions-table-modifiers">
 				<d2l-hm-filter

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -28,13 +28,20 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 			<style>
 				.d2l-quick-eval-submissions-table-modifiers {
 					display: flex;
-					margin-top: 18px;
+					margin-top: 0.9rem;
 					width: 100%;
+				}
+				d2l-hm-filter {
+					margin-left: -0.7rem;
+					margin-right: .25rem;
+				}
+				:host(:dir(rtl)) d2l-hm-filter {
+					margin-left: .25rem;
+					margin-right: -0.7rem;
 				}
 				d2l-hm-search {
 					display: inline-block;
 					width: 250px;
-					margin-left: .25rem;
 					flex: 1;
 				}
 				d2l-alert {

--- a/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
@@ -12,12 +12,6 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 	static get template() {
 		const toggleTemplate = html`
 			<style>
-				:host {
-					margin: 0 -0.9rem;
-				}
-				label {
-					margin: 0 0.9rem;
-				}
 				:host button.d2l-quick-eval-view-toggle-left,
 				:host(:dir(rtl)) button.d2l-quick-eval-view-toggle-right {
 					border-top-left-radius: 0.3rem;
@@ -45,6 +39,7 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 					color: var(--d2l-color-ferrite);
 					cursor: pointer;
 					display: inline;
+					flex: 1;
 					font-family: inherit;
 					font-size: .7rem;
 					font-weight: 700;
@@ -70,20 +65,22 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 					border-color: var(--d2l-color-tungsten);
 					color: var(--d2l-color-white);
 				}
-				@media (max-width: 525px) {
+				:host {
+					width: 100%;
+					display: flex;
+				}
+				label {
+					display: none;
+				}
+				@media (min-width: 525px) {
 					:host {
-						margin: 0;
-						width: 100%;
-						display: flex;
-					}
-					button {
-						flex: 1;
+						margin: 0 -0.9rem;
+						display: block;
+						width: auto;
 					}
 					label {
-						display: none;
-					}
-					:host button.d2l-quick-eval-view-toggle-left {
-						margin-inline-start: 0;
+						margin: 0 0.9rem;
+						display: inline;
 					}
 				}
 			</style>

--- a/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
@@ -67,22 +67,35 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 					border-color: var(--d2l-color-tungsten);
 					color: var(--d2l-color-white);
 				}
+				@media (max-width: 525px) {
+					:host {
+						width: 100%;
+						display: flex;
+					}
+					button {
+						flex: 1;
+					}
+					label {
+						display: none;
+					}
+					:host button.d2l-quick-eval-view-toggle-left {
+						margin-inline-start: 0;
+					}
+				}
 			</style>
-			<div>
-				<label>[[localize('viewBy')]]</label>
-				<button
-					aria-pressed$="[[_isSelected(_viewTypes.submissions, currentSelected)]]"
-					class="d2l-quick-eval-view-toggle-left"
-					on-click="_selectSubmissions"
-					selected$="[[_isSelected(_viewTypes.submissions, currentSelected)]]"
-				>[[localize('submissions')]]</button>
-				<button
-					aria-pressed$="[[_isSelected(_viewTypes.activities, currentSelected)]]"
-					class="d2l-quick-eval-view-toggle-right"
-					on-click="_selectActivities"
-					selected$="[[_isSelected(_viewTypes.activities, currentSelected)]]"
-				>[[localize('activities')]]</button>
-			<div>
+			<label>[[localize('viewBy')]]</label>
+			<button
+				aria-pressed$="[[_isSelected(_viewTypes.submissions, currentSelected)]]"
+				class="d2l-quick-eval-view-toggle-left"
+				on-click="_selectSubmissions"
+				selected$="[[_isSelected(_viewTypes.submissions, currentSelected)]]"
+			>[[localize('submissions')]]</button>
+			<button
+				aria-pressed$="[[_isSelected(_viewTypes.activities, currentSelected)]]"
+				class="d2l-quick-eval-view-toggle-right"
+				on-click="_selectActivities"
+				selected$="[[_isSelected(_viewTypes.activities, currentSelected)]]"
+			>[[localize('activities')]]</button>
 		`;
 		toggleTemplate.setAttribute('strip-whitespace', 'strip-whitespace');
 		return toggleTemplate;

--- a/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
@@ -12,6 +12,12 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 	static get template() {
 		const toggleTemplate = html`
 			<style>
+				:host {
+					margin: 0 -0.9rem;
+				}
+				label {
+					margin: 0 0.9rem;
+				}
 				:host button.d2l-quick-eval-view-toggle-left,
 				:host(:dir(rtl)) button.d2l-quick-eval-view-toggle-right {
 					border-top-left-radius: 0.3rem;
@@ -20,9 +26,6 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 					border-top-right-radius: 0rem;
 					border-bottom-right-radius: 0;
 					border-left-color: var(--d2l-color-mica);
-				}
-				:host button.d2l-quick-eval-view-toggle-left {
-					margin-inline-start: 0.9rem;
 				}
 				:host button.d2l-quick-eval-view-toggle-right,
 				:host(:dir(rtl)) button.d2l-quick-eval-view-toggle-left {
@@ -69,6 +72,7 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 				}
 				@media (max-width: 525px) {
 					:host {
+						margin: 0;
 						width: 100%;
 						display: flex;
 					}

--- a/components/d2l-quick-eval/d2l-quick-eval.js
+++ b/components/d2l-quick-eval/d2l-quick-eval.js
@@ -20,14 +20,9 @@ class D2LQuickEval extends  QuickEvalLocalize(PolymerElement) {
 					@apply --d2l-heading-1;
 					margin: 0;
 				}
-				d2l-quick-eval-view-toggle {
-					clear: both;
-					float: left;
-				}
 				.d2l-quick-eval-header {
 					float: left;
 				}
-				:host(:dir(rtl)) d2l-quick-eval-view-toggle,
 				:host(:dir(rtl)) .d2l-quick-eval-header-with-toggle {
 					float: right;
 				}
@@ -37,6 +32,15 @@ class D2LQuickEval extends  QuickEvalLocalize(PolymerElement) {
 				}
 				[hidden] {
 					display: none;
+				}
+				@media (min-width: 525px) {
+					d2l-quick-eval-view-toggle {
+						clear: both;
+						float: left;
+					}
+					:host(:dir(rtl)) d2l-quick-eval-view-toggle {
+						float: right;
+					}
 				}
 			</style>
 			<template is="dom-if" if="[[headerText]]">


### PR DESCRIPTION
Checked rtl and different browsers (chrome, safari, firefox, osx-edge).
This is what it looks like in different sizes:
![Screen Shot 2019-08-06 at 2 47 35 PM](https://user-images.githubusercontent.com/52468201/62568059-73bf6000-b85a-11e9-8442-07b36b43eb20.png)
![Screen Shot 2019-08-06 at 2 47 16 PM](https://user-images.githubusercontent.com/52468201/62568060-73bf6000-b85a-11e9-931e-a14d96cbeb1b.png)
![Screen Shot 2019-08-06 at 2 46 56 PM](https://user-images.githubusercontent.com/52468201/62568061-73bf6000-b85a-11e9-99ce-b38a88aeb5fe.png)

