### PR TITLE
fix to prevent button cutoff on safari

### DIFF
--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-action-button.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-action-button.js
@@ -46,6 +46,7 @@ class D2LQuickEvalActivityCardActionButton extends mixinBehaviors(
 					display: flex;
 					justify-content: center;
 					align-items: center;
+					z-index: 0; /* safari fix */
 				}
 				button:hover,
 				button:hover d2l-icon,
@@ -61,6 +62,9 @@ class D2LQuickEvalActivityCardActionButton extends mixinBehaviors(
 				button:focus .d2l-quick-eval-activity-card-button-icon {
 					background-color: var(--d2l-color-gypsum);
 					box-shadow: var(--d2l-quick-eval-card-button-icon-hover), var(--d2l-quick-eval-card-button-icon-focus-inner), var(--d2l-quick-eval-card-button-icon-focus-outer)
+				}
+				span {
+					z-index: 0; /* safari fix */
 				}
 				.d2l-quick-eval-card-button-icon-large {
 					display: none;


### PR DESCRIPTION
Before:
![Screen Shot 2019-08-22 at 12 02 10 PM](https://user-images.githubusercontent.com/52468201/63538937-f137d100-c4e6-11e9-8c99-b91f38d87769.png)
After:
![Screen Shot 2019-08-22 at 2 11 56 PM](https://user-images.githubusercontent.com/52468201/63538898-dcf3d400-c4e6-11e9-97d1-c523b9f8abf9.png)
tested in edge, chrome, firefox and safari on both windows and mac