### PR TITLE
US109690 - display currently searched term on initial load

### DIFF
--- a/components/d2l-quick-eval/behaviors/d2l-hm-search-behavior.js
+++ b/components/d2l-quick-eval/behaviors/d2l-hm-search-behavior.js
@@ -26,6 +26,10 @@ D2L.PolymerBehaviors.QuickEval.D2LHMSearchBehaviourImpl = {
 		searchLoading: {
 			type: Boolean,
 			value: false
+		},
+		searchTerm: {
+			type: String,
+			computed: '_computeSearchTerm(entity)'
 		}
 	},
 
@@ -43,6 +47,22 @@ D2L.PolymerBehaviors.QuickEval.D2LHMSearchBehaviourImpl = {
 
 	_computeSearchAction: function(entity) {
 		return this._getAction(entity, 'search');
+	},
+
+	_computeSearchTerm: function(entity) {
+		if (!entity) {
+			return;
+		}
+		const searchTerm = entity
+			.getActionByName('search')
+			.getFieldByName('collectionSearch')
+			.value;
+
+		if (searchTerm) {
+			this.searchApplied = true;
+		}
+
+		return searchTerm;
 	},
 
 	onSearchResultsLoading: function() {

--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -130,6 +130,7 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 					search-action="[[searchAction]]"
 					placeholder="[[localize('search')]]"
 					aria-label$="[[localize('search')]]"
+					initial-value="[[searchTerm]]"
 					>
 				</d2l-hm-search>
 			</div>
@@ -145,7 +146,7 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 			</d2l-alert>
 			<d2l-quick-eval-search-results-summary-container
 				search-results-count="[[_searchResultsCount]]"
-				hidden$="[[!searchApplied]]"
+				hidden$="[[!_showSearchSummary]]"
 				on-d2l-quick-eval-search-results-summary-container-clear-search="clearSearchResults">
 			</d2l-quick-eval-search-results-summary-container>
 			<div class="d2l-quick-eval-no-submissions" hidden$="[[!_shouldShowNoSubmissions(_data, _loading, _isError, filterApplied, searchApplied)]]">
@@ -213,6 +214,10 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 			_publishAllToasts: {
 				type: Array,
 				value: []
+			},
+			_showSearchSummary: {
+				type: Boolean,
+				computed: '_computeShowSearchSummary(_loading, filtersLoading, searchLoading, searchApplied)'
 			}
 		};
 	}
@@ -440,6 +445,10 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 			return this.localize('publishAllToastMessageTruncated', 'truncatedActivityName', toast.activityName.substring(0, maxLength));
 		}
 		return this.localize('publishAllToastMessage', 'activityName', toast.activityName);
+	}
+
+	_computeShowSearchSummary(_loading, filtersLoading, searchLoading, searchApplied) {
+		return !_loading && !filtersLoading && !searchLoading && searchApplied;
 	}
 
 	ready() {

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -104,7 +104,8 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 					search-action="[[searchAction]]"
 					placeholder="[[localize('search')]]"
 					result-size="[[_numberOfActivitiesToShow]]"
-					aria-label$="[[localize('search')]]">
+					aria-label$="[[localize('search')]]"
+					initial-value="[[searchTerm]]">
 				</d2l-hm-search>
 			</div>
 			<div class="clear"></div>
@@ -117,7 +118,7 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 			<d2l-quick-eval-search-results-summary-container
 				search-results-count="[[_searchResultsCount]]"
 				more-results="[[_moreSearchResults]]"
-				hidden$="[[!_searchResultsMessageEnabled(searchApplied)]]"
+				hidden$="[[!_showSearchSummary]]"
 				on-d2l-quick-eval-search-results-summary-container-clear-search="clearSearchResults">
 			</d2l-quick-eval-search-results-summary-container>
 			<d2l-quick-eval-submissions-table
@@ -240,6 +241,10 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 			},
 			hidden: {
 				type: Boolean
+			},
+			_showSearchSummary: {
+				type: Boolean,
+				computed: '_computeShowSearchSummary(_loading, filtersLoading, searchLoading, searchApplied)'
 			}
 		};
 	}
