### PR TITLE
Add auto-versioning and release generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,20 @@ script:
     echo "Not a pull request and/or no secure environment variables, running headless tests...";
     npm run test:polymer:local || travis_terminate 1;
   fi
+after_success:
+- frauci-update-version && export TRAVIS_TAG=$(frauci-get-version)
+deploy:
+  provider: releases
+  api_key: "$GITHUB_RELEASE_TOKEN"
+  on:
+    tags: true
 env:
   global:
+  - OWNER_NAME: Brightspacehypermediacomponents
+  - REPO_NAME: activities
+  - DEFAULT_INCREMENT: patch
   - SAUCE_USERNAME: Desire2Learn
+  # SAUCE_ACCESS_KEY
   - secure: uI1bP8ViYhpBhMczmiqmDowwG5cqmqL1xr+RGRwbqxQiTbnDcGI77H/DEnbuKDYcSMZ/a4qqwN1DMoUWmD+n23oxUKSDr6dR0tP/6++Y0wykPU+79UX4SdTM2UvW4arcsU9Yy7MG7H+HsM8IaHqDUw+V/hIThK0/axE9qEUZyb2s3IQSbt6sJxDvFDlyeqMny9VABlV/PIG4IPJ4PsWPjSVFGAWUPE+64h2STxvRixd8DI6n53PqGZEXl5huWgKosfnmXS+S37gjGJXJmZj/kCLvvAoQi3L6k/Hlf/8QwCdnHkCjN8In8I278S+zBGQsBMhxUVuTbbUbNuf71oKaYutF0uYMCH+CPb7LcNbpC9sDFdxZXCLyMVQOAw38473SVXui2INxzq4lGI5Pf4PGhqh3gacg5PLg4QjDyRbI8Qx9axzn5vaFotgvW0t3ZSynNfhxOnPhUs7nQoJjhcJPRRBzGI33XSQzwZGOBLUiXrwGTyKTy6hHjGYV+EolH08mtCzXfGBdvTXbOf3e0AwNm7s00CO6ablwvtdSzfRDnKX0A+rMlbcJZp+4gTiqZV/jLMXTUoyteeZ6hn2C04z7xh0BiytpcW+Nx1VkCVr6JukgtzzA5HQAMub7ofklGvkACYn/IWATPlItMgRFg1Wydy6d4n3qSts50Qmyhq1W1NM=
+  # GITHUB_RELEASE_TOKEN (859f......865e)
+  - secure: QP5YZ7oT1NAyyLDhNG/kHii+SasV5zR/9XO5ePl2ThAevdpEgrLLk1A76NV0XZMMSRIdvgzMZIvPqHWfA81I2O7QCzXOJKQ+xj8hanGqUUNlGxgDMo8FGmqf7OWyxw+XHoM5E0P20yntmDQnCsYnuPvTwYyZ/6ujQgTbPli2ewvoZL+Doh+RnOHmc7R8HbdpU2Cv42PIZr/H/nW6tpuliP1fNrMvKwzjbRu+zh/ag62CkPOk0jbu6klXTwdwytb0jseY7Y/ybJ/0kOZGmgCguH3Lb2kj4Uncp78aQiAZFyCIurb6iXVZ5K7YtABbpWj2sRtMkJwQedTSCUY7PI8FTuvNowZ9URmJ5d4FAAbo03D6jgur4SHxakyV+iQj5z0vfmw5bJT/ykJzXFgyRTkjy/zznZE3arDeyRiLPKGmlKSYDS51eXUhJ2yqgFtsw3ArCqIoIm3xxe9Qy2DNsJllf/SGIhcGhPXIlG4Mj/59OiqNVJuXORJkwuj4SNK4ujkTGkHWYgwGEglhF9nCSPBOrITaFtyfECNvHc9HM/SeYyaDjMqrvXnGusoU6BKhxqiwhb2LhqrK9SRq6ibeP9ykjvi3PkrmbyVHKTAzXHxKJ5uS1orwQ7oOnC4p751pjZB570wIg4ENUsPML/EwbtfsqWjCYnzGZqOgP8mYDXDprr8=

--- a/README.md
+++ b/README.md
@@ -35,19 +35,6 @@ To lint AND run local unit tests:
 ```shell
 npm test
 ```
-## Releases
-
-To generate a new release:
-```shell
-npm version [major|minor|patch] -m "New version: %s"
-git push origin master --tags
-```
-
-This will update the version in the package.json file, commit that, and generate a new tag.
-
-Once the tag is generated, navigate to the [Releases](https://github.com/BrightspaceHypermediaComponents/activities/releases) tab and draft a new release that matches the tag. Here you can provide more detailed information on what has changed in the release.
-
-When Travis CI runs on the tagged release, it will be deployed to NPM.
 
 ## Usage
 
@@ -59,3 +46,9 @@ Quick Eval should be pulled directly from `my-unassessed-activities`:
 
 [ci-url]: https://travis-ci.org/BrightspaceUI/activities
 [ci-image]: https://travis-ci.org/BrightspaceUI/activities.svg?branch=master
+
+## Versioning, Releasing & Deploying
+
+ By default, when a pull request is merged the patch version in the `package.json` will be incremented, a tag will be created, and a Github release will be created.
+
+ Include `[increment major]`, `[increment minor]` or `[skip version]` in your merge commit message to change the default versioning behavior.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"eslint": "^5.1.0",
 		"eslint-config-brightspace": "^0.4.0",
 		"eslint-plugin-html": "^4.0.5",
+		"frau-ci": "^1.40.0",
 		"gulp": "^4.0.0",
 		"gulp-cli": "^2.0.1",
 		"gulp-ejs": "^3.1.3",
@@ -37,7 +38,7 @@
 		"wct-browser-legacy": "^1.0.1",
 		"whatwg-fetch": "^3.0.0"
 	},
-	"version": "3.2.1",
+	"version": "3.45.0",
 	"resolutions": {
 		"inherits": "2.0.3",
 		"samsam": "1.1.3",


### PR DESCRIPTION
# Changes
1. Add auto-versioning using `frau-ci` with the default behavior being to bump the patch version if no increment tag is specified in the commit.
1. Add automatic release creation
1. Update the `package.json` version to be consistent with the current release version.
