### PR TITLE
added margin-bottom to submissions table

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -68,6 +68,7 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 				d2l-quick-eval-submissions-table {
 					display: block;
 					padding-top: 1rem;
+					margin-bottom: 2.1rem;
 				}
 				@media (min-width: 525px) {
 					.d2l-quick-eval-submissions-table-modifiers {


### PR DESCRIPTION
There's now 42px of space below the submissions, because otherwise if the last submission has a tooltip, it will look weird.
![Screen Shot 2019-08-16 at 11 26 55 AM](https://user-images.githubusercontent.com/52468201/63178812-cd711880-c018-11e9-95e8-4e87aef9da4d.png)
