### PR TITLE
US109366 - change langterm to be specific to activities

### DIFF
--- a/components/d2l-quick-eval/build/lang/ar.js
+++ b/components/d2l-quick-eval/build/lang/ar.js
@@ -34,6 +34,7 @@ const LangArImpl = (superClass) => class extends superClass {
 			'masterTeacher': 'المعلّم',
 			'no': 'No',
 			'noCriteriaMatch': 'لا تتوفر أي عمليات إرسال تتوافق مع معاييرك.',
+			'noCriteriaMatchActivities': 'There are no activities that match your criteria.',
 			'noResults': 'لا تتوفر أي نتائج هنا.',
 			'noSubmissions': 'لا تتوفر أي عمليات إرسال تتطلب اهتمامك.',
 			'publishAll': 'نشر الكل',

--- a/components/d2l-quick-eval/build/lang/da-dk.js
+++ b/components/d2l-quick-eval/build/lang/da-dk.js
@@ -34,6 +34,7 @@ const LangDadkImpl = (superClass) => class extends superClass {
 			'masterTeacher': 'Lærer',
 			'no': 'No',
 			'noCriteriaMatch': 'Der er ingen afleveringer, der matcher dine kriterier.',
+			'noCriteriaMatchActivities': 'There are no activities that match your criteria.',
 			'noResults': 'Ingen resultater her.',
 			'noSubmissions': 'Der er ingen afleveringer, der kræver din opmærksomhed.',
 			'publishAll': 'Publish All',

--- a/components/d2l-quick-eval/build/lang/de.js
+++ b/components/d2l-quick-eval/build/lang/de.js
@@ -34,6 +34,7 @@ const LangDeImpl = (superClass) => class extends superClass {
 			'masterTeacher': 'Lehrer',
 			'no': 'No',
 			'noCriteriaMatch': 'Es gibt keine Abgaben, die mit Ihren Kriterien übereinstimmen.',
+			'noCriteriaMatchActivities': 'There are no activities that match your criteria.',
 			'noResults': 'Keine Ergebnisse',
 			'noSubmissions': 'Es gibt keine Abgaben, die Ihre Aufmerksamkeit erfordern.',
 			'publishAll': 'Alle veröffentlichen',

--- a/components/d2l-quick-eval/build/lang/en.js
+++ b/components/d2l-quick-eval/build/lang/en.js
@@ -34,6 +34,7 @@ const LangEnImpl = (superClass) => class extends superClass {
 			'masterTeacher': 'Teacher',
 			'no': 'No',
 			'noCriteriaMatch': 'There are no submissions that match your criteria.',
+			'noCriteriaMatchActivities': 'There are no activities that match your criteria.',
 			'noResults': 'No results here.',
 			'noSubmissions': 'There are no submissions that need your attention.',
 			'publishAll': 'Publish All',

--- a/components/d2l-quick-eval/build/lang/es.js
+++ b/components/d2l-quick-eval/build/lang/es.js
@@ -34,6 +34,7 @@ const LangEsImpl = (superClass) => class extends superClass {
 			'masterTeacher': 'Profesor',
 			'no': 'No',
 			'noCriteriaMatch': 'No hay materiales enviados que coincidan con sus criterios.',
+			'noCriteriaMatchActivities': 'There are no activities that match your criteria.',
 			'noResults': 'No hay resultados aquí.',
 			'noSubmissions': 'No hay envíos que requieran su atención.',
 			'publishAll': 'Publicar todo',

--- a/components/d2l-quick-eval/build/lang/fi.js
+++ b/components/d2l-quick-eval/build/lang/fi.js
@@ -34,6 +34,7 @@ const LangFiImpl = (superClass) => class extends superClass {
 			'masterTeacher': 'Teacher',
 			'no': 'No',
 			'noCriteriaMatch': 'There are no submissions that match your criteria.',
+			'noCriteriaMatchActivities': 'There are no activities that match your criteria.',
 			'noResults': 'No results here.',
 			'noSubmissions': 'There are no submissions that need your attention.',
 			'publishAll': 'Publish All',

--- a/components/d2l-quick-eval/build/lang/fr-fr.js
+++ b/components/d2l-quick-eval/build/lang/fr-fr.js
@@ -34,6 +34,7 @@ const LangFrfrImpl = (superClass) => class extends superClass {
 			'masterTeacher': 'Enseignant',
 			'no': 'No',
 			'noCriteriaMatch': 'Aucune soumission ne correspond à vos critères.',
+			'noCriteriaMatchActivities': 'There are no activities that match your criteria.',
 			'noResults': 'Aucun résultat.',
 			'noSubmissions': 'Aucune soumission ne nécessite votre attention.',
 			'publishAll': 'Publish All',

--- a/components/d2l-quick-eval/build/lang/fr.js
+++ b/components/d2l-quick-eval/build/lang/fr.js
@@ -34,6 +34,7 @@ const LangFrImpl = (superClass) => class extends superClass {
 			'masterTeacher': 'Enseignant',
 			'no': 'No',
 			'noCriteriaMatch': 'Aucune soumission ne correspond à vos critères.',
+			'noCriteriaMatchActivities': 'There are no activities that match your criteria.',
 			'noResults': 'Aucun résultat ici.',
 			'noSubmissions': 'Aucune soumission ne requiert votre attention.',
 			'publishAll': 'Tout publier',

--- a/components/d2l-quick-eval/build/lang/ja.js
+++ b/components/d2l-quick-eval/build/lang/ja.js
@@ -34,6 +34,7 @@ const LangJaImpl = (superClass) => class extends superClass {
 			'masterTeacher': '講師',
 			'no': 'No',
 			'noCriteriaMatch': '条件に一致する送信物はありません。',
+			'noCriteriaMatchActivities': 'There are no activities that match your criteria.',
 			'noResults': 'ここには結果がありません。',
 			'noSubmissions': '確認が必要な送信物はありません。',
 			'publishAll': 'すべて公開',

--- a/components/d2l-quick-eval/build/lang/ko.js
+++ b/components/d2l-quick-eval/build/lang/ko.js
@@ -34,6 +34,7 @@ const LangKoImpl = (superClass) => class extends superClass {
 			'masterTeacher': '교사',
 			'no': 'No',
 			'noCriteriaMatch': '기준과 일치하는 제출 항목이 없습니다',
+			'noCriteriaMatchActivities': 'There are no activities that match your criteria.',
 			'noResults': '결과가 없습니다.',
 			'noSubmissions': '주목할 제출 항목이 없습니다.',
 			'publishAll': '모두 게시',

--- a/components/d2l-quick-eval/build/lang/nl.js
+++ b/components/d2l-quick-eval/build/lang/nl.js
@@ -34,6 +34,7 @@ const LangNlImpl = (superClass) => class extends superClass {
 			'masterTeacher': 'Docent',
 			'no': 'No',
 			'noCriteriaMatch': 'Er zijn geen indieningen via postvak die overeenkomen met uw criteria.',
+			'noCriteriaMatchActivities': 'There are no activities that match your criteria.',
 			'noResults': 'Geen resultaten hier.',
 			'noSubmissions': 'Er zijn geen indieningen via postvak die uw aandacht nodig hebben.',
 			'publishAll': 'Alles publiceren',

--- a/components/d2l-quick-eval/build/lang/pt.js
+++ b/components/d2l-quick-eval/build/lang/pt.js
@@ -34,6 +34,7 @@ const LangPtImpl = (superClass) => class extends superClass {
 			'masterTeacher': 'Professor',
 			'no': 'No',
 			'noCriteriaMatch': 'Não há nenhum envio correspondente aos seus critérios.',
+			'noCriteriaMatchActivities': 'There are no activities that match your criteria.',
 			'noResults': 'Nenhum resultado aqui.',
 			'noSubmissions': 'Não há envios que precisem de sua atenção.',
 			'publishAll': 'Publicar Tudo',

--- a/components/d2l-quick-eval/build/lang/sv.js
+++ b/components/d2l-quick-eval/build/lang/sv.js
@@ -34,6 +34,7 @@ const LangSvImpl = (superClass) => class extends superClass {
 			'masterTeacher': 'Lärare',
 			'no': 'No',
 			'noCriteriaMatch': 'Det finns inga inlämningar som matchar dina kriterier.',
+			'noCriteriaMatchActivities': 'There are no activities that match your criteria.',
 			'noResults': 'Det finns inga resultat här.',
 			'noSubmissions': 'Det finns inga inlämningar som du behöver utföra någon åtgärd på.',
 			'publishAll': 'Publicera alla',

--- a/components/d2l-quick-eval/build/lang/tr.js
+++ b/components/d2l-quick-eval/build/lang/tr.js
@@ -34,6 +34,7 @@ const LangTrImpl = (superClass) => class extends superClass {
 			'masterTeacher': 'Öğretmen',
 			'no': 'No',
 			'noCriteriaMatch': 'Kriterinizle eşleşen gönderi yok.',
+			'noCriteriaMatchActivities': 'There are no activities that match your criteria.',
 			'noResults': 'Sonuç yok.',
 			'noSubmissions': 'İlgilenmeniz gereken gönderi yok.',
 			'publishAll': 'Tümünü Yayımla',

--- a/components/d2l-quick-eval/build/lang/zh-tw.js
+++ b/components/d2l-quick-eval/build/lang/zh-tw.js
@@ -34,6 +34,7 @@ const LangZhtwImpl = (superClass) => class extends superClass {
 			'masterTeacher': '教師',
 			'no': 'No',
 			'noCriteriaMatch': '沒有提交項目符合您的標準。',
+			'noCriteriaMatchActivities': 'There are no activities that match your criteria.',
 			'noResults': '這裡沒有任何結果。',
 			'noSubmissions': '沒有提交項目需要您注意。',
 			'publishAll': '全部發佈',

--- a/components/d2l-quick-eval/build/lang/zh.js
+++ b/components/d2l-quick-eval/build/lang/zh.js
@@ -34,6 +34,7 @@ const LangZhImpl = (superClass) => class extends superClass {
 			'masterTeacher': '教师',
 			'no': 'No',
 			'noCriteriaMatch': '没有与筛选条件匹配的提交。',
+			'noCriteriaMatchActivities': 'There are no activities that match your criteria.',
 			'noResults': '此处没有结果。',
 			'noSubmissions': '没有需要您注意的提交。',
 			'publishAll': '全部发布',

--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -148,7 +148,7 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 			<div class="d2l-quick-eval-no-criteria-results" hidden$="[[!_shouldShowNoCriteriaResults(_data, _loading, filterApplied, searchApplied)]]">
 				<d2l-quick-eval-no-criteria-results-image></d2l-quick-eval-no-criteria-results-image>
 				<h2 class="d2l-quick-eval-no-criteria-results-heading">[[localize('noResults')]]</h2>
-				<p class="d2l-body-standard">[[localize('noCriteriaMatch')]]</p>
+				<p class="d2l-body-standard">[[localize('noCriteriaMatchActivities')]]</p>
 			</div>
 			<d2l-quick-eval-activities-skeleton hidden$="[[!_showLoadingSkeleton]]"></d2l-quick-eval-activities-skeleton>
 			<d2l-quick-eval-activities-list

--- a/components/d2l-quick-eval/lang/ar.json
+++ b/components/d2l-quick-eval/lang/ar.json
@@ -26,6 +26,7 @@
    "masterTeacher" : "المعلّم",
    "no": "No",
    "noCriteriaMatch" : "لا تتوفر أي عمليات إرسال تتوافق مع معاييرك.",
+   "noCriteriaMatchActivities": "There are no activities that match your criteria.",
    "noResults" : "لا تتوفر أي نتائج هنا.",
    "noSubmissions" : "لا تتوفر أي عمليات إرسال تتطلب اهتمامك.",
    "publishAll" : "نشر الكل",

--- a/components/d2l-quick-eval/lang/da-dk.json
+++ b/components/d2l-quick-eval/lang/da-dk.json
@@ -26,6 +26,7 @@
    "masterTeacher" : "Lærer",
    "no": "No",
    "noCriteriaMatch" : "Der er ingen afleveringer, der matcher dine kriterier.",
+   "noCriteriaMatchActivities": "There are no activities that match your criteria.",
    "noResults" : "Ingen resultater her.",
    "noSubmissions" : "Der er ingen afleveringer, der kræver din opmærksomhed.",
    "publishAll" : "Publish All",

--- a/components/d2l-quick-eval/lang/de.json
+++ b/components/d2l-quick-eval/lang/de.json
@@ -26,6 +26,7 @@
    "masterTeacher" : "Lehrer",
    "no": "No",
    "noCriteriaMatch" : "Es gibt keine Abgaben, die mit Ihren Kriterien übereinstimmen.",
+   "noCriteriaMatchActivities": "There are no activities that match your criteria.",
    "noResults" : "Keine Ergebnisse",
    "noSubmissions" : "Es gibt keine Abgaben, die Ihre Aufmerksamkeit erfordern.",
    "publishAll" : "Alle veröffentlichen",

--- a/components/d2l-quick-eval/lang/en.json
+++ b/components/d2l-quick-eval/lang/en.json
@@ -26,6 +26,7 @@
   "masterTeacher": "Teacher",
   "no": "No",
   "noCriteriaMatch": "There are no submissions that match your criteria.",
+  "noCriteriaMatchActivities": "There are no activities that match your criteria.",
   "noResults": "No results here.",
   "noSubmissions": "There are no submissions that need your attention.",
   "publishAll" : "Publish All",

--- a/components/d2l-quick-eval/lang/es.json
+++ b/components/d2l-quick-eval/lang/es.json
@@ -26,6 +26,7 @@
    "masterTeacher" : "Profesor",
    "no": "No",
    "noCriteriaMatch" : "No hay materiales enviados que coincidan con sus criterios.",
+   "noCriteriaMatchActivities": "There are no activities that match your criteria.",
    "noResults" : "No hay resultados aquí.",
    "noSubmissions" : "No hay envíos que requieran su atención.",
    "publishAll" : "Publicar todo",

--- a/components/d2l-quick-eval/lang/fi.json
+++ b/components/d2l-quick-eval/lang/fi.json
@@ -26,6 +26,7 @@
   "masterTeacher": "Teacher",
   "no": "No",
   "noCriteriaMatch": "There are no submissions that match your criteria.",
+  "noCriteriaMatchActivities": "There are no activities that match your criteria.",
   "noResults": "No results here.",
   "noSubmissions": "There are no submissions that need your attention.",
   "publishAll" : "Publish All",

--- a/components/d2l-quick-eval/lang/fr-fr.json
+++ b/components/d2l-quick-eval/lang/fr-fr.json
@@ -26,6 +26,7 @@
    "masterTeacher" : "Enseignant",
    "no": "No",
    "noCriteriaMatch" : "Aucune soumission ne correspond à vos critères.",
+   "noCriteriaMatchActivities": "There are no activities that match your criteria.",
    "noResults" : "Aucun résultat.",
    "noSubmissions" : "Aucune soumission ne nécessite votre attention.",
    "publishAll" : "Publish All",

--- a/components/d2l-quick-eval/lang/fr.json
+++ b/components/d2l-quick-eval/lang/fr.json
@@ -26,6 +26,7 @@
    "masterTeacher" : "Enseignant",
    "no": "No",
    "noCriteriaMatch" : "Aucune soumission ne correspond à vos critères.",
+   "noCriteriaMatchActivities": "There are no activities that match your criteria.",
    "noResults" : "Aucun résultat ici.",
    "noSubmissions" : "Aucune soumission ne requiert votre attention.",
    "publishAll" : "Tout publier",

--- a/components/d2l-quick-eval/lang/ja.json
+++ b/components/d2l-quick-eval/lang/ja.json
@@ -26,6 +26,7 @@
    "masterTeacher" : "講師",
    "no": "No",
    "noCriteriaMatch" : "条件に一致する送信物はありません。",
+   "noCriteriaMatchActivities": "There are no activities that match your criteria.",
    "noResults" : "ここには結果がありません。",
    "noSubmissions" : "確認が必要な送信物はありません。",
    "publishAll" : "すべて公開",

--- a/components/d2l-quick-eval/lang/ko.json
+++ b/components/d2l-quick-eval/lang/ko.json
@@ -26,6 +26,7 @@
    "masterTeacher" : "교사",
    "no": "No",
    "noCriteriaMatch" : "기준과 일치하는 제출 항목이 없습니다",
+   "noCriteriaMatchActivities": "There are no activities that match your criteria.",
    "noResults" : "결과가 없습니다.",
    "noSubmissions" : "주목할 제출 항목이 없습니다.",
    "publishAll" : "모두 게시",

--- a/components/d2l-quick-eval/lang/nl.json
+++ b/components/d2l-quick-eval/lang/nl.json
@@ -26,6 +26,7 @@
    "masterTeacher" : "Docent",
    "no": "No",
    "noCriteriaMatch" : "Er zijn geen indieningen via postvak die overeenkomen met uw criteria.",
+   "noCriteriaMatchActivities": "There are no activities that match your criteria.",
    "noResults" : "Geen resultaten hier.",
    "noSubmissions" : "Er zijn geen indieningen via postvak die uw aandacht nodig hebben.",
    "publishAll" : "Alles publiceren",

--- a/components/d2l-quick-eval/lang/pt.json
+++ b/components/d2l-quick-eval/lang/pt.json
@@ -26,6 +26,7 @@
    "masterTeacher" : "Professor",
    "no": "No",
    "noCriteriaMatch" : "Não há nenhum envio correspondente aos seus critérios.",
+   "noCriteriaMatchActivities": "There are no activities that match your criteria.",
    "noResults" : "Nenhum resultado aqui.",
    "noSubmissions" : "Não há envios que precisem de sua atenção.",
    "publishAll" : "Publicar Tudo",

--- a/components/d2l-quick-eval/lang/sv.json
+++ b/components/d2l-quick-eval/lang/sv.json
@@ -26,6 +26,7 @@
    "masterTeacher" : "Lärare",
    "no": "No",
    "noCriteriaMatch" : "Det finns inga inlämningar som matchar dina kriterier.",
+   "noCriteriaMatchActivities": "There are no activities that match your criteria.",
    "noResults" : "Det finns inga resultat här.",
    "noSubmissions" : "Det finns inga inlämningar som du behöver utföra någon åtgärd på.",
    "publishAll" : "Publicera alla",

--- a/components/d2l-quick-eval/lang/tr.json
+++ b/components/d2l-quick-eval/lang/tr.json
@@ -26,6 +26,7 @@
    "masterTeacher" : "Öğretmen",
    "no": "No",
    "noCriteriaMatch" : "Kriterinizle eşleşen gönderi yok.",
+   "noCriteriaMatchActivities": "There are no activities that match your criteria.",
    "noResults" : "Sonuç yok.",
    "noSubmissions" : "İlgilenmeniz gereken gönderi yok.",
    "publishAll" : "Tümünü Yayımla",

--- a/components/d2l-quick-eval/lang/zh-tw.json
+++ b/components/d2l-quick-eval/lang/zh-tw.json
@@ -26,6 +26,7 @@
    "masterTeacher" : "教師",
    "no": "No",
    "noCriteriaMatch" : "沒有提交項目符合您的標準。",
+   "noCriteriaMatchActivities": "There are no activities that match your criteria.",
    "noResults" : "這裡沒有任何結果。",
    "noSubmissions" : "沒有提交項目需要您注意。",
    "publishAll" : "全部發佈",

--- a/components/d2l-quick-eval/lang/zh.json
+++ b/components/d2l-quick-eval/lang/zh.json
@@ -26,6 +26,7 @@
    "masterTeacher" : "教师",
    "no": "No",
    "noCriteriaMatch" : "没有与筛选条件匹配的提交。",
+   "noCriteriaMatchActivities": "There are no activities that match your criteria.",
    "noResults" : "此处没有结果。",
    "noSubmissions" : "没有需要您注意的提交。",
    "publishAll" : "全部发布",


### PR DESCRIPTION
https://rally1.rallydev.com/#/238990806412d/detail/userstory/328911639612

Basically, we were re-using the submissions langterm for activities. So I created one specific to activities.