### PR TITLE
Create error handling mixin for setting and clearing errors

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -3,11 +3,11 @@ import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { AssignmentEntity } from 'siren-sdk/src/activities/assignments/AssignmentEntity.js';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
+import { ErrorHandlingMixin } from '../error-handling-mixin.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 import { SirenFetchMixinLit } from 'siren-sdk/src/mixin/siren-fetch-mixin-lit.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
-import { ErrorHandlingMixin } from '../error-handling-mixin.js';
 
 class AssignmentEditorDetail extends ErrorHandlingMixin(SirenFetchMixinLit(EntityMixinLit(LocalizeMixin(LitElement)))) {
 

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -7,8 +7,9 @@ import { labelStyles } from '@brightspace-ui/core/components/typography/styles.j
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 import { SirenFetchMixinLit } from 'siren-sdk/src/mixin/siren-fetch-mixin-lit.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
+import { ErrorHandlingMixin } from '../error-handling-mixin.js';
 
-class AssignmentEditorDetail extends SirenFetchMixinLit(EntityMixinLit(LocalizeMixin(LitElement))) {
+class AssignmentEditorDetail extends ErrorHandlingMixin(SirenFetchMixinLit(EntityMixinLit(LocalizeMixin(LitElement)))) {
 
 	static get properties() {
 		return {
@@ -82,10 +83,15 @@ class AssignmentEditorDetail extends SirenFetchMixinLit(EntityMixinLit(LocalizeM
 	_saveNameOnInput(e) {
 		const name = e.target.value;
 		const isNameEmpty = (name || '').trim().length === 0;
+
+		const errorProperty = '_nameError';
+		const emptyNameErrorLangterm = 'emptyNameError';
+		const tooltipId = 'name-tooltip';
+
 		if (isNameEmpty) {
-			this._nameError = this.localize('emptyNameError');
+			this.setError(errorProperty, emptyNameErrorLangterm, tooltipId);
 		} else {
-			this._nameError = '';
+			this.clearError(errorProperty);
 			this._debounceJob = Debouncer.debounce(
 				this._debounceJob,
 				timeOut.after(500),

--- a/components/d2l-activity-editor/error-handling-mixin.js
+++ b/components/d2l-activity-editor/error-handling-mixin.js
@@ -1,9 +1,6 @@
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 
 export const ErrorHandlingMixin = superclass => class extends LocalizeMixin(superclass) {
-	constructor() {
-		super();
-	}
 
 	async setError(errorProperty, langterm, tooltipId) {
 		this[errorProperty] = this.localize(langterm);

--- a/components/d2l-activity-editor/error-handling-mixin.js
+++ b/components/d2l-activity-editor/error-handling-mixin.js
@@ -1,6 +1,6 @@
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 
-export const ErrorHandlingMixin = superclass => class extends superclass {
+export const ErrorHandlingMixin = superclass => class extends LocalizeMixin(superclass) {
 	constructor() {
 		super();
 	}

--- a/components/d2l-activity-editor/error-handling-mixin.js
+++ b/components/d2l-activity-editor/error-handling-mixin.js
@@ -1,0 +1,25 @@
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+
+export const ErrorHandlingMixin = superclass => class extends superclass {
+	constructor() {
+		super();
+	}
+
+	async setError(errorProperty, langterm, tooltipId) {
+		this[errorProperty] = this.localize(langterm);
+
+		await this.updateComplete;
+		this._showTooltip(tooltipId);
+	}
+
+	clearError(errorProperty) {
+		this[errorProperty] = '';
+	}
+
+	_showTooltip(tooltipId) {
+		const tooltipElem = this.shadowRoot.getElementById(tooltipId);
+		if (tooltipElem) {
+			tooltipElem.show();
+		}
+	}
+};


### PR DESCRIPTION
When we have the tooltip conditionally render, the tooltip will not initially show. The easiest way to work around that is to manually call `show()` on the tooltip.

If the tooltips did not conditionally render, we wouldn't need to do this. But due to possible impacts on performance, we should have it conditionally render.