### PR TITLE
Allow quick eval to dynamically respond to activitiesHref changes

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval.js
+++ b/components/d2l-quick-eval/d2l-quick-eval.js
@@ -57,7 +57,7 @@ class D2LQuickEval extends
 			</template>
 			<d2l-quick-eval-view-toggle current-selected="[[toggleState]]" toggle-href="[[toggleHref]]" hidden$="[[!activitiesViewEnabled]]" on-d2l-quick-eval-view-toggle-changed="_toggleView"></d2l-quick-eval-view-toggle>
 			<d2l-quick-eval-submissions href="[[submissionsHref]]" token="[[token]]" logging-endpoint="[[loggingEndpoint]]" data-telemetry-endpoint="[[dataTelemetryEndpoint]]" hidden$="[[_showActivitiesView]]" master-teacher="[[masterTeacher]]"></d2l-quick-eval-submissions>
-			<d2l-quick-eval-activities href="[[_activitiesHref(activitiesViewEnabled)]]" token="[[token]]" logging-endpoint="[[loggingEndpoint]]" hidden$="[[!_showActivitiesView]]"></d2l-quick-eval-activities>
+			<d2l-quick-eval-activities href="[[_activitiesHref(activitiesViewEnabled, activitiesHref)]]" token="[[token]]" logging-endpoint="[[loggingEndpoint]]" hidden$="[[!_showActivitiesView]]"></d2l-quick-eval-activities>
 		`;
 	}
 	ready() {


### PR DESCRIPTION
Problem: Activities does not work when you dynamically set `activitiesHref` because the `_activitiesHref` function is only called when one if its parameters change
Problem: This was preventing auth-me (the dev tool I'm creating to automatically fetch keys) from working with activities
Solution: force polymer to recalculate `_activitiesHref` when `activitiesHref` changes