### PR TITLE
US109690 - send collectionSearch param to evaluation page

### DIFF
--- a/components/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
+++ b/components/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
@@ -85,6 +85,15 @@ D2L.PolymerBehaviors.Siren.D2LSirenHelperBehaviorImpl = {
 				}
 			);
 		}
+		const searchVal = GetQueryStringParam('collectionSearch', parsedUrl);
+		if (searchVal) {
+			extraParams.push(
+				{
+					name: 'collectionSearch',
+					value: searchVal
+				}
+			);
+		}
 
 		return extraParams;
 	},

--- a/test/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
+++ b/test/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
@@ -214,7 +214,7 @@
 			test('when parsing url for sort and filter params, if only collectionSearch is present, return array with correct values', () => {
 				const url = 'https://www.example.com/?pageSize=20&collectionSearch=ragnaros';
 
-				var params = component._getExtraParams(url);
+				const params = component._getExtraParams(url);
 				assert.equal(params.length, 1);
 
 				const expectedParams = [

--- a/test/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
+++ b/test/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
@@ -160,11 +160,11 @@
 				var params = component._getExtraParams(null);
 				assert.equal(params.length, 0);
 			});
-			test('when parsing url for sort and filter params, if they are both present, return array with correct values', () => {
-				const url = 'https://www.example.com/?pageSize=20&filter=96W3siU29ydCI6eyJJ&sort=Y3Rpb24iOjB9';
+			test('when parsing url for sort, filter, and collectionSearch params, if they are all present, return array with correct values', () => {
+				const url = 'https://www.example.com/?pageSize=20&filter=96W3siU29ydCI6eyJJ&sort=Y3Rpb24iOjB9&collectionSearch=arthas';
 
 				var params = component._getExtraParams(url);
-				assert.equal(params.length, 2);
+				assert.equal(params.length, 3);
 
 				const expectedParams = [
 					{
@@ -174,6 +174,10 @@
 					{
 						name: 'sort',
 						value: 'Y3Rpb24iOjB9'
+					},
+					{
+						name: 'collectionSearch',
+						value: 'arthas'
 					}
 				];
 				assert.deepEqual(params, expectedParams);
@@ -202,6 +206,21 @@
 					{
 						name: 'filter',
 						value: '96W3siU29ydCI6eyJJ'
+					}
+				];
+				assert.deepEqual(params, expectedParams);
+			});
+
+			test('when parsing url for sort and filter params, if only collectionSearch is present, return array with correct values', () => {
+				const url = 'https://www.example.com/?pageSize=20&collectionSearch=ragnaros';
+
+				var params = component._getExtraParams(url);
+				assert.equal(params.length, 1);
+
+				const expectedParams = [
+					{
+						name: 'collectionSearch',
+						value: 'ragnaros'
 					}
 				];
 				assert.deepEqual(params, expectedParams);


### PR DESCRIPTION
Problem: Search is not persisted when you go QE -> Evaluate -> Back to QE
Solution: Send search params to the evaluation page

This is only half the battle, we need an LMS change to echo the search params back to QE.

FYI @amauryperez since you will be reviewing the LMS change