### PR TITLE
Dont request activities data when activities view is disabled

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval.js
+++ b/components/d2l-quick-eval/d2l-quick-eval.js
@@ -48,8 +48,8 @@ class D2LQuickEval extends  QuickEvalLocalize(PolymerElement) {
 				<h1 class="d2l-quick-eval-header" hidden$="[[activitiesViewEnabled]]">[[headerText]]</h1>
 			</template>
 			<d2l-quick-eval-view-toggle current-selected="[[toggleState]]" toggle-href="[[toggleHref]]" hidden$="[[!activitiesViewEnabled]]" on-d2l-quick-eval-view-toggle-changed="_toggleView"></d2l-quick-eval-view-toggle>
-			<d2l-quick-eval-submissions href="[[_submissionsHref(submissionsHref, href)]]" token="[[token]]" logging-endpoint="[[loggingEndpoint]]" data-telemetry-endpoint="[[dataTelemetryEndpoint]]" hidden$="[[_showActivitiesView]]" master-teacher="[[masterTeacher]]" search-enabled="[[searchEnabled]]"></d2l-quick-eval-submissions>
-			<d2l-quick-eval-activities href="[[activitiesHref]]" token="[[token]]" logging-endpoint="[[loggingEndpoint]]" hidden$="[[!_showActivitiesView]]"></d2l-quick-eval-activities>
+			<d2l-quick-eval-submissions href="[[submissionsHref]]" token="[[token]]" logging-endpoint="[[loggingEndpoint]]" data-telemetry-endpoint="[[dataTelemetryEndpoint]]" hidden$="[[_showActivitiesView]]" master-teacher="[[masterTeacher]]" search-enabled="[[searchEnabled]]"></d2l-quick-eval-submissions>
+			<d2l-quick-eval-activities href="[[_activitiesHref(activitiesViewEnabled)]]" token="[[token]]" logging-endpoint="[[loggingEndpoint]]" hidden$="[[!_showActivitiesView]]"></d2l-quick-eval-activities>
 		`;
 	}
 
@@ -83,9 +83,6 @@ class D2LQuickEval extends  QuickEvalLocalize(PolymerElement) {
 			dataTelemetryEndpoint: {
 				type: String
 			},
-			href: {
-				type: String
-			},
 			submissionsHref: {
 				type: String
 			},
@@ -114,9 +111,8 @@ class D2LQuickEval extends  QuickEvalLocalize(PolymerElement) {
 		}
 	}
 
-	// Temporary until the LMS has been updated to use the new property
-	_submissionsHref() {
-		return this.submissionsHref || this.href;
+	_activitiesHref(activitiesViewEnabled) {
+		return activitiesViewEnabled ? this.activitiesHref : '';
 	}
 }
 


### PR DESCRIPTION
This PR contains 2 changes:

1. when `activitiesViewEnabled` is set to `false`, we set `d2l-quick-eval-activities` `href` to empty string. [This causes the entitybehavior to not request the href](https://github.com/Brightspace/polymer-siren-behaviors/blob/9bc765ab8f130a980fd7d947f7925c2eea5bd2f4/store/entity-behavior.js#L70) since it will 404 anyways. This is from https://d2l.slack.com/archives/CBTK3JB6D/p1566491095322300
2. Cleanup of some old code that is no longer necessary (the LMS sends `submissionHref` now instead of `href`)