### PR TITLE
added white box-shadow to action-card items

### DIFF
--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-items.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-items.js
@@ -12,6 +12,9 @@ class D2LQuickEvalActivityCardItems extends mixinBehaviors([D2L.PolymerBehaviors
 					display: flex;
 					align-items: stretch;
 					justify-content: space-between;
+					-webkit-box-shadow: 0px 7px 0px 0px rgb(255, 255, 255);
+					-moz-box-shadow: 0px 7px 0px 0px rgba(255,255,255);
+					box-shadow: 0px 7px 0px 0px rgb(255, 255, 255);
 				}
 				.d2l-quick-eval-activity-card-items-container ::slotted(*) {
 					width: 7.5rem;


### PR DESCRIPTION
there's a small miniscule dot under "evaluate all", so i found a way to hide it using a white `box-shadow`
![Screen Shot 2019-08-22 at 3 08 24 PM](https://user-images.githubusercontent.com/52468201/63542731-13355180-c4ef-11e9-95ac-eeb9dac1c146.png)
![Screen Shot 2019-08-22 at 3 09 15 PM](https://user-images.githubusercontent.com/52468201/63542730-13355180-c4ef-11e9-99cc-cb91a792e3fd.png)

