### PR TITLE
US108655 - wire up two dots

### DIFF
--- a/components/d2l-quick-eval/activities-list/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/activities-list/d2l-quick-eval-activities-list.js
@@ -115,7 +115,7 @@ class D2LQuickEvalActivitiesList extends QuickEvalLocalize(PolymerElement) {
 
 	_handleOnMouseenter(e) {
 		if (e && e.path && e.path.length && e.path[0].tagName.toLowerCase() === 'd2l-quick-eval-activity-card') {
-			const focused = this.shadowRoot.querySelector('d2l-quick-eval-activity-card:focus-within');
+			const focused = this.shadowRoot.querySelector('d2l-quick-eval-activity-card[focus-within]');
 			if (e.path[0] !== focused) {
 				document.activeElement.blur();
 			}
@@ -124,7 +124,7 @@ class D2LQuickEvalActivitiesList extends QuickEvalLocalize(PolymerElement) {
 
 	_handleOnMouseleave(e) {
 		if (e && e.path && e.path.length) {
-			const focused = this.shadowRoot.querySelector('d2l-quick-eval-activity-card:focus-within');
+			const focused = this.shadowRoot.querySelector('d2l-quick-eval-activity-card[focus-within]');
 			if (e.path[0] === focused) {
 				document.activeElement.blur();
 			}

--- a/components/d2l-quick-eval/activities-list/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/activities-list/d2l-quick-eval-activities-list.js
@@ -70,7 +70,10 @@ class D2LQuickEvalActivitiesList extends QuickEvalLocalize(PolymerElement) {
 										due-date="[[a.dueDate]]"
 										activity-type="[[a.activityType]]"
 										activity-name-href="[[a.activityNameHref]]"
-										token="[[token]]"></d2l-quick-eval-activity-card>
+										activity-name="[[a.activityName]]"
+										token="[[token]]"
+										on-mouseenter="_handleOnMouseenter"
+										on-mouseleave="_handleOnMouseleave"></d2l-quick-eval-activity-card>
 										<div class="d2l-quick-eval-activities-list-card-spacer d2l-quick-eval-activities-list-card-spacer-border"></div>
 									</li>
 								</template>
@@ -108,6 +111,24 @@ class D2LQuickEvalActivitiesList extends QuickEvalLocalize(PolymerElement) {
 				type: String
 			}
 		};
+	}
+
+	_handleOnMouseenter(e) {
+		if (e && e.path && e.path.length && e.path[0].tagName.toLowerCase() === 'd2l-quick-eval-activity-card') {
+			const focused = this.shadowRoot.querySelector('d2l-quick-eval-activity-card:focus-within');
+			if (e.path[0] !== focused) {
+				document.activeElement.blur();
+			}
+		}
+	}
+
+	_handleOnMouseleave(e) {
+		if (e && e.path && e.path.length) {
+			const focused = this.shadowRoot.querySelector('d2l-quick-eval-activity-card:focus-within');
+			if (e.path[0] === focused) {
+				document.activeElement.blur();
+			}
+		}
 	}
 }
 

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-action-button.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-action-button.js
@@ -149,6 +149,10 @@ class D2LQuickEvalActivityCardActionButton extends mixinBehaviors(
 	_computeLabelledbyId() {
 		return D2L.Id.getUniqueId();
 	}
+
+	focus() {
+		this.shadowRoot.querySelector('button').focus();
+	}
 }
 
 window.customElements.define('d2l-quick-eval-activity-card-action-button', D2LQuickEvalActivityCardActionButton);

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
@@ -324,6 +324,12 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 			_hovered: {
 				type: Boolean,
 				value: false
+			},
+			// Becaue IE11 and Edge don't have :focus-within selector.
+			focusWithin: {
+				type: Boolean,
+				value: false,
+				reflectToAttribute: true
 			}
 		};
 	}
@@ -456,10 +462,12 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 	}
 
 	_handleOnFocusin() {
+		this.focusWithin = true;
 		this._indicatorPressed = 'true';
 	}
 
 	_handleOnFocusout() {
+		this.focusWithin = false;
 		if (!this._hovered) {
 			this._indicatorPressed = 'false';
 		}

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
@@ -169,19 +169,16 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 				[hidden] {
 					display: none;
 				}
-				.d2l-quick-eval-card:hover .d2l-quick-eval-activity-card-hovered-on,
-				.d2l-quick-eval-card:focus-within .d2l-quick-eval-activity-card-hovered-on,
-				.d2l-quick-eval-activity-card-hovered-off {
+				button[aria-pressed="true"] .d2l-quick-eval-activity-card-hovered-on,
+				button[aria-pressed="false"] .d2l-quick-eval-activity-card-hovered-off {
 					fill: var(--d2l-color-tungsten);
 				}
-				.d2l-quick-eval-card:hover .d2l-quick-eval-activity-card-hovered-off,
-				.d2l-quick-eval-card:focus-within .d2l-quick-eval-activity-card-hovered-off,
-				.d2l-quick-eval-activity-card-hovered-on {
+				button[aria-pressed="true"] .d2l-quick-eval-activity-card-hovered-off,
+				button[aria-pressed="false"] .d2l-quick-eval-activity-card-hovered-on {
 					fill: transparent;
 				}
 				button {
 					background-color: white;
-					outline: none;
 					border: none;
 					width: 100%;
 					height: 100%;
@@ -191,7 +188,12 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 				}
 
 			</style>
-			<div class="d2l-quick-eval-card d2l-visible-on-ancestor-target">
+			<div
+				class="d2l-quick-eval-card d2l-visible-on-ancestor-target"
+				on-mouseenter="_handleOnMouseenter"
+				on-mouseleave="_handleOnMouseleave"
+				on-focusin="_handleOnFocusin"
+				on-focusout="_handleOnFocusout">
 				<div class="d2l-quick-eval-card-titles">
 					<h3 class="d2l-activity-name-wrapper">
 						<d2l-activity-name href="[[activityNameHref]]" token="[[token]]"></d2l-activity-name>
@@ -237,12 +239,16 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 							</d2l-quick-eval-activity-card-items>
 						</div>
 					</div>
-					<div class="d2l-quick-eval-card-indicator">
+					<button
+						class="d2l-quick-eval-card-indicator"
+						on-click="_handleIndicatorToggle"
+						aria-label$="[[_computeIndicatorLabel(activityName)]]"
+						aria-pressed$="[[_indicatorPressed]]">
 						<svg width="12px" height="33px" viewBox="0 0 12 33">
 							<circle class="d2l-quick-eval-activity-card-hovered-off" stroke-width="2" cx="5.5" cy="5.5" r="4.5"></circle>
 							<circle class="d2l-quick-eval-activity-card-hovered-on" stroke-width="2" cx="5.5" cy="26.5" r="4.5"></circle>
 						</svg>
-					</div>
+					</button>
 				</div>
 			</div>
 		`;
@@ -307,6 +313,17 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 			activityType: {
 				type: String,
 				value: ''
+			},
+			activityName: {
+				type: String
+			},
+			_indicatorPressed: {
+				type: String,
+				value: 'false'
+			},
+			_hovered: {
+				type: Boolean,
+				value: false
 			}
 		};
 	}
@@ -408,6 +425,44 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 			return this.formatDateTime(new Date(dueDate));
 		}
 		return '';
+	}
+
+	_computeIndicatorLabel(activityName) {
+		return this.localize('toggleIndicatorLabel', 'target', activityName);
+	}
+
+	_handleIndicatorToggle() {
+		const attr = 'd2l-visible-on-ancestor-hide';
+		const actions = this.shadowRoot.querySelector('.d2l-quick-eval-card-actions d2l-quick-eval-activity-card-items');
+		if (actions.hasAttribute(attr)) {
+			actions.removeAttribute(attr);
+			const firstButton = this.shadowRoot.querySelector('d2l-quick-eval-activity-card-action-button');
+			firstButton.focus();
+			this._indicatorPressed = 'true';
+		} else {
+			actions.setAttribute(attr, attr);
+			this._indicatorPressed = 'false';
+		}
+	}
+
+	_handleOnMouseenter() {
+		this._indicatorPressed = 'true';
+		this._hovered = true;
+	}
+
+	_handleOnMouseleave() {
+		this._indicatorPressed = 'false';
+		this._hovered = false;
+	}
+
+	_handleOnFocusin() {
+		this._indicatorPressed = 'true';
+	}
+
+	_handleOnFocusout() {
+		if (!this._hovered) {
+			this._indicatorPressed = 'false';
+		}
 	}
 
 	_disablePublishAllButton() {

--- a/components/d2l-quick-eval/behaviors/d2l-quick-eval-siren-helper-behavior.js
+++ b/components/d2l-quick-eval/behaviors/d2l-quick-eval-siren-helper-behavior.js
@@ -196,6 +196,29 @@ D2L.PolymerBehaviors.QuickEval.D2LQuickEvalSirenHelperBehaviorImpl = {
 		return '';
 	},
 
+	_getActivityName: function(entity) {
+		return this._followHref(this._getActivityNameHref(entity))
+			.then(function(a) {
+				let rel;
+				if (a.entity.hasClass(Classes.activities.userQuizAttemptActivity) || a.entity.hasClass(Classes.activities.userQuizActivity)) {
+					rel = Rels.quiz;
+				} else if (a.entity.hasClass(Classes.activities.userAssignmentActivity)) {
+					rel = Rels.assignment;
+				} else if (a.entity.hasClass(Classes.activities.userDiscussionActivity)) {
+					rel = Rels.Discussions.topic;
+				} else {
+					return Promise.resolve();
+				}
+
+				return this._followLink(a.entity, rel);
+			}.bind(this))
+			.then(function(n) {
+				if (n && n.entity && n.entity.properties) {
+					return n.entity.properties.name;
+				}
+			});
+	},
+
 	_getSubmissionDate: function(entity) {
 		if (entity.hasSubEntityByClass('localized-formatted-date')) {
 			const i = entity.getSubEntityByClass('localized-formatted-date');

--- a/components/d2l-quick-eval/build/lang/en.js
+++ b/components/d2l-quick-eval/build/lang/en.js
@@ -49,6 +49,7 @@ const LangEnImpl = (superClass) => class extends superClass {
 			'submissionList': 'Submission List',
 			'submissions': 'Submissions',
 			'tableTitle': 'List of unevaluated Learner submissions from across courses and tools',
+			'toggleIndicatorLabel': 'Perform Actions on {target}',
 			'tryAgain': 'Try Again',
 			'newSubmissions': 'New Submissions',
 			'newSubmissionDetails': '{newNum} new, {resub} resubmissions',
@@ -63,4 +64,3 @@ const LangEnImpl = (superClass) => class extends superClass {
 };
 
 export const LangEn = dedupingMixin(LangEnImpl);
-

--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -235,6 +235,8 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 		const result = await Promise.all(entity.entities.map(async function(activity) {
 			const evalStatus = await this._getEvaluationStatusPromise(activity);
 			const courseName = await this._getCourseNamePromise(activity);
+			const activityNameHref = this._getActivityNameHref(activity);
+			const activityName = await this._getActivityName(activity);
 			const evaluationStatusHref = this.getEvaluationStatusHref(activity);
 			return {
 				courseName: courseName,
@@ -251,7 +253,8 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 				key: this._getOrgHref(activity),
 				dueDate: this._getActivityDueDate(activity),
 				activityType: this._getActivityType(activity),
-				activityNameHref: this._getActivityNameHref(activity),
+				activityNameHref: activityNameHref,
+				activityName: activityName,
 				evaluationStatusHref: evaluationStatusHref
 			};
 		}.bind(this)));

--- a/components/d2l-quick-eval/lang/en.json
+++ b/components/d2l-quick-eval/lang/en.json
@@ -41,6 +41,7 @@
   "submissionList": "Submission List",
   "submissions": "Submissions",
   "tableTitle": "List of unevaluated Learner submissions from across courses and tools",
+  "toggleIndicatorLabel": "Perform Actions on {target}",
   "tryAgain": "Try Again",
   "newSubmissions": "New Submissions",
   "newSubmissionDetails": "{newNum} new, {resub} resubmissions",


### PR DESCRIPTION
I'm pushing this on behalf of Carol who is locked out of her GitHub account for now. Her comments:

Okay, so these are the design requirements that I'm attempting to fulfill with this PR:
State A is showing the action buttons and having the indicator aria-pressed="true" with the bottom circle filled in. State B is showing the speedometers and having the indicator aria-pressed="false" with the top circle filled in and none of the action buttons focused.
1. On hover enter, State A. If any other cards are in state A, change them to state B.
2. On hover leave, clear focus if it's inside the card just left and change to state B.
3. On tab/focus enter, state A
4. On tab/focus leave, state A if hover is still within the card, otherwise state B.
5. Clicking on the indicator button will toggle between State A and State B. If going from B -> A, the first action button in the card is focused.
6. The indicator button should have an aria-labelledby that describes its function to screen readers, which includes the name of the activity that the card is for.

We'll need to add in one localization key/value, but I don't fancy sending you 32 localization files now