### PR TITLE
clear both views on toggle change

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -269,16 +269,14 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 		return this._groupByCourse(result);
 	}
 
-	async _clearAllOnHidden(hidden) {
-		if (hidden) {
-			// NOTE: clearFilters has to be before clearSearchResults or else
-			// it doesn't effectively clears the filters and searches
-			if (this.filterApplied) {
-				await this.clearFilters();
-			}
-			if (this.searchApplied) {
-				await this.clearSearchResults();
-			}
+	async _clearAllOnHidden() {
+		// NOTE: clearFilters has to be before clearSearchResults or else
+		// it doesn't effectively clears the filters and searches
+		if (this.filterApplied) {
+			await this.clearFilters();
+		}
+		if (this.searchApplied) {
+			await this.clearSearchResults();
 		}
 	}
 

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -362,16 +362,14 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 		return result;
 	}
 
-	async _clearAllOnHidden(hidden) {
-		if (hidden) {
-			// NOTE: clearFilters has to be before clearSearchResults or else
-			// it doesn't effectively clears the filters and searches
-			if (this.filterApplied) {
-				await this.clearFilters();
-			}
-			if (this.searchApplied) {
-				await this.clearSearchResults();
-			}
+	async _clearAllOnHidden() {
+		// NOTE: clearFilters has to be before clearSearchResults or else
+		// it doesn't effectively clears the filters and searches
+		if (this.filterApplied) {
+			await this.clearFilters();
+		}
+		if (this.searchApplied) {
+			await this.clearSearchResults();
 		}
 	}
 


### PR DESCRIPTION
This allows that when the toggle is pressed, both submissions and activities are cleared. This is my attempt to solve the bug where clicking `back to quick eval` applies filters on both. This fixes the aforementioned bug.