### PR TITLE
clears options and searches on hidden

### DIFF
--- a/components/d2l-quick-eval/behaviors/d2l-hm-filter-behavior.js
+++ b/components/d2l-quick-eval/behaviors/d2l-hm-filter-behavior.js
@@ -64,6 +64,13 @@ D2L.PolymerBehaviors.QuickEval.D2LHMFilterBehaviourImpl = {
 		this._clearErrors();
 	},
 
+	clearFilters: async function() {
+		this.filtersLoading = true;
+		const filter = this.shadowRoot.querySelector('d2l-hm-filter');
+		this.entity = await filter._clearAllOptions();
+		this.filtersLoading = false;
+	},
+
 	_onFilterError: function(e) {
 		this.filtersLoading = false;
 		this.filterError = e.detail;

--- a/components/d2l-quick-eval/behaviors/d2l-hm-search-behavior.js
+++ b/components/d2l-quick-eval/behaviors/d2l-hm-search-behavior.js
@@ -57,6 +57,13 @@ D2L.PolymerBehaviors.QuickEval.D2LHMSearchBehaviourImpl = {
 		this._clearErrors();
 	},
 
+	clearSearchResults: function() {
+		this.searchLoading = true;
+		const search = this.shadowRoot.querySelector('d2l-hm-search');
+		search.clearSearch();
+		this.searchLoading = false;
+	},
+
 	onSearchError: function(e) {
 		this.searchLoading = false;
 		this.searchError = e.detail;

--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -192,12 +192,16 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 			_showLoadingSkeleton: {
 				type: Boolean,
 				computed: '_computeShowLoadingSkeleton(_loading, filtersLoading, searchLoading)'
+			},
+			hidden: {
+				type: Boolean
 			}
 		};
 	}
 	static get observers() {
 		return [
 			'_loadData(entity)',
+			'_clearAllOnHidden(hidden)',
 		];
 	}
 
@@ -252,6 +256,19 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 		return this._groupByCourse(result);
 	}
 
+	async _clearAllOnHidden(hidden) {
+		if (hidden) {
+			// NOTE: _clearFilterResults has to be before _clearSearchResults or else
+			// it doesn't effectively clears the filters and searches
+			if (this.filterApplied) {
+				this.entity = await this._clearFilterResults();
+			}
+			if (this.searchApplied) {
+				await this._clearSearchResults();
+			}
+		}
+	}
+
 	_groupByCourse(act) {
 		if (act) {
 			const grouped = act.reduce((acts, a) => {
@@ -274,6 +291,11 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 	_clearSearchResults() {
 		const search = this.shadowRoot.querySelector('d2l-hm-search');
 		search.clearSearch();
+	}
+
+	async _clearFilterResults() {
+		const filter = this.shadowRoot.querySelector('d2l-hm-filter');
+		return await filter._clearAllOptions();
 	}
 
 	_updateSearchResultsCount(courses) {

--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -197,7 +197,7 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 			},
 			hidden: {
 				type: Boolean
-      },
+			},
 			_displayPublishAllToast: {
 				type: Boolean,
 				value: false

--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -137,7 +137,7 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 			<d2l-quick-eval-search-results-summary-container
 				search-results-count="[[_searchResultsCount]]"
 				hidden$="[[!searchApplied]]"
-				on-d2l-quick-eval-search-results-summary-container-clear-search="_clearSearchResults">
+				on-d2l-quick-eval-search-results-summary-container-clear-search="clearSearchResults">
 			</d2l-quick-eval-search-results-summary-container>
 			<div class="d2l-quick-eval-no-submissions" hidden$="[[!_shouldShowNoSubmissions(_data, _loading, filterApplied, searchApplied)]]">
 				<d2l-quick-eval-no-submissions-image></d2l-quick-eval-no-submissions-image>
@@ -264,13 +264,13 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 
 	async _clearAllOnHidden(hidden) {
 		if (hidden) {
-			// NOTE: _clearFilterResults has to be before _clearSearchResults or else
+			// NOTE: clearFilters has to be before clearSearchResults or else
 			// it doesn't effectively clears the filters and searches
 			if (this.filterApplied) {
-				this.entity = await this._clearFilterResults();
+				await this.clearFilters();
 			}
 			if (this.searchApplied) {
-				await this._clearSearchResults();
+				await this.clearSearchResults();
 			}
 		}
 	}
@@ -292,16 +292,6 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 	_clearErrors() {
 		this.searchError = null;
 		this.filterError = null;
-	}
-
-	_clearSearchResults() {
-		const search = this.shadowRoot.querySelector('d2l-hm-search');
-		search.clearSearch();
-	}
-
-	async _clearFilterResults() {
-		const filter = this.shadowRoot.querySelector('d2l-hm-filter');
-		return await filter._clearAllOptions();
 	}
 
 	_updateSearchResultsCount(courses) {

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -245,6 +245,9 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 			_showLoadingSkeleton: {
 				type: Boolean,
 				computed: '_computeShowLoadingSkeleton(_loading, filtersLoading, searchLoading)'
+			},
+			hidden: {
+				type: Boolean
 			}
 		};
 	}
@@ -254,7 +257,8 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 			'_loadData(entity)',
 			'_handleSorts(entity)',
 			'_onFilterErrorChange(filterError)',
-			'_onSearchErrorChange(searchError)'
+			'_onSearchErrorChange(searchError)',
+			'_clearAllOnHidden(hidden)'
 		];
 	}
 
@@ -358,6 +362,19 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 		return result;
 	}
 
