### PR TITLE
Remove unneeded DOM nodes and style the :host instead

### DIFF
--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-items.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-items.js
@@ -7,12 +7,12 @@ class D2LQuickEvalActivityCardItems extends mixinBehaviors([D2L.PolymerBehaviors
 	static get template() {
 		return html`
 			<style include="d2l-visible-on-ancestor-styles">
-				.d2l-quick-eval-activity-card-items-container {
+				:host {
 					display: flex;
 					align-items: stretch;
 					justify-content: space-between;
 				}
-				.d2l-quick-eval-activity-card-items-container ::slotted(*) {
+				:host ::slotted(*) {
 					width: 7.5rem;
 					height: 3rem;
 					text-align: center;
@@ -22,12 +22,12 @@ class D2LQuickEvalActivityCardItems extends mixinBehaviors([D2L.PolymerBehaviors
 					flex: 1 1 auto;
 				}
 				@media (min-width: 525px) {
-					.d2l-quick-eval-activity-card-items-container ::slotted(div) {
+					:host ::slotted(div) {
 						border-width: 0 1px 0 0;
 						border-style: solid;
 						border-color: var(--d2l-color-mica);
 					}
-					.d2l-quick-eval-activity-card-items-container ::slotted(*:last-child) {
+					:host ::slotted(*:last-child) {
 						border-right-width: 0;
 					}
 					:host([small]) ::slotted(*) {
@@ -35,24 +35,22 @@ class D2LQuickEvalActivityCardItems extends mixinBehaviors([D2L.PolymerBehaviors
 					}
 				}
 				@media (min-width: 900px) {
-					:host([small]) .d2l-quick-eval-activity-card-items-container ::slotted(*) {
+					:host([small]) :host ::slotted(*) {
 						border-width: 0 1px 0 0;
 						border-style: solid;
 						border-color: var(--d2l-color-mica);
 					}
 					:host([small]) ::slotted(*:first-child),
-					.d2l-quick-eval-activity-card-items-container ::slotted(*:first-child) {
+					:host ::slotted(*:first-child) {
 						border-left-width: 1px;
 					}
 					:host([small]) ::slotted(*:last-child),
-					.d2l-quick-eval-activity-card-items-container ::slotted(*:last-child) {
+					:host ::slotted(*:last-child) {
 						border-right-width: 1px;
 					}
 				}
 			</style>
-			<div class="d2l-quick-eval-activity-card-items-container">
-				<slot></slot>
-			</div>
+			<slot></slot>
 		`;
 	}
 }

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-items.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-items.js
@@ -35,7 +35,7 @@ class D2LQuickEvalActivityCardItems extends mixinBehaviors([D2L.PolymerBehaviors
 					}
 				}
 				@media (min-width: 900px) {
-					:host([small]) :host ::slotted(*) {
+					:host([small]) ::slotted(*) {
 						border-width: 0 1px 0 0;
 						border-style: solid;
 						border-color: var(--d2l-color-mica);

--- a/components/d2l-quick-eval/d2l-quick-eval-search-results-summary-container.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-search-results-summary-container.js
@@ -6,16 +6,11 @@ class D2LQuickEvalSearchResultsSummaryContainer extends QuickEvalLocalize(Polyme
 	static get template() {
 		return html `
 		<style>
-			.d2l-msg-container {
+			:host {
 				border-radius: 8px;
 				background-color: var(--d2l-color-regolith);
 				border: 1px solid var(--d2l-color-gypsum);
 				color: var(--d2l-color-ferrite);
-			}
-			.d2l-msg-container-inner {
-				padding: 0;
-			}
-			.d2l-msg-container-text {
 				padding: 10px 20px;
 			}
 			span {
@@ -26,14 +21,8 @@ class D2LQuickEvalSearchResultsSummaryContainer extends QuickEvalLocalize(Polyme
 				margin-left: 2.3em;
 			}
 		</style>
-		<div class="d2l-msg-container">
-			<div class="d2l-msg-container-inner">
-				<div class="d2l-msg-container-text">
-					<span class="d2l-quick-eval-search-results-summary">[[_getSummaryString(searchResultsCount, moreResults)]]</span>
-					<d2l-link on-click="_linkClicked">[[localize('clearSearch')]]</d2l-link>
-				</div>
-			</div>
-		</div>
+		<span class="d2l-quick-eval-search-results-summary">[[_getSummaryString(searchResultsCount, moreResults)]]</span>
+		<d2l-link on-click="_linkClicked">[[localize('clearSearch')]]</d2l-link>
 		`;
 	}
 	static get properties() {

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions-table.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions-table.js
@@ -185,7 +185,7 @@ class D2LQuickEvalSubmissionsTable extends QuickEvalLogging(QuickEvalLocalize(Po
 											class="d2l-user-badge-image"
 											href="[[s.userHref]]"
 											token="[[token]]"
-											small=""
+											small
 											aria-hidden="true">
 										</d2l-profile-image>
 									</template>


### PR DESCRIPTION
This crosses off 2 Lockhart items (one of which is really small):
`Templates - Avoid Unnecessary DOM Nodes (Slide 18)` - majority of this PR
`Templates - Boolean attributes (Slide 16)` - one line, since I didn't find any other outstanding instances of this.

Again, this is a no-op change - I played around with it on the demo page with Quad data and it looks the same as before :) I would appreciate a verify of this - thanks!