### PR TITLE
Display activity name in toast

### DIFF
--- a/components/d2l-quick-eval/build/lang/ar.js
+++ b/components/d2l-quick-eval/build/lang/ar.js
@@ -38,6 +38,8 @@ const LangArImpl = (superClass) => class extends superClass {
 			'noSubmissions': 'لا تتوفر أي عمليات إرسال تتطلب اهتمامك.',
 			'publishAll': 'نشر الكل',
 			'publishAllConfirmDialogMessage': '{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?',
+			'publishAllToastMessage': '{activityName} evaluations published successfully.',
+			'publishAllToastMessageTruncated': '{truncatedActivityName}… evaluations published successfully.',
 			'published': 'منشور',
 			'quiz': 'الاختبار',
 			'search': 'بحث',

--- a/components/d2l-quick-eval/build/lang/da-dk.js
+++ b/components/d2l-quick-eval/build/lang/da-dk.js
@@ -38,6 +38,8 @@ const LangDadkImpl = (superClass) => class extends superClass {
 			'noSubmissions': 'Der er ingen afleveringer, der kræver din opmærksomhed.',
 			'publishAll': 'Publish All',
 			'publishAllConfirmDialogMessage': '{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?',
+			'publishAllToastMessage': '{activityName} evaluations published successfully.',
+			'publishAllToastMessageTruncated': '{truncatedActivityName}… evaluations published successfully.',
 			'published': 'Published',
 			'quiz': 'Quiz',
 			'search': 'Søg',

--- a/components/d2l-quick-eval/build/lang/de.js
+++ b/components/d2l-quick-eval/build/lang/de.js
@@ -38,6 +38,8 @@ const LangDeImpl = (superClass) => class extends superClass {
 			'noSubmissions': 'Es gibt keine Abgaben, die Ihre Aufmerksamkeit erfordern.',
 			'publishAll': 'Alle veröffentlichen',
 			'publishAllConfirmDialogMessage': '{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?',
+			'publishAllToastMessage': '{activityName} evaluations published successfully.',
+			'publishAllToastMessageTruncated': '{truncatedActivityName}… evaluations published successfully.',
 			'published': 'Veröffentlicht',
 			'quiz': 'Test',
 			'search': 'Suchen',

--- a/components/d2l-quick-eval/build/lang/en.js
+++ b/components/d2l-quick-eval/build/lang/en.js
@@ -38,6 +38,8 @@ const LangEnImpl = (superClass) => class extends superClass {
 			'noSubmissions': 'There are no submissions that need your attention.',
 			'publishAll': 'Publish All',
 			'publishAllConfirmDialogMessage': '{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?',
+			'publishAllToastMessage': '{activityName} evaluations published successfully.',
+			'publishAllToastMessageTruncated': '{truncatedActivityName}… evaluations published successfully.',
 			'published': 'Published',
 			'quiz': 'Quiz',
 			'search': 'Search',
@@ -64,3 +66,4 @@ const LangEnImpl = (superClass) => class extends superClass {
 };
 
 export const LangEn = dedupingMixin(LangEnImpl);
+

--- a/components/d2l-quick-eval/build/lang/es.js
+++ b/components/d2l-quick-eval/build/lang/es.js
@@ -38,6 +38,8 @@ const LangEsImpl = (superClass) => class extends superClass {
 			'noSubmissions': 'No hay envíos que requieran su atención.',
 			'publishAll': 'Publicar todo',
 			'publishAllConfirmDialogMessage': '{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?',
+			'publishAllToastMessage': '{activityName} evaluations published successfully.',
+			'publishAllToastMessageTruncated': '{truncatedActivityName}… evaluations published successfully.',
 			'published': 'Publicado',
 			'quiz': 'Cuestionario',
 			'search': 'Buscar',

--- a/components/d2l-quick-eval/build/lang/fi.js
+++ b/components/d2l-quick-eval/build/lang/fi.js
@@ -38,6 +38,8 @@ const LangFiImpl = (superClass) => class extends superClass {
 			'noSubmissions': 'There are no submissions that need your attention.',
 			'publishAll': 'Publish All',
 			'publishAllConfirmDialogMessage': '{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?',
+			'publishAllToastMessage': '{activityName} evaluations published successfully.',
+			'publishAllToastMessageTruncated': '{truncatedActivityName}… evaluations published successfully.',
 			'published': 'Published',
 			'quiz': 'Quiz',
 			'search': 'Search',

--- a/components/d2l-quick-eval/build/lang/fr-fr.js
+++ b/components/d2l-quick-eval/build/lang/fr-fr.js
@@ -38,6 +38,8 @@ const LangFrfrImpl = (superClass) => class extends superClass {
 			'noSubmissions': 'Aucune soumission ne nécessite votre attention.',
 			'publishAll': 'Publish All',
 			'publishAllConfirmDialogMessage': '{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?',
+			'publishAllToastMessage': '{activityName} evaluations published successfully.',
+			'publishAllToastMessageTruncated': '{truncatedActivityName}… evaluations published successfully.',
 			'published': 'Published',
 			'quiz': 'Quiz',
 			'search': 'Rechercher',

--- a/components/d2l-quick-eval/build/lang/fr.js
+++ b/components/d2l-quick-eval/build/lang/fr.js
@@ -38,6 +38,8 @@ const LangFrImpl = (superClass) => class extends superClass {
 			'noSubmissions': 'Aucune soumission ne requiert votre attention.',
 			'publishAll': 'Tout publier',
 			'publishAllConfirmDialogMessage': '{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?',
+			'publishAllToastMessage': '{activityName} evaluations published successfully.',
+			'publishAllToastMessageTruncated': '{truncatedActivityName}… evaluations published successfully.',
 			'published': 'Publié',
 			'quiz': 'Questionnaire',
 			'search': 'Rechercher',

--- a/components/d2l-quick-eval/build/lang/ja.js
+++ b/components/d2l-quick-eval/build/lang/ja.js
@@ -38,6 +38,8 @@ const LangJaImpl = (superClass) => class extends superClass {
 			'noSubmissions': '確認が必要な送信物はありません。',
 			'publishAll': 'すべて公開',
 			'publishAllConfirmDialogMessage': '{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?',
+			'publishAllToastMessage': '{activityName} evaluations published successfully.',
+			'publishAllToastMessageTruncated': '{truncatedActivityName}… evaluations published successfully.',
 			'published': '公開済み',
 			'quiz': 'クイズ',
 			'search': '検索',

--- a/components/d2l-quick-eval/build/lang/ko.js
+++ b/components/d2l-quick-eval/build/lang/ko.js
@@ -38,6 +38,8 @@ const LangKoImpl = (superClass) => class extends superClass {
 			'noSubmissions': '주목할 제출 항목이 없습니다.',
 			'publishAll': '모두 게시',
 			'publishAllConfirmDialogMessage': '{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?',
+			'publishAllToastMessage': '{activityName} evaluations published successfully.',
+			'publishAllToastMessageTruncated': '{truncatedActivityName}… evaluations published successfully.',
 			'published': '게시됨',
 			'quiz': '퀴즈',
 			'search': '검색',

--- a/components/d2l-quick-eval/build/lang/nl.js
+++ b/components/d2l-quick-eval/build/lang/nl.js
@@ -38,6 +38,8 @@ const LangNlImpl = (superClass) => class extends superClass {
 			'noSubmissions': 'Er zijn geen indieningen via postvak die uw aandacht nodig hebben.',
 			'publishAll': 'Alles publiceren',
 			'publishAllConfirmDialogMessage': '{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?',
+			'publishAllToastMessage': '{activityName} evaluations published successfully.',
+			'publishAllToastMessageTruncated': '{truncatedActivityName}… evaluations published successfully.',
 			'published': 'Gepubliceerd',
 			'quiz': 'Test',
 			'search': 'Zoeken',

--- a/components/d2l-quick-eval/build/lang/pt.js
+++ b/components/d2l-quick-eval/build/lang/pt.js
@@ -38,6 +38,8 @@ const LangPtImpl = (superClass) => class extends superClass {
 			'noSubmissions': 'Não há envios que precisem de sua atenção.',
 			'publishAll': 'Publicar Tudo',
 			'publishAllConfirmDialogMessage': '{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?',
+			'publishAllToastMessage': '{activityName} evaluations published successfully.',
+			'publishAllToastMessageTruncated': '{truncatedActivityName}… evaluations published successfully.',
 			'published': 'Publicado',
 			'quiz': 'Questionário',
 			'search': 'Pesquisar',

--- a/components/d2l-quick-eval/build/lang/sv.js
+++ b/components/d2l-quick-eval/build/lang/sv.js
@@ -38,6 +38,8 @@ const LangSvImpl = (superClass) => class extends superClass {
 			'noSubmissions': 'Det finns inga inlämningar som du behöver utföra någon åtgärd på.',
 			'publishAll': 'Publicera alla',
 			'publishAllConfirmDialogMessage': '{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?',
+			'publishAllToastMessage': '{activityName} evaluations published successfully.',
+			'publishAllToastMessageTruncated': '{truncatedActivityName}… evaluations published successfully.',
 			'published': 'Publicerad',
 			'quiz': 'Förhör',
 			'search': 'Sökning',

--- a/components/d2l-quick-eval/build/lang/tr.js
+++ b/components/d2l-quick-eval/build/lang/tr.js
@@ -38,6 +38,8 @@ const LangTrImpl = (superClass) => class extends superClass {
 			'noSubmissions': 'İlgilenmeniz gereken gönderi yok.',
 			'publishAll': 'Tümünü Yayımla',
 			'publishAllConfirmDialogMessage': '{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?',
+			'publishAllToastMessage': '{activityName} evaluations published successfully.',
+			'publishAllToastMessageTruncated': '{truncatedActivityName}… evaluations published successfully.',
 			'published': 'Yayınlandı',
 			'quiz': 'Sınav',
 			'search': 'Ara',

--- a/components/d2l-quick-eval/build/lang/zh-tw.js
+++ b/components/d2l-quick-eval/build/lang/zh-tw.js
@@ -38,6 +38,8 @@ const LangZhtwImpl = (superClass) => class extends superClass {
 			'noSubmissions': '沒有提交項目需要您注意。',
 			'publishAll': '全部發佈',
 			'publishAllConfirmDialogMessage': '{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?',
+			'publishAllToastMessage': '{activityName} evaluations published successfully.',
+			'publishAllToastMessageTruncated': '{truncatedActivityName}… evaluations published successfully.',
 			'published': '已發佈',
 			'quiz': '測驗',
 			'search': '搜尋',

--- a/components/d2l-quick-eval/build/lang/zh.js
+++ b/components/d2l-quick-eval/build/lang/zh.js
@@ -38,6 +38,8 @@ const LangZhImpl = (superClass) => class extends superClass {
 			'noSubmissions': '没有需要您注意的提交。',
 			'publishAll': '全部发布',
 			'publishAllConfirmDialogMessage': '{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?',
+			'publishAllToastMessage': '{activityName} evaluations published successfully.',
+			'publishAllToastMessageTruncated': '{truncatedActivityName}… evaluations published successfully.',
 			'published': '已发布',
 			'quiz': '测验',
 			'search': '搜索',

--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -407,9 +407,9 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 		const maxLength = 48;
 
 		if (toast.activityName.length > maxLength) {
-			return this.localize('publishAllToastMessageTruncated', 'truncatedActivityName', toast.activityName.substring(0, maxLength))
+			return this.localize('publishAllToastMessageTruncated', 'truncatedActivityName', toast.activityName.substring(0, maxLength));
 		}
-		return this.localize('publishAllToastMessage', 'activityName', toast.activityName)
+		return this.localize('publishAllToastMessage', 'activityName', toast.activityName);
 	}
 }
 window.customElements.define(D2LQuickEvalActivities.is, D2LQuickEvalActivities);

--- a/components/d2l-quick-eval/lang/ar.json
+++ b/components/d2l-quick-eval/lang/ar.json
@@ -30,6 +30,8 @@
    "noSubmissions" : "لا تتوفر أي عمليات إرسال تتطلب اهتمامك.",
    "publishAll" : "نشر الكل",
    "publishAllConfirmDialogMessage": "{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?",
+   "publishAllToastMessage" : "{activityName} evaluations published successfully.",
+   "publishAllToastMessageTruncated" : "{truncatedActivityName}… evaluations published successfully.",
    "published" : "منشور",
    "quiz" : "الاختبار",
    "search" : "بحث",

--- a/components/d2l-quick-eval/lang/da-dk.json
+++ b/components/d2l-quick-eval/lang/da-dk.json
@@ -30,6 +30,8 @@
    "noSubmissions" : "Der er ingen afleveringer, der kræver din opmærksomhed.",
    "publishAll" : "Publish All",
    "publishAllConfirmDialogMessage": "{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?",
+   "publishAllToastMessage" : "{activityName} evaluations published successfully.",
+   "publishAllToastMessageTruncated" : "{truncatedActivityName}… evaluations published successfully.",
    "published" : "Published",
    "quiz" : "Quiz",
    "search" : "Søg",

--- a/components/d2l-quick-eval/lang/de.json
+++ b/components/d2l-quick-eval/lang/de.json
@@ -30,6 +30,8 @@
    "noSubmissions" : "Es gibt keine Abgaben, die Ihre Aufmerksamkeit erfordern.",
    "publishAll" : "Alle veröffentlichen",
    "publishAllConfirmDialogMessage": "{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?",
+   "publishAllToastMessage" : "{activityName} evaluations published successfully.",
+   "publishAllToastMessageTruncated" : "{truncatedActivityName}… evaluations published successfully.",
    "published" : "Veröffentlicht",
    "quiz" : "Test",
    "search" : "Suchen",

--- a/components/d2l-quick-eval/lang/en.json
+++ b/components/d2l-quick-eval/lang/en.json
@@ -30,6 +30,8 @@
   "noSubmissions": "There are no submissions that need your attention.",
   "publishAll" : "Publish All",
   "publishAllConfirmDialogMessage": "{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?",
+  "publishAllToastMessage" : "{activityName} evaluations published successfully.",
+  "publishAllToastMessageTruncated" : "{truncatedActivityName}… evaluations published successfully.",
   "published" : "Published",
   "quiz" : "Quiz",
   "search": "Search",

--- a/components/d2l-quick-eval/lang/es.json
+++ b/components/d2l-quick-eval/lang/es.json
@@ -30,6 +30,8 @@
    "noSubmissions" : "No hay envíos que requieran su atención.",
    "publishAll" : "Publicar todo",
    "publishAllConfirmDialogMessage": "{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?",
+   "publishAllToastMessage" : "{activityName} evaluations published successfully.",
+   "publishAllToastMessageTruncated" : "{truncatedActivityName}… evaluations published successfully.",
    "published" : "Publicado",
    "quiz" : "Cuestionario",
    "search" : "Buscar",

--- a/components/d2l-quick-eval/lang/fi.json
+++ b/components/d2l-quick-eval/lang/fi.json
@@ -30,6 +30,8 @@
   "noSubmissions": "There are no submissions that need your attention.",
   "publishAll" : "Publish All",
   "publishAllConfirmDialogMessage": "{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?",
+  "publishAllToastMessage" : "{activityName} evaluations published successfully.",
+  "publishAllToastMessageTruncated" : "{truncatedActivityName}… evaluations published successfully.",
   "published" : "Published",
   "quiz" : "Quiz",
   "search": "Search",

--- a/components/d2l-quick-eval/lang/fr-fr.json
+++ b/components/d2l-quick-eval/lang/fr-fr.json
@@ -30,6 +30,8 @@
    "noSubmissions" : "Aucune soumission ne nécessite votre attention.",
    "publishAll" : "Publish All",
    "publishAllConfirmDialogMessage": "{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?",
+   "publishAllToastMessage" : "{activityName} evaluations published successfully.",
+   "publishAllToastMessageTruncated" : "{truncatedActivityName}… evaluations published successfully.",
    "published" : "Published",
    "quiz" : "Quiz",
    "search" : "Rechercher",

--- a/components/d2l-quick-eval/lang/fr.json
+++ b/components/d2l-quick-eval/lang/fr.json
@@ -30,6 +30,8 @@
    "noSubmissions" : "Aucune soumission ne requiert votre attention.",
    "publishAll" : "Tout publier",
    "publishAllConfirmDialogMessage": "{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?",
+   "publishAllToastMessage" : "{activityName} evaluations published successfully.",
+   "publishAllToastMessageTruncated" : "{truncatedActivityName}… evaluations published successfully.",
    "published" : "Publié",
    "quiz" : "Questionnaire",
    "search" : "Rechercher",

--- a/components/d2l-quick-eval/lang/ja.json
+++ b/components/d2l-quick-eval/lang/ja.json
@@ -30,6 +30,8 @@
    "noSubmissions" : "確認が必要な送信物はありません。",
    "publishAll" : "すべて公開",
    "publishAllConfirmDialogMessage": "{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?",
+   "publishAllToastMessage" : "{activityName} evaluations published successfully.",
+   "publishAllToastMessageTruncated" : "{truncatedActivityName}… evaluations published successfully.",
    "published" : "公開済み",
    "quiz" : "クイズ",
    "search" : "検索",

--- a/components/d2l-quick-eval/lang/ko.json
+++ b/components/d2l-quick-eval/lang/ko.json
@@ -30,6 +30,8 @@
    "noSubmissions" : "주목할 제출 항목이 없습니다.",
    "publishAll" : "모두 게시",
    "publishAllConfirmDialogMessage": "{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?",
+   "publishAllToastMessage" : "{activityName} evaluations published successfully.",
+   "publishAllToastMessageTruncated" : "{truncatedActivityName}… evaluations published successfully.",
    "published" : "게시됨",
    "quiz" : "퀴즈",
    "search" : "검색",

--- a/components/d2l-quick-eval/lang/nl.json
+++ b/components/d2l-quick-eval/lang/nl.json
@@ -30,6 +30,8 @@
    "noSubmissions" : "Er zijn geen indieningen via postvak die uw aandacht nodig hebben.",
    "publishAll" : "Alles publiceren",
    "publishAllConfirmDialogMessage": "{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?",
+   "publishAllToastMessage" : "{activityName} evaluations published successfully.",
+   "publishAllToastMessageTruncated" : "{truncatedActivityName}… evaluations published successfully.",
    "published" : "Gepubliceerd",
    "quiz" : "Test",
    "search" : "Zoeken",

--- a/components/d2l-quick-eval/lang/pt.json
+++ b/components/d2l-quick-eval/lang/pt.json
@@ -30,6 +30,8 @@
    "noSubmissions" : "Não há envios que precisem de sua atenção.",
    "publishAll" : "Publicar Tudo",
    "publishAllConfirmDialogMessage": "{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?",
+   "publishAllToastMessage" : "{activityName} evaluations published successfully.",
+   "publishAllToastMessageTruncated" : "{truncatedActivityName}… evaluations published successfully.",
    "published" : "Publicado",
    "quiz" : "Questionário",
    "search" : "Pesquisar",

--- a/components/d2l-quick-eval/lang/sv.json
+++ b/components/d2l-quick-eval/lang/sv.json
@@ -30,6 +30,8 @@
    "noSubmissions" : "Det finns inga inlämningar som du behöver utföra någon åtgärd på.",
    "publishAll" : "Publicera alla",
    "publishAllConfirmDialogMessage": "{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?",
+   "publishAllToastMessage" : "{activityName} evaluations published successfully.",
+   "publishAllToastMessageTruncated" : "{truncatedActivityName}… evaluations published successfully.",
    "published" : "Publicerad",
    "quiz" : "Förhör",
    "search" : "Sökning",

--- a/components/d2l-quick-eval/lang/tr.json
+++ b/components/d2l-quick-eval/lang/tr.json
@@ -30,6 +30,8 @@
    "noSubmissions" : "İlgilenmeniz gereken gönderi yok.",
    "publishAll" : "Tümünü Yayımla",
    "publishAllConfirmDialogMessage": "{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?",
+   "publishAllToastMessage" : "{activityName} evaluations published successfully.",
+   "publishAllToastMessageTruncated" : "{truncatedActivityName}… evaluations published successfully.",
    "published" : "Yayınlandı",
    "quiz" : "Sınav",
    "search" : "Ara",

--- a/components/d2l-quick-eval/lang/zh-tw.json
+++ b/components/d2l-quick-eval/lang/zh-tw.json
@@ -30,6 +30,8 @@
    "noSubmissions" : "沒有提交項目需要您注意。",
    "publishAll" : "全部發佈",
    "publishAllConfirmDialogMessage": "{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?",
+   "publishAllToastMessage" : "{activityName} evaluations published successfully.",
+   "publishAllToastMessageTruncated" : "{truncatedActivityName}… evaluations published successfully.",
    "published" : "已發佈",
    "quiz" : "測驗",
    "search" : "搜尋",

--- a/components/d2l-quick-eval/lang/zh.json
+++ b/components/d2l-quick-eval/lang/zh.json
@@ -30,6 +30,8 @@
    "noSubmissions" : "没有需要您注意的提交。",
    "publishAll" : "全部发布",
    "publishAllConfirmDialogMessage": "{evaluated} out of {assigned} users will receive feedback on publishing. Do you want to continue?",
+   "publishAllToastMessage" : "{activityName} evaluations published successfully.",
+   "publishAllToastMessageTruncated" : "{truncatedActivityName}… evaluations published successfully.",
    "published" : "已发布",
    "quiz" : "测验",
    "search" : "搜索",


### PR DESCRIPTION
This PR adds:

* The activity name is now present in the toast
* The activity name is truncated to 48 characters
* Multiple toasts now appear on top of one another instead of replacing the older one
* English langterms. Other languages to follow after initial review