+	async _clearAllOnHidden(hidden) {
+		if (hidden) {
+			// NOTE: _clearFilterResults has to be before _clearSearchResults or else
+			// it doesn't effectively clears the filters and searches
+			if (this.filterApplied) {
+				this.entity = await this._clearFilterResults();
+			}
+			if (this.searchApplied) {
+				await this._clearSearchResults();
+			}
+		}
+	}
+
 	_handleSorts(entity) {
 		// entity is null on initial load
 		if (!entity) {
@@ -453,6 +470,11 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 	_clearSearchResults() {
 		const search = this.shadowRoot.querySelector('d2l-hm-search');
 		search.clearSearch();
+	}
+
+	async _clearFilterResults() {
+		const filter = this.shadowRoot.querySelector('d2l-hm-filter');
+		return await filter._clearAllOptions();
 	}
 
 	_computeNumberOfActivitiesToShow(data, currentNumberOfActivitiesShown) {

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -117,7 +117,7 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 				search-results-count="[[_searchResultsCount]]"
 				more-results="[[_moreSearchResults]]"
 				hidden$="[[!_searchResultsMessageEnabled(searchApplied, searchEnabled)]]"
-				on-d2l-quick-eval-search-results-summary-container-clear-search="_clearSearchResults">
+				on-d2l-quick-eval-search-results-summary-container-clear-search="clearSearchResults">
 			</d2l-quick-eval-search-results-summary-container>
 			<d2l-quick-eval-submissions-table
 				href="[[href]]"
@@ -364,13 +364,13 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 
 	async _clearAllOnHidden(hidden) {
 		if (hidden) {
-			// NOTE: _clearFilterResults has to be before _clearSearchResults or else
+			// NOTE: clearFilters has to be before clearSearchResults or else
 			// it doesn't effectively clears the filters and searches
 			if (this.filterApplied) {
-				this.entity = await this._clearFilterResults();
+				await this.clearFilters();
 			}
 			if (this.searchApplied) {
-				await this._clearSearchResults();
+				await this.clearSearchResults();
 			}
 		}
 	}
@@ -465,16 +465,6 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 
 	_searchResultsMessageEnabled() {
 		return this.searchApplied && this.searchEnabled;
-	}
-
-	_clearSearchResults() {
-		const search = this.shadowRoot.querySelector('d2l-hm-search');
-		search.clearSearch();
-	}
-
-	async _clearFilterResults() {
-		const filter = this.shadowRoot.querySelector('d2l-hm-filter');
-		return await filter._clearAllOptions();
 	}
 
 	_computeNumberOfActivitiesToShow(data, currentNumberOfActivitiesShown) {


### PR DESCRIPTION
Should clear search and filter when switching toggles from submissions to activities and vice-versa.