@@ -509,6 +514,10 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 
 	_computeShowLoadingSkeleton(_loading, filtersLoading, searchLoading) {
 		return _loading || filtersLoading || searchLoading;
+	}
+
+	_computeShowSearchSummary(_loading, filtersLoading, searchLoading, searchApplied) {
+		return !_loading && !filtersLoading && !searchLoading && searchApplied;
 	}
 
 	ready() {

--- a/test/d2l-quick-eval/behaviors/d2l-hm-search-behavior.js
+++ b/test/d2l-quick-eval/behaviors/d2l-hm-search-behavior.js
@@ -1,7 +1,29 @@
 import SirenParse from 'siren-parser';
 
 (function() {
-	var searchBehavior;
+	let searchBehavior;
+
+	function makeEntity(term) {
+		const entity = {
+			'actions': [
+				{
+					'name': 'search',
+					'href': '/not/a/real/url',
+					fields: [
+						{ name: 'collectionSearch' }
+					]
+				}
+			]
+		};
+
+		if (term) {
+			entity.actions[0].fields[0].value = term;
+		}
+
+		const parsedEntity = SirenParse(entity);
+
+		return parsedEntity;
+	}
 
 	suite('d2l-hm-search-behavior', function() {
 		setup(function() {
@@ -14,16 +36,8 @@ import SirenParse from 'siren-parser';
 			assert.isFalse(searchBehavior.searchLoading);
 		});
 		test('properly sets searchAction given valid entity', () => {
-			const entity = {
-				'actions': [
-					{
-						'name': 'search',
-						'href': '/not/a/real/url'
-					}
-				]
-			};
+			const parsedEntity = makeEntity();
 
-			const parsedEntity = SirenParse(entity);
 			searchBehavior.entity = parsedEntity;
 			assert.isOk(searchBehavior.searchAction);
 			assert.equal(searchBehavior.searchAction, parsedEntity.actions[0]);
@@ -32,6 +46,19 @@ import SirenParse from 'siren-parser';
 		test('Properly set searchAction given invalid entity', () => {
 			searchBehavior.entity = null;
 			assert.isNotOk(searchBehavior.searchAction);
+		});
+
+		test('properly sets searchTerm given valid entity', () => {
+			const searchTerm = 'assignment';
+			const parsedEntity = makeEntity(searchTerm);
+
+			searchBehavior.entity = parsedEntity;
+			assert.equal(searchBehavior.searchTerm, searchTerm);
+		});
+
+		test('properly sets searchTerm given invalid entity', () => {
+			searchBehavior.entity = null;
+			assert.isNotOk(searchBehavior.searchTerm);
 		});
 
 		test('d2l-hm-search-results-loading sets searchLoading to true', () => {
@@ -44,13 +71,14 @@ import SirenParse from 'siren-parser';
 		});
 
 		test('d2l-hm-search-results-loaded sets searchLoading to false and entity to results and error to null', () => {
-			const results = ['some', 'arbitrary', 'results'];
+			const parsedEntity = makeEntity();
+
 			searchBehavior.dispatchEvent(
 				new CustomEvent(
 					'd2l-hm-search-results-loaded',
 					{
 						detail: {
-							results: results,
+							results: parsedEntity,
 							searchIsCleared: false
 						}
 					}
@@ -58,7 +86,7 @@ import SirenParse from 'siren-parser';
 			);
 			assert.isTrue(searchBehavior.searchApplied);
 			assert.isFalse(searchBehavior.searchLoading);
-			assert.equal(results, searchBehavior.entity);
+			assert.equal(parsedEntity, searchBehavior.entity);
 			assert.isNull(searchBehavior.searchError);
 		});
 
@@ -88,7 +116,7 @@ import SirenParse from 'siren-parser';
 					'd2l-hm-search-results-loaded',
 					{
 						detail: {
-							results: [],
+							results: makeEntity(),
 							searchIsCleared: true
 						}
 					}


### PR DESCRIPTION
Problem: we want to be able to persist search state during evaluation
Problem: search state is persisted, but upon load the search state is not displayed to the user
Solution: use the new `initialValue` property of `d2l-hm-search` from https://github.com/BrightspaceHypermediaComponents/common/pull/32
 
FYI @jeroach since you found the bug in the first place