### PR TITLE
Integrate PendingContainerMixin into activity editor

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -4,9 +4,8 @@ import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { AssignmentActivityUsageEntity } from 'siren-sdk/src/activities/assignments/AssignmentActivityUsageEntity.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
-import { PendingContainerMixin } from 'siren-sdk/src/mixin/pending-container-mixin.js';
 
-class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LocalizeMixin(LitElement))) {
+class AssignmentEditor extends EntityMixinLit(LocalizeMixin(LitElement)) {
 
 	static get properties() {
 		return {
@@ -65,10 +64,8 @@ class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LocalizeMixi
 	}
 
 	render() {
-		// console.log('Assigment render');
 		return html`
-			<div ?hidden="${!this._hasPendingChildren}">Loading ...</div>
-			<d2l-activity-editor ?hidden="${this._hasPendingChildren}">
+			<d2l-activity-editor>
 				<d2l-activity-assignment-editor-detail
 					.href="${this._assignmentHref}"
 					.token="${this.token}"

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -4,8 +4,9 @@ import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { AssignmentActivityUsageEntity } from 'siren-sdk/src/activities/assignments/AssignmentActivityUsageEntity.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { PendingContainerMixin } from 'siren-sdk/src/mixin/pending-container-mixin.js';
 
-class AssignmentEditor extends EntityMixinLit(LocalizeMixin(LitElement)) {
+class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LocalizeMixin(LitElement))) {
 
 	static get properties() {
 		return {
@@ -64,8 +65,10 @@ class AssignmentEditor extends EntityMixinLit(LocalizeMixin(LitElement)) {
 	}
 
 	render() {
+		// console.log('Assigment render');
 		return html`
-			<d2l-activity-editor>
+			<div ?hidden="${!this._hasPendingChildren}">Loading ...</div>
+			<d2l-activity-editor ?hidden="${this._hasPendingChildren}">
 				<d2l-activity-assignment-editor-detail
 					.href="${this._assignmentHref}"
 					.token="${this.token}"

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -4,8 +4,9 @@ import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { AssignmentActivityUsageEntity } from 'siren-sdk/src/activities/assignments/AssignmentActivityUsageEntity.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { PendingContainerMixin } from 'siren-sdk/src/mixin/pending-container-mixin.js';
 
-class AssignmentEditor extends EntityMixinLit(LocalizeMixin(LitElement)) {
+class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LocalizeMixin(LitElement))) {
 
 	static get properties() {
 		return {
@@ -65,7 +66,7 @@ class AssignmentEditor extends EntityMixinLit(LocalizeMixin(LitElement)) {
 
 	render() {
 		return html`
-			<d2l-activity-editor>
+			<d2l-activity-editor ?loading="${this._hasPendingChildren}">
 				<d2l-activity-assignment-editor-detail
 					.href="${this._assignmentHref}"
 					.token="${this.token}"

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -1,6 +1,7 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { PendingContainerMixin } from 'siren-sdk/src/mixin/pending-container-mixin.js';
 
-class ActivityEditor extends LitElement {
+class ActivityEditor extends PendingContainerMixin(LitElement) {
 
 	static get styles() {
 		return css`
@@ -15,7 +16,10 @@ class ActivityEditor extends LitElement {
 
 	render() {
 		return html`
-			<slot name="editor"></slot>
+			<div ?hidden="${!this._hasPendingChildren}">Loading ...</div>
+			<div ?hidden="${this._hasPendingChildren}">
+				<slot name="editor"></slot>
+			</div>
 		`;
 	}
 }

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -1,7 +1,12 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
-import { PendingContainerMixin } from 'siren-sdk/src/mixin/pending-container-mixin.js';
 
-class ActivityEditor extends PendingContainerMixin(LitElement) {
+class ActivityEditor extends LitElement {
+
+	static get properties() {
+		return {
+			loading: { type: Boolean },
+		};
+	}
 
 	static get styles() {
 		return css`
@@ -16,8 +21,8 @@ class ActivityEditor extends PendingContainerMixin(LitElement) {
 
 	render() {
 		return html`
-			<div ?hidden="${!this._hasPendingChildren}">Loading ...</div>
-			<div ?hidden="${this._hasPendingChildren}">
+			<div ?hidden="${!this.loading}">Loading ...</div>
+			<div ?hidden="${this.loading}">
 				<slot name="editor"></slot>
 			</div>
 		`;


### PR DESCRIPTION
This PR makes the `d2l-activity-assignment-editor` a `PendingContainer` so it tracks the loading of all it's child components.

It uses the `_hasPendingChildren` state to set a property on the `d2l-activity-editor` to control whether the `d2l-activity-editor` renders a loading placeholder (will soon be replaced with a skeleton image so not bothering to localize it for now) or renders the actual editor detail.

I considered making the `d2l-activity-editor` itself the `PendingContainer` so that we don't have to add that to every other activity editor instance, but it really needs to be on the top level so that it can also take into account the loading of the initial activity usage URL.