### PR TITLE
US105733 - add method to detect if search or filter is applied immediately

### DIFF
--- a/components/d2l-quick-eval/behaviors/d2l-hm-filter-behavior.js
+++ b/components/d2l-quick-eval/behaviors/d2l-hm-filter-behavior.js
@@ -78,6 +78,10 @@ D2L.PolymerBehaviors.QuickEval.D2LHMFilterBehaviourImpl = {
 
 	_clearErrors: function() {
 		this.filterError = null;
+	},
+
+	filterAppliedShortcut: function() {
+		this.filterApplied = this._hasNonEmptyQueryParam(this.href, 'filter');
 	}
 };
 

--- a/components/d2l-quick-eval/behaviors/d2l-hm-search-behavior.js
+++ b/components/d2l-quick-eval/behaviors/d2l-hm-search-behavior.js
@@ -92,6 +92,10 @@ D2L.PolymerBehaviors.QuickEval.D2LHMSearchBehaviourImpl = {
 	_clearErrors: function() {
 		this.searchError = null;
 	},
+
+	searchAppliedShortcut: function() {
+		this.searchApplied = this._hasNonEmptyQueryParam(this.href, 'collectionSearch');
+	}
 };
 
 /** @polymerBehavior */

--- a/components/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
+++ b/components/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
@@ -117,6 +117,16 @@ D2L.PolymerBehaviors.Siren.D2LSirenHelperBehaviorImpl = {
 			return entity.getActionByName(name);
 		}
 		return null;
+	},
+
+	_hasNonEmptyQueryParam: function(url, queryParam) {
+		const parsed = new URL(url, 'https://ThisExistsToAvoidAnException.com');
+
+		if (!parsed.searchParams.has(queryParam)) {
+			return false;
+		}
+
+		return parsed.searchParams.get(queryParam) !== '';
 	}
 };
 

--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -248,11 +248,15 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 		}
 		this._loading = true;
 
+		if (this._initialLoad) {
+			this._setApplied();
+		}
+
 		if (this._initialLoad &&
 			entity.hasClass('empty') &&
 			(this.searchApplied || this.filterApplied)
 		) {
-			this._clearFilterAndSearch();
+			await this._clearFilterAndSearch();
 			this._initialLoad = false;
 			return;
 		}
@@ -323,6 +327,15 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 		}
 		if (this.searchApplied) {
 			await this.clearSearchResults();
+		}
+	}
+
+	_setApplied() {
+		if (this._hasNonEmptyQueryParam(this.href, 'filter')) {
+			this.filterApplied = true;
+		}
+		if (this._hasNonEmptyQueryParam(this.href, 'collectionSearch')) {
+			this.searchApplied = true;
 		}
 	}
 

--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -249,7 +249,8 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 		this._loading = true;
 
 		if (this._initialLoad) {
-			this._setApplied();
+			this.filterAppliedShortcut();
+			this.searchAppliedShortcut();
 		}
 
 		if (this._initialLoad &&
@@ -327,15 +328,6 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 		}
 		if (this.searchApplied) {
 			await this.clearSearchResults();
-		}
-	}
-
-	_setApplied() {
-		if (this._hasNonEmptyQueryParam(this.href, 'filter')) {
-			this.filterApplied = true;
-		}
-		if (this._hasNonEmptyQueryParam(this.href, 'collectionSearch')) {
-			this.searchApplied = true;
 		}
 	}
 

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -270,7 +270,8 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 		this._loading = true;
 
 		if (this._initialLoad) {
-			this._setApplied();
+			this.filterAppliedShortcut();
+			this.searchAppliedShortcut();
 		}
 
 		if (this._initialLoad &&
@@ -391,15 +392,6 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 		}
 		if (this.searchApplied) {
 			await this.clearSearchResults();
-		}
-	}
-
-	_setApplied() {
-		if (this._hasNonEmptyQueryParam(this.href, 'filter')) {
-			this.filterApplied = true;
-		}
-		if (this._hasNonEmptyQueryParam(this.href, 'collectionSearch')) {
-			this.searchApplied = true;
 		}
 	}
 

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -269,11 +269,15 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 		}
 		this._loading = true;
 
