### PR TITLE
DE35611-fix low contrast issue from the new design

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
@@ -65,6 +65,9 @@ class D2LQuickEvalViewToggle extends QuickEvalLocalize(PolymerElement) {
 					border-color: var(--d2l-color-tungsten);
 					color: var(--d2l-color-white);
 				}
+				:host button[selected]:hover, :host button[selected]:focus {
+					box-shadow: inset 0 0 0 2px #ffffff;
+				}
 				:host {
 					width: 100%;
 					display: flex;


### PR DESCRIPTION
Fix the low contrast when the button is selected and in focus/hover states (button background color and the border), see new design from here https://rally1.rallydev.com/#/15545167705d/detail/defect/328634861272.