### PR TITLE
US110605 Followup: Serge run_command

### DIFF
--- a/activities.serge.json
+++ b/activities.serge.json
@@ -97,7 +97,7 @@
     "callback_plugins": [{
       "plugin": "run_command",
       "data": {
-        "command": "echo \"export const translations = JSON.parse(\\`$(cat %OUTFILE%)\\`);\" > %OUTPATH%/build/%LANG%.js"
+        "command": "echo \"export const translations = $(cat %OUTFILE%);\" > %OUTPATH%/build/%LANG%.js"
       }
     }]
   }

--- a/activities.serge.json
+++ b/activities.serge.json
@@ -97,17 +97,7 @@
     "callback_plugins": [{
       "plugin": "run_command",
       "data": {
-        "command": "export LANG_PATH=./components/d2l-activity-editor/d2l-activity-assignment-editor/lang"
-      }
-    },{
-      "plugin": "run_command",
-      "data": {
-        "command": "rm -rf $LANG_PATH/build && mkdir -p $LANG_PATH/build"
-      }
-    }, {
-      "plugin": "run_command",
-      "data": {
-        "command": "for language in $(find $LANG_PATH -name \"*.json\" -type f -printf \"%f\\n\" | sed 's/\\.json$//'); do echo \"export const translations = JSON.parse(\\`$(cat $LANG_PATH/$language.json)\\`);\" > $LANG_PATH/build/$language.js; done"
+        "command": "echo \"export const translations = JSON.parse(\\`$(cat %OUTFILE%)\\`);\" > %OUTPATH%/build/%LANG%.js"
       }
     }]
   }

--- a/activities.serge.json
+++ b/activities.serge.json
@@ -93,6 +93,22 @@
       "tr-tr tr",
       "zh-cn zh",
       "zh-tw zh-tw"
-    ]
+    ],
+    "callback_plugins": [{
+      "plugin": "run_command",
+      "data": {
+        "command": "export LANG_PATH=./components/d2l-activity-editor/d2l-activity-assignment-editor/lang"
+      }
+    },{
+      "plugin": "run_command",
+      "data": {
+        "command": "rm -rf $LANG_PATH/build && mkdir -p $LANG_PATH/build"
+      }
+    }, {
+      "plugin": "run_command",
+      "data": {
+        "command": "for language in $(find $LANG_PATH -name \"*.json\" -type f -printf \"%f\\n\" | sed 's/\\.json$//'); do echo \"export const translations = JSON.parse(\\`$(cat $LANG_PATH/$language.json)\\`);\" > $LANG_PATH/build/$language.js; done"
+      }
+    }]
   }
 ]

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/build/en.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/build/en.js
@@ -1,4 +1,4 @@
-export const translations = JSON.parse(`{
+export const translations = {
   "name": {
     "translation": "Name",
     "context": "Helpful hints to make the Serge translation better"
@@ -7,4 +7,4 @@ export const translations = JSON.parse(`{
     "translation": "Name is required",
     "context": "Helpful hints to make the Serge translation better"
   }
-}`);
+};

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/build/en.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/build/en.js
@@ -1,0 +1,10 @@
+export const translations = JSON.parse(`{
+  "name": {
+    "translation": "Name",
+    "context": "Helpful hints to make the Serge translation better"
+  },
+  "emptyNameError": {
+    "translation": "Name is required",
+    "context": "Helpful hints to make the Serge translation better"
+  }
+}`);

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/build/fr.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/build/fr.js
@@ -1,4 +1,4 @@
-export const translations = JSON.parse(`{
+export const translations = {
   "name": {
     "translation": "Nom",
     "context": "Helpful hints to make the Serge translation better"
@@ -7,4 +7,4 @@ export const translations = JSON.parse(`{
     "translation": "Le nom est requis",
     "context": "Helpful hints to make the Serge translation better"
   }
-}`);
+};

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/build/fr.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/build/fr.js
@@ -1,0 +1,10 @@
+export const translations = JSON.parse(`{
+  "name": {
+    "translation": "Nom",
+    "context": "Helpful hints to make the Serge translation better"
+  },
+  "emptyNameError": {
+    "translation": "Le nom est requis",
+    "context": "Helpful hints to make the Serge translation better"
+  }
+}`);

--- a/components/d2l-activity-editor/localization.js
+++ b/components/d2l-activity-editor/localization.js
@@ -1,39 +1,27 @@
-import { resolveUrl } from '@polymer/polymer/lib/utils/resolve-url.js';
-
-const SUPPORTED_LANGUAGES = ['en', 'fr'];
-const cache = {};
-
-export async function getLocalizeResources(langs, baseUrl) {
-	const supportedLanguages = langs.reverse().filter(language => {
-		return SUPPORTED_LANGUAGES.indexOf(language) > -1;
-	});
-
-	const sergeLangterms = supportedLanguages.map(language => {
-		const url = resolveUrl(`./lang/${language}.json`, baseUrl);
-		if (cache[url]) {
-			return cache[url];
+export async function getLocalizeResources(langs) {
+	const imports = [];
+	let supportedLanguage;
+	for (const language of langs.reverse()) {
+		switch (language) {
+			case 'en':
+				supportedLanguage = 'en';
+				imports.push(import('./lang/build/en.js'));
+				break;
+			case 'fr':
+				supportedLanguage = 'fr';
+				imports.push(import('./lang/build/fr.js'));
+				break;
 		}
-
-		const langterms = fetch(url).then(res => res.json()).then(json => {
-			const langterms = {};
-			for (const langterm in json) {
-				langterms[langterm] = json[langterm].translation;
-			}
-			return langterms;
-		});
-		cache[url] = langterms;
-		return langterms;
-	});
-
-	const responses = await Promise.all(sergeLangterms);
-
+	}
+	const translationFiles = await Promise.all(imports);
 	const langterms = {};
-	responses.forEach(language => {
-		Object.assign(langterms, language);
-	});
-
+	for (const translationFile of translationFiles) {
+		for (const langterm in translationFile.translations) {
+			langterms[langterm] = translationFile.translations[langterm].translation;
+		}
+	}
 	return {
-		language: supportedLanguages[supportedLanguages.length - 1],
+		language: supportedLanguage,
 		resources: langterms
 	};
 }


### PR DESCRIPTION
[Based on the Serge docs](https://serge.io/docs/plugins/callback/run_command/), there's a `run_command` plugin with which you can run arbitrary commands. This adds a command to build our language files for us, so that (in theory) Serge will return to us both the translated JSON files, as well as built JavaScript files, which we can then import. Importing these by name allows the BSI analyzer to actually include the files correctly - we load only the files we need initially, and lazy-load the others if they're needed (e.g. if the page language changes).

I say "in theory" above as I've not been able to actually test this on the Serge service itself - the command works as expected locally, but I'm still not 100% sure about how the Serge integration actually works - still tracking down some of those details. For one, I don't know if the files that `run_command` generates will actually get committed back to the repo by Serge or...? But yeah, still looking.