### PR TITLE
Remove unneeded reflectToAttribute

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-submissions-table.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions-table.js
@@ -251,8 +251,7 @@ class D2LQuickEvalSubmissionsTable extends QuickEvalLogging(QuickEvalLocalize(Po
 		return {
 			masterTeacher: {
 				type: Boolean,
-				value: false,
-				reflectToAttribute: true
+				value: false
 			},
 			_headerColumns: {
 				type: Array,

--- a/components/d2l-quick-eval/d2l-quick-eval.js
+++ b/components/d2l-quick-eval/d2l-quick-eval.js
@@ -60,13 +60,11 @@ class D2LQuickEval extends  QuickEvalLocalize(PolymerElement) {
 			},
 			masterTeacher: {
 				type: Boolean,
-				value: false,
-				reflectToAttribute: true
+				value: false
 			},
 			activitiesViewEnabled: {
 				type: Boolean,
-				value: false,
-				reflectToAttribute: true
+				value: false
 			},
 			_showActivitiesView: {
 				type: Boolean,


### PR DESCRIPTION
Lockhart list: `Web Components - reflectToAttribute (Slide 19)`

As per: https://polymer-library.polymer-project.org/3.0/docs/devguide/properties#attribute-reflection

We don't need to use `reflectToAttribute: true` if the variable in question does not change within the component. As the only time a value would be reflected back to the attribute would be on a value change.