### PR TITLE
US109177 - disable publish all button if api does not allow it

### DIFF
--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
@@ -219,17 +219,18 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 							hidden$="[[!_showUnreadSubmissions(unread, resubmitted)]]"></d2l-quick-eval-activity-card-unread-submissions>
 						<div class="d2l-quick-eval-card-actions">
 							<d2l-quick-eval-activity-card-items visible-on-ancestor small>
-								<d2l-quick-eval-activity-card-action-button 
-									icon-name="evaluate-all" 
+								<d2l-quick-eval-activity-card-action-button
+									icon-name="evaluate-all"
 									text="[[localize('evaluateAll')]]"></d2l-quick-eval-activity-card-action-button>
-								<d2l-quick-eval-activity-card-action-button 
-									icon-name="view-submission-list" 
+								<d2l-quick-eval-activity-card-action-button
+									icon-name="view-submission-list"
 									text="[[localize('submissionList')]]"
 									on-click="_dispatchViewSubmissionListEvent"></d2l-quick-eval-activity-card-action-button>
-								<d2l-quick-eval-activity-card-action-button 
-									icon-name="publish-all" 
+								<d2l-quick-eval-activity-card-action-button
+									icon-name="publish-all"
 									text="[[localize('publishAll')]]"
-									on-click="_dispatchPublishAllEvent"></d2l-quick-eval-activity-card-action-button>
+									on-click="_dispatchPublishAllEvent"
+									disabled$="[[_disablePublishAllButton(publishAll)]]"></d2l-quick-eval-activity-card-action-button>
 							</d2l-quick-eval-activity-card-items>
 						</div>
 					</div>
@@ -366,6 +367,10 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 			return this.formatDateTime(new Date(dueDate));
 		}
 		return '';
+	}
+
+	_disablePublishAllButton() {
+		return !this.publishAll;
 	}
 }
 


### PR DESCRIPTION
Problem: the publish all button is always enabled, but only certain activity types and permission sets allow it
Solution: disable the publish all button if the api does not allow it