### PR TITLE
Initial checkin

### DIFF
--- a/components/d2l-quick-eval/activities-list/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/activities-list/d2l-quick-eval-activities-list.js
@@ -46,7 +46,7 @@ class D2LQuickEvalActivitiesList extends QuickEvalLocalize(PolymerElement) {
 				}
 				.d2l-quick-eval-activities-course-name-heading {
 					margin-top: 1.8rem;
-					margin-bottom: 1.2rem;
+					margin-bottom: .8rem;
 				}
 			}
 		</style>

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-action-button.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-action-button.js
@@ -20,6 +20,7 @@ class D2LQuickEvalActivityCardActionButton extends mixinBehaviors(
 					--d2l-quick-eval-card-button-icon-hover: 0 0 0 var(--d2l-quick-eval-card-button-icon-padding) var(--d2l-color-gypsum);
 					--d2l-quick-eval-card-button-icon-focus-inner: 0 0 0 0.25rem white;
 					--d2l-quick-eval-card-button-icon-focus-outer: 0 0 0 0.35rem var(--d2l-color-celestine);
+					--d2l-quick-eval-card-button-icon-border-radius: .15rem;
 				}
 				button {
 					display: flex;
@@ -42,7 +43,7 @@ class D2LQuickEvalActivityCardActionButton extends mixinBehaviors(
 				.d2l-quick-eval-activity-card-button-icon {
 					width: var(--d2l-quick-eval-card-button-icon-size);
 					height: var(--d2l-quick-eval-card-button-icon-size);
-					border-radius: .3rem;
+					border-radius: var(--d2l-quick-eval-card-button-icon-border-radius);
 					display: flex;
 					justify-content: center;
 					align-items: center;
@@ -50,7 +51,7 @@ class D2LQuickEvalActivityCardActionButton extends mixinBehaviors(
 				button:hover,
 				button:hover d2l-icon,
 				button:focus,
-				buton:focus d2l-icon {
+				button:focus d2l-icon {
 					text-decoration: underline;
 					color: var(--d2l-color-celestine-minus-1);
 				}
@@ -79,6 +80,7 @@ class D2LQuickEvalActivityCardActionButton extends mixinBehaviors(
 						--d2l-quick-eval-card-button-icon-padding: 0.3rem;
 						--d2l-quick-eval-card-button-icon-focus-inner: 0 0 0 0.4rem white;
 						--d2l-quick-eval-card-button-icon-focus-outer: 0 0 0 0.5rem var(--d2l-color-celestine);
+						--d2l-quick-eval-card-button-icon-border-radius: .01rem;
 					}
 				}
 				:host([disabled]) button {

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
@@ -47,8 +47,8 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 				.d2l-quick-eval-card-meters span {
 					height: 2.7rem;
 				}
-				d2l-quick-eval-activity-card-subtitle {
-					height: .9rem;
+				.d2l-quick-eval-card-titles d2l-quick-eval-activity-card-subtitle {
+					min-height: .9rem;
 				}
 				d2l-quick-eval-activity-card-unread-submissions {
 					border-bottom: 1px solid var(--d2l-color-mica);
@@ -85,8 +85,15 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 					.d2l-quick-eval-card-meters span {
 						height: 3rem;
 					}
-					d2l-quick-eval-activity-card-subtitle {
+					.d2l-quick-eval-card-titles d2l-quick-eval-activity-card-subtitle {
 						display: inline;
+					}
+					.d2l-quick-eval-card-titles {
+						display: flex;
+					}
+					.d2l-quick-eval-card-titles h3 {
+						display: inline-block;
+						margin-right: .9rem;
 					}
 					d2l-quick-eval-activity-card-unread-submissions {
 						flex-grow: 1;
@@ -107,7 +114,7 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 					}
 					.d2l-quick-eval-card:hover,
 					.d2l-quick-eval-card:focus-within {
-						border-color: var(--d2l-color-celestine-plus-1);
+						border-color: var(--d2l-color-celestine-minus-1);
 						outline: none;
 					}
 					.d2l-quick-eval-card-indicator {
@@ -146,9 +153,10 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 					.d2l-quick-eval-card-titles {
 						min-width: 0;
 						min-height: 3rem;
+						display: block;
 					}
-					d2l-quick-eval-activity-card-subtitle {
-						height: 1.8rem;
+					.d2l-quick-eval-card-titles d2l-quick-eval-activity-card-subtitle {
+						min-height: 1.8rem;
 						display: flex;
 						align-items: flex-end;
 						margin-left: 1.5rem;

--- a/components/d2l-subtitle/d2l-subtitle.js
+++ b/components/d2l-subtitle/d2l-subtitle.js
@@ -18,7 +18,10 @@ class D2LSubtitle extends PolymerElement {
 				@media (min-width: 900px) {
 					span {
 						font-size: .7rem;
-						line-height: .7rem;
+						line-height: .9rem;
+					}
+					:host {
+						line-height: .9rem;
 					}
 				}
 			</style>


### PR DESCRIPTION
Fixes in this PR include:

1. `Hover effect on button needs a corner radius of 6px (current radius is 12px)` The div for the icon had its border radius set to 6px, however since the hover background also includes a box-shadow, the corner radius gets increased the farther out the box shadow goes 
![image](https://user-images.githubusercontent.com/54106708/63592999-f0ec1400-c580-11e9-8113-9c9354e6788c.png)
The red border is the div, and that corner radius is 6px, while the box shadow (6px outside the base div) ends up at 12px. Solution was to decrease the border-radius by the padding amount. Since at the largest size the padding and the corner radius are the same (and a border-radius of 0 would cause no rounding), we are just setting the border-radius very small (.01rem).
2. `Border colour of card on hover needs to be #004489 (New value of Celestine -1)`
3. `Need space between activity type and bullet before due date` - note that there is no change in this PR for this, as this was fixed with the new subtitle component, but is included in this summary to verify that it should no longer be an issue.
4. `Too much space between course name and first card` The line-height and font-size for the h2 that we're using for the course name are different, which causes padding around the course name so despite the fact that the h2 element itself was 24px from the first card, the text (roughly vertically centered in the h2 element) was too far away. After some trial and error with design, it seems that .8rem gives us the correct spacing.
5. `When wrapping, the metadata is displaying weird` This has also been fixed by the new subtitle component, however the line-height was much too large when we need to line wrap. After discussing with design, it was decided a line-height of .9rem was appropriate, and also that the activity card should expand vertically to account for the extra height if necessary.
6. `Between 525 – 899, there are some alignment issues` The subtitle has been moved to be inline with the activity name.