### PR TITLE
Adding try/catch if loading an activity fails.

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -280,9 +280,9 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 					activityName: activityName,
 					evaluationStatusHref: evaluationStatusHref
 				};
-			} catch(e) {
+			} catch (e) {
 				this._logError(e, {developerMessage: 'Error loading activity data .'});
-				return null; 
+				return null;
 			}
 		}.bind(this)));
 		return this._groupByCourse(result.filter(r => r));

--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -281,7 +281,7 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 					evaluationStatusHref: evaluationStatusHref
 				};
 			} catch (e) {
-				this._logError(e, {developerMessage: 'Error loading activity data .'});
+				this._logError(e, {developerMessage: `Error loading activity data for ${this._getHref(activity, 'self')}.`});
 				return null;
 			}
 		}.bind(this)));

--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -255,32 +255,37 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 	async _parseActivities(entity) {
 		const extraParams = this._getExtraParams(this._getHref(entity, 'self'));
 		const result = await Promise.all(entity.entities.map(async function(activity) {
-			const evalStatus = await this._getEvaluationStatusPromise(activity, extraParams);
-			const courseName = await this._getCourseNamePromise(activity);
-			const activityNameHref = this._getActivityNameHref(activity);
-			const activityName = await this._getActivityName(activity);
-			const evaluationStatusHref = this.getEvaluationStatusHref(activity);
-			return {
-				courseName: courseName,
-				assigned: evalStatus.assigned,
-				completed: evalStatus.completed,
-				published: evalStatus.published,
-				evaluated: evalStatus.evaluated,
-				unread: evalStatus.unread,
-				resubmitted: evalStatus.resubmitted,
-				publishAll: evalStatus.publishAll,
-				submissionListHref: evalStatus.submissionListHref,
-				evaluateAllHref: evalStatus.evaluateAllHref,
-				evaluateNewHref: evalStatus.evaluateNewHref,
-				key: this._getOrgHref(activity),
-				dueDate: this._getActivityDueDate(activity),
-				activityType: this._getActivityType(activity),
-				activityNameHref: activityNameHref,
-				activityName: activityName,
-				evaluationStatusHref: evaluationStatusHref
-			};
+			try {
+				const evalStatus = await this._getEvaluationStatusPromise(activity, extraParams);
+				const courseName = await this._getCourseNamePromise(activity);
+				const activityNameHref = this._getActivityNameHref(activity);
+				const activityName = await this._getActivityName(activity);
+				const evaluationStatusHref = this.getEvaluationStatusHref(activity);
+				return {
+					courseName: courseName,
+					assigned: evalStatus.assigned,
+					completed: evalStatus.completed,
+					published: evalStatus.published,
+					evaluated: evalStatus.evaluated,
+					unread: evalStatus.unread,
+					resubmitted: evalStatus.resubmitted,
+					publishAll: evalStatus.publishAll,
+					submissionListHref: evalStatus.submissionListHref,
+					evaluateAllHref: evalStatus.evaluateAllHref,
+					evaluateNewHref: evalStatus.evaluateNewHref,
+					key: this._getOrgHref(activity),
+					dueDate: this._getActivityDueDate(activity),
+					activityType: this._getActivityType(activity),
+					activityNameHref: activityNameHref,
+					activityName: activityName,
+					evaluationStatusHref: evaluationStatusHref
+				};
+			} catch(e) {
+				this._logError(e, {developerMessage: 'Error loading activity data .'});
+				return null; 
+			}
 		}.bind(this)));
-		return this._groupByCourse(result);
+		return this._groupByCourse(result.filter(r => r));
 	}
 
 	async _clearAllOnHidden() {

--- a/demo/d2l-quick-eval/d2l-quick-eval-activities.html
+++ b/demo/d2l-quick-eval/d2l-quick-eval-activities.html
@@ -59,7 +59,7 @@
 					</div>
 					<div>Note: last discussion has no due date</div>
 					<hr/>
-					<d2l-quick-eval-activities href="https://activities.api.proddev.d2l/my-unassessed-activities/collections" token="eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjA3MGEzYTI5LWU0NTEtNGZmNC04YWQ0LTIwYmIyNDA1MmYwZiJ9.eyJzdWIiOiIxNzciLCJ0ZW5hbnRpZCI6IjRmM2UwYjM4LWZiMDQtNDNkNC05N2NmLWNjZDFmMThiOTUxNCIsInNjb3BlIjoiKjoqOioiLCJqdGkiOiJjNjQyODU2My00ZDMyLTQzNjgtYTFkNC0wYzcwMGVlYzZmMzciLCJpc3MiOiJodHRwczovL2FwaS5icmlnaHRzcGFjZS5jb20vYXV0aCIsImF1ZCI6Imh0dHBzOi8vYXBpLmJyaWdodHNwYWNlLmNvbS9hdXRoL3Rva2VuIiwiZXhwIjoxNTY2MzE1Nzk4LCJuYmYiOjE1NjYzMTIxOTh9.DtME1leO4JTVClHjc1eksdPYfdwX-cbjLbOkUnYyyZHOHQSEeghC62I-7Y8BmYeQjyQ6UADfTOomciFV5n8AlEh92zjyJ4BvhW138jImPijmduZ0nlF-5Yz4omLv9ffvUMPjfDYNWxDFhPa7ODfsRQjK5S1EkMNOdI13Eis6fnE3P6nGFou3M-8OuFdwOKe4kst8pT9hyj9lEkyQkTioRF37Yhe-Avcb_CHlUDTK0qlHYRDCecAWxvr7WeGSkhF7VajobtDg5oS_BIAcoNgJmKS37e8DHAWw1CQK49RJNl7L_7KLU4Tx25MVrNPcUL7QyTlNKAzN0oFDCIdliJ-FNg"></d2l-quick-eval-activities>
+					<d2l-quick-eval-activities href="pages/" token="whatever"></d2l-quick-eval-activities>
 				</template>
 			</demo-snippet>
 		</div>

--- a/demo/d2l-quick-eval/d2l-quick-eval-activities.html
+++ b/demo/d2l-quick-eval/d2l-quick-eval-activities.html
@@ -59,7 +59,7 @@
 					</div>
 					<div>Note: last discussion has no due date</div>
 					<hr/>
-					<d2l-quick-eval-activities href="pages/" token="whatever"></d2l-quick-eval-activities>
+					<d2l-quick-eval-activities href="https://activities.api.proddev.d2l/my-unassessed-activities/collections" token="eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjA3MGEzYTI5LWU0NTEtNGZmNC04YWQ0LTIwYmIyNDA1MmYwZiJ9.eyJzdWIiOiIxNzciLCJ0ZW5hbnRpZCI6IjRmM2UwYjM4LWZiMDQtNDNkNC05N2NmLWNjZDFmMThiOTUxNCIsInNjb3BlIjoiKjoqOioiLCJqdGkiOiJjNjQyODU2My00ZDMyLTQzNjgtYTFkNC0wYzcwMGVlYzZmMzciLCJpc3MiOiJodHRwczovL2FwaS5icmlnaHRzcGFjZS5jb20vYXV0aCIsImF1ZCI6Imh0dHBzOi8vYXBpLmJyaWdodHNwYWNlLmNvbS9hdXRoL3Rva2VuIiwiZXhwIjoxNTY2MzE1Nzk4LCJuYmYiOjE1NjYzMTIxOTh9.DtME1leO4JTVClHjc1eksdPYfdwX-cbjLbOkUnYyyZHOHQSEeghC62I-7Y8BmYeQjyQ6UADfTOomciFV5n8AlEh92zjyJ4BvhW138jImPijmduZ0nlF-5Yz4omLv9ffvUMPjfDYNWxDFhPa7ODfsRQjK5S1EkMNOdI13Eis6fnE3P6nGFou3M-8OuFdwOKe4kst8pT9hyj9lEkyQkTioRF37Yhe-Avcb_CHlUDTK0qlHYRDCecAWxvr7WeGSkhF7VajobtDg5oS_BIAcoNgJmKS37e8DHAWw1CQK49RJNl7L_7KLU4Tx25MVrNPcUL7QyTlNKAzN0oFDCIdliJ-FNg"></d2l-quick-eval-activities>
 				</template>
 			</demo-snippet>
 		</div>


### PR DESCRIPTION
If there are any `reject`ions inside a `Promise.all`, the entire thing is rejected. Wrapping each activity in a try/catch so that we still load all the 'good' activities instead of returning an empty array, and logging the error.