### PR TITLE
d2l-activities-admin-list siren-sdk integration

### DIFF
--- a/components/d2l-activity-admin-list/d2l-activity-admin-list.js
+++ b/components/d2l-activity-admin-list/d2l-activity-admin-list.js
@@ -1,44 +1,107 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
-import { heading1Styles } from '@brightspace-ui/core/components/typography/styles.js';
+import { heading1Styles, bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';
+import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/button/button.js';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
+import { ActivityUsageCollectionEntity } from 'siren-sdk/src/activities/ActivityUsageCollectionEntity.js';
 
-class AdminList extends LitElement {
+class AdminList extends EntityMixinLit(LitElement) {
+	constructor() {
+		super();
+		this._items = [];
+		this._setEntityType(ActivityUsageCollectionEntity);
+	}
+
+	set _entity(entity) {
+		if (this._entityHasChanged(entity)) {
+			this._onActivityUsageCollectionChanged(entity);
+			super._entity = entity;
+		}
+	}
+
+	_onActivityUsageCollectionChanged(collection) {
+		this._items = [];
+		collection.onItemsChange((item, index) => {
+			this._items[index] = item;
+			this.requestUpdate();
+		});
+	}
+
 	static get properties() {
 		return {
-			titleText: {
+			'title-text': {
 				type: String
 			},
-			collectionHref: {
-				type: String
-			},
+			_items: {
+				type: Array
+			}
 		};
 	}
 
 	static get styles() {
-		return [ heading1Styles, css`
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.d2l-activity-admin-list-container {
-				display: flex;
-				justify-content: space-between;
-				align-items: center;
-			}
-		` ];
+		return [
+			heading1Styles,
+			bodyStandardStyles,
+			css`
+				:host {
+					display: block;
+				}
+				:host([hidden]) {
+					display: none;
+				}
+				.d2l-activity-admin-list-content-container {
+					display: flex;
+					justify-content: center;
+				}
+				.d2l-activity-admin-list-content {
+					box-sizing: border-box;
+					padding: 0 30px;
+					max-width: 1230px;
+					width: 100%;
+				}
+
+				.d2l-activity-admin-list-header-container {
+					border-bottom: solid 1px var(--d2l-color-gypsum);
+					box-sizing: border-box;
+					height: 96px;
+					width: 100%;
+				}
+				.d2l-activity-admin-list-header {
+					align-items: center;
+					display: flex;
+					justify-content: space-between;
+				}
+
+				.d2l-activity-admin-list-body-container {
+					background-color: #f9fafb;
+				}
+				.d2l-activity-admin-list-body {
+					padding-top: 72px;
+					padding-bottom: 72px;
+				}
+			`
+		];
 	}
 
 	render() {
 		return html`
-		<div class="d2l-activity-admin-list-container">
-			<h1 class="d2l-heading-1">${this.titleText}</h1>
-			<d2l-button primary>Create Learning Path</d2l-button>
-		</div>
-		<div>
-			CollectionHref: ${this.collectionHref}
-		</div>
+			<div class="d2l-activity-admin-list-content-container d2l-activity-admin-list-header-container">
+				<div class="d2l-activity-admin-list-content d2l-activity-admin-list-header">
+					<h1 class="d2l-heading-1">${this['title-text']}</h1>
+					<d2l-button primary>Create Learning Path</d2l-button>
+				</div>
+			</div>
+
+			<div class="d2l-activity-admin-list-content-container d2l-activity-admin-list-body-container">
+				<div class="d2l-activity-admin-list-content d2l-activity-admin-list-body">
+	${this._items.map(
+		item =>
+			html`
+				<p class="d2l-body-standard">${item.activityUsageHref()}</p>
+			`
+	)}
+				</div>
+			</div>
 		`;
 	}
 }

--- a/demo/d2l-activity-admin-list/d2l-activity-admin-list-demo.html
+++ b/demo/d2l-activity-admin-list/d2l-activity-admin-list-demo.html
@@ -11,12 +11,17 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta http-equiv="X-UA-Compatible" content="ie=edge">
 		<meta charset="UTF-8">
+		<style>
+			d2l-demo-snippet {
+				max-width: 100%;
+			}
+		</style>
 	</head>
 	<body>
 		<d2l-demo-page page-title="d2l-activity-admin-list">
 			<h2>d2l-activity-admin-list</h2>
-			<d2l-demo-snippet>
-				<d2l-activity-admin-list titleText="Learning Paths" collectionHref="data/collection.json"></d2l-activity-admin-list>
+			<d2l-demo-snippet no-padding>
+				<d2l-activity-admin-list title-text="Learning Paths" href="data/collection.json" token="secret"></d2l-activity-admin-list>
 			</d2l-demo-snippet>
 		</d2l-demo-page>
 	</body>

--- a/test/d2l-activity-admin-list/d2l-activity-admin-list.js
+++ b/test/d2l-activity-admin-list/d2l-activity-admin-list.js
@@ -2,14 +2,39 @@ import { runAxe } from '@brightspace-ui/core/tools/a11y-test-helper.js';
 
 describe('d2l-activity-admin-list', () => {
 	let element;
+	let collectionEntity;
 
 	beforeEach(async() => {
 		element = fixture('admin-list');
 		await element.updateComplete;
+
+		collectionEntity = {};
 	});
 
 	it('should pass all axe tests', async() => {
 		await runAxe(element);
 	});
 
+	it('should reset items on collection changed', () => {
+		collectionEntity.onItemsChange = () => {};
+		element._items = ['non', 'empty', 'items', 'array'];
+
+		element._onActivityUsageCollectionChanged(collectionEntity);
+
+		expect(element._items).to.be.empty;
+	});
+
+	it('should add item on items changed', () => {
+		collectionEntity.onItemsChange = callback => {
+			callback('item-3', 2);
+			callback('item-1', 0);
+			callback('item-2', 1);
+		};
+		element._onActivityUsageCollectionChanged(collectionEntity);
+
+		expect(element._items).to.have.lengthOf(3);
+		expect(element._items[0]).to.equal('item-1');
+		expect(element._items[1]).to.equal('item-2');
+		expect(element._items[2]).to.equal('item-3');
+	});
 });


### PR DESCRIPTION
# Changes
- Load list items using the `siren-sdk` `ActivityUsageCollectionEntity`
- Add basic styling for the header and body sections of the page

## Screenshots
![Capture](https://user-images.githubusercontent.com/11379933/66319719-9b2eb980-e8eb-11e9-8ae0-b2012a3cda90.PNG)