### PR TITLE
Screen readers should read tooltip text for draft icon.

### DIFF
--- a/components/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.js
+++ b/components/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.js
@@ -23,13 +23,12 @@ class ActivityEvaluationIconBase extends ActivityEvaluationIconBaseLocalize(Poly
 				}
 			</style>
 			<template is="dom-if" if="[[draft]]">
-				<d2l-icon aria-labelledby$="[[_tooltipId]]" icon="d2l-tier1:draft"></d2l-icon>
+				<d2l-icon aria-label$="[[_label]]" icon="d2l-tier1:draft"></d2l-icon>
 				<d2l-tooltip
-					id$="[[_tooltipId]]"
 					position="bottom"
 					offset="15"
 				>
-					[[localize('draftInfo')]]
+					[[_label]]
 				</d2l-tooltip>
 			</template>
 		`;
@@ -44,15 +43,11 @@ class ActivityEvaluationIconBase extends ActivityEvaluationIconBaseLocalize(Poly
 				value: false,
 				reflectToAttribute: true
 			},
-			_tooltipId: {
+			_label: {
 				type:String,
-				computed: '_computeId()'
+				computed: 'localize("draftInfo")'
 			}
 		};
-	}
-
-	_computeId() {
-		return D2L.Id.getUniqueId();
 	}
 }
 

--- a/components/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.js
+++ b/components/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.js
@@ -23,9 +23,9 @@ class ActivityEvaluationIconBase extends ActivityEvaluationIconBaseLocalize(Poly
 				}
 			</style>
 			<template is="dom-if" if="[[draft]]">
-				<d2l-icon id$="[[_tooltipForId]]" icon="d2l-tier1:draft"></d2l-icon>
+				<d2l-icon aria-labelledby$="[[_tooltipId]]" icon="d2l-tier1:draft"></d2l-icon>
 				<d2l-tooltip
-					for="[[_tooltipForId]]"
+					id$="[[_tooltipId]]"
 					position="bottom"
 					offset="15"
 				>
@@ -44,14 +44,14 @@ class ActivityEvaluationIconBase extends ActivityEvaluationIconBaseLocalize(Poly
 				value: false,
 				reflectToAttribute: true
 			},
-			_tooltipForId: {
-				type: String,
-				computed: '_computeTooltipForId()'
+			_tooltipId: {
+				type:String,
+				computed: '_computeId()'
 			}
 		};
 	}
 
-	_computeTooltipForId() {
+	_computeId() {
 		return D2L.Id.getUniqueId();
 	}
 }

--- a/components/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.js
+++ b/components/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.js
@@ -23,12 +23,12 @@ class ActivityEvaluationIconBase extends ActivityEvaluationIconBaseLocalize(Poly
 				}
 			</style>
 			<template is="dom-if" if="[[draft]]">
-				<d2l-icon aria-label$="[[_label]]" icon="d2l-tier1:draft"></d2l-icon>
+				<d2l-icon aria-label$="[[localize('draftInfo')]]" icon="d2l-tier1:draft"></d2l-icon>
 				<d2l-tooltip
 					position="bottom"
 					offset="15"
 				>
-					[[_label]]
+					[[localize('draftInfo')]]
 				</d2l-tooltip>
 			</template>
 		`;
@@ -42,10 +42,6 @@ class ActivityEvaluationIconBase extends ActivityEvaluationIconBaseLocalize(Poly
 				type: Boolean,
 				value: false,
 				reflectToAttribute: true
-			},
-			_label: {
-				type:String,
-				computed: 'localize("draftInfo")'
 			}
 		};
 	}

--- a/test/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.js
+++ b/test/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.js
@@ -30,7 +30,7 @@
 				assert.equal('d2l-tier1:draft', draftIconName);
 
 				var draftIconToolTip = draftEvaluation.shadowRoot.querySelector('d2l-tooltip');
-				assert.equal(draftIcon.id, draftIconToolTip.for);
+				assert.equal(draftIcon.getAttribute('aria-labelledby'), draftIconToolTip.id);
 				assert.equal('bottom', draftIconToolTip.getAttribute('position'));
 				assert.equal('15', draftIconToolTip.getAttribute('offset'));
 

--- a/test/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.js
+++ b/test/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.js
@@ -30,7 +30,6 @@
 				assert.equal('d2l-tier1:draft', draftIconName);
 
 				var draftIconToolTip = draftEvaluation.shadowRoot.querySelector('d2l-tooltip');
-				assert.equal(draftIcon.getAttribute('aria-labelledby'), draftIconToolTip.id);
 				assert.equal('bottom', draftIconToolTip.getAttribute('position'));
 				assert.equal('15', draftIconToolTip.getAttribute('offset'));
 


### PR DESCRIPTION
Should be no visual change. Screen readers should now read the tooltip when navigating to the draft icon.