### PR TITLE
added extra params to evaluate all and evaluate new buttons

### DIFF
--- a/components/d2l-quick-eval/behaviors/d2l-quick-eval-siren-helper-behavior.js
+++ b/components/d2l-quick-eval/behaviors/d2l-quick-eval-siren-helper-behavior.js
@@ -81,7 +81,7 @@ D2L.PolymerBehaviors.QuickEval.D2LQuickEvalSirenHelperBehaviorImpl = {
 		return entity.getLinkByRel(Rels.Activities.evaluationStatus).href;
 	},
 
-	_getEvaluationStatusPromise: async function(entity) {
+	_getEvaluationStatusPromise: async function(entity, extraParams) {
 		return this._followLink(entity, Rels.Activities.evaluationStatus)
 			.then(function(e) {
 				if (e && e.entity && e.entity.properties) {
@@ -99,12 +99,18 @@ D2L.PolymerBehaviors.QuickEval.D2LQuickEvalSirenHelperBehaviorImpl = {
 
 					if (evaluateAllSubEntity && evaluateAllSubEntity.properties.path) {
 						evaluateAllHref = evaluateAllSubEntity.properties.path;
+						if (extraParams.length) {
+							evaluateAllHref = this._buildRelativeUri(evaluateAllHref, extraParams);
+						}
 					}
 					const evaluateNewSubEntity = e.entity.getSubEntityByRel(Rels.Assessments.assessNewApplication);
 
 					let evaluateNewHref = '';
 					if (evaluateNewSubEntity && evaluateNewSubEntity.properties.path) {
 						evaluateNewHref = evaluateNewSubEntity.properties.path;
+						if (extraParams.length) {
+							evaluateNewHref = this._buildRelativeUri(evaluateNewHref, extraParams);
+						}
 					}
 					return {
 						assigned: p.assigned || 0,

--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -236,8 +236,9 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 	}
 
 	async _parseActivities(entity) {
+		const extraParams = this._getExtraParams(this._getHref(entity, 'self'));
 		const result = await Promise.all(entity.entities.map(async function(activity) {
-			const evalStatus = await this._getEvaluationStatusPromise(activity);
+			const evalStatus = await this._getEvaluationStatusPromise(activity, extraParams);
 			const courseName = await this._getCourseNamePromise(activity);
 			const activityNameHref = this._getActivityNameHref(activity);
 			const activityName = await this._getActivityName(activity);


### PR DESCRIPTION
After applying filters to activities view and clicking evaluate-all or evaluate-new, clicking to `back to quick eval` should persist the filters that we originally had. I am simply leveraging functionality that already existed in submissions view.

things to keep in mind:
When clicking `back to quick eval` theres a bug that applies the filters to both submissions and acitivities views. Would appreciate some ideas over how to proceed in fixing it (probably in a separate PR).