### PR TITLE
add a nullcheck to address errors bubbling up to kibana

### DIFF
--- a/components/d2l-activity-name/d2l-activity-name.js
+++ b/components/d2l-activity-name/d2l-activity-name.js
@@ -95,6 +95,9 @@ class D2LActivityName extends mixinBehaviors([D2L.PolymerBehaviors.Siren.EntityB
 	async _getActivityPromise(activityEntity) {
 		let rel;
 		let activityIcon;
+		if (!activityEntity) {
+			return Promise.resolve();
+		}
 		if (activityEntity.hasClass(Classes.activities.userQuizAttemptActivity) || activityEntity.hasClass(Classes.activities.userQuizActivity)) {
 			rel = Rels.quiz;
 			activityIcon = 'd2l-tier1:quizzing';


### PR DESCRIPTION
This is to address 
```
TypeError: Cannot read property 'hasClass' of null
    at HTMLElement.<anonymous> (https://s.brightspace.com/lib/bsi/20.19.9-75/es6-bundled/web-components/bsi.js:1344:5787)
```

I checked the instance system logs and there is nothing logged during the window that this happened, I can only attribute it to a network blip or something innocuous. 