+		if (this._initialLoad) {
+			this._setApplied();
+		}
+
 		if (this._initialLoad &&
 			entity.hasClass('empty') &&
 			(this.searchApplied || this.filterApplied)
 		) {
-			this._clearFilterAndSearch();
+			await this._clearFilterAndSearch();
 			this._initialLoad = false;
 			return;
 		}
@@ -387,6 +391,15 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 		}
 		if (this.searchApplied) {
 			await this.clearSearchResults();
+		}
+	}
+
+	_setApplied() {
+		if (this._hasNonEmptyQueryParam(this.href, 'filter')) {
+			this.filterApplied = true;
+		}
+		if (this._hasNonEmptyQueryParam(this.href, 'collectionSearch')) {
+			this.searchApplied = true;
 		}
 	}
 

--- a/test/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
+++ b/test/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
@@ -269,5 +269,48 @@
 				assert.equal(evalLink, expectedEvalLink);
 			});
 		});
+		suite('_hasNonEmptyQueryParam', () => {
+
+			const queryParam = 'param';
+			const testCases = [
+				{
+					testName: 'query param is present',
+					url: 'https://d2l.com/?param=123',
+					expected: true
+				},
+				{
+					testName: 'query param is empty',
+					url: 'https://d2l.com/?param=',
+					expected: false
+				},
+				{
+					testName: 'no query param',
+					url: 'https://d2l.com/',
+					expected: false
+				},
+				{
+					testName: 'other query param',
+					url: 'https://d2l.com/?hello=123',
+					expected: false
+				},
+				{
+					testName: 'relative url with qp',
+					url: '/api/path/?param=123',
+					expected: true
+				},
+				{
+					testName: 'relative url without qp',
+					url: '/api/path/',
+					expected: false
+				}
+			];
+
+			testCases.forEach(testCase => {
+				test(testCase.testName, () => {
+					const actual = component._hasNonEmptyQueryParam(testCase.url, queryParam);
+					assert.equal(actual, testCase.expected);
+				});
+			})
+		});
 	});
 })();

--- a/test/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
+++ b/test/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
@@ -310,7 +310,7 @@
 					const actual = component._hasNonEmptyQueryParam(testCase.url, queryParam);
 					assert.equal(actual, testCase.expected);
 				});
-			})
+			});
 		});
 	});
 })();

--- a/test/d2l-quick-eval/d2l-quick-eval-clear-on-intial-load.html
+++ b/test/d2l-quick-eval/d2l-quick-eval-clear-on-intial-load.html
@@ -56,7 +56,7 @@
 						test('_initialLoad is false after empty initial load', (done) => {
 							const entity = makeEmptyEntity();
 							const clearSpy = sinon.spy();
-							module.searchApplied = true;
+							module.searchAppliedShortcut = () => module.searchApplied = true;
 							module._clearFilterAndSearch = clearSpy;
 
 							module._loadData(entity)


### PR DESCRIPTION
Previous PR: https://github.com/BrightspaceHypermediaComponents/activities/pull/385

Problem: In test, sometimes the filters would not be loaded before `_loadData` ran. This meant that `filtersApplied` was `undefined`. Thus in this case, the criteria would not be reset on an empty response.
Solution: Instead of waiting for `/filters` to load, just detect if the query string param is present in the `href`.

Obviously this solution breaks our design because now the UI knows too much about the filters implementation. But I can't think of any other way of doing it (short of the HM route returning this information - I think we should eventually do this). An advantage of this solution is that if we do go forward with lazily loading the filters then the features that rely on `filtersApplied` will still work.

What are your thoughts?

- [x] add tests for `_hasNonEmptyQueryParam`