### PR TITLE
US110196 Fix _resolveUrl path

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -69,7 +69,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SirenFetchMixinLit(Entit
 		if (super._entity.canEditName()) {
 			const action = super._entity.getSaveNameAction();
 			const fields = [{ 'name': 'name', 'value': value }];
-			this._performSirenAction(action, fields, this.token);
+			this._performSirenAction(action, fields);
 		}
 	}
 
@@ -77,7 +77,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SirenFetchMixinLit(Entit
 		if (super._entity.canEditInstructions()) {
 			const action = super._entity.getSaveInstructionsAction();
 			const fields = [{ name: 'instructions', value: value }];
-			this._performSirenAction(action, fields, this.token);
+			this._performSirenAction(action, fields);
 		}
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-html-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-editor.js
@@ -2,7 +2,6 @@ import 'd2l-html-editor/d2l-html-editor.js';
 import 'd2l-html-editor/d2l-html-editor-client.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId';
-import { resolveUrl } from '@polymer/polymer/lib/utils/resolve-url.js';
 
 class ActivityHtmlEditor extends LitElement {
 
@@ -149,7 +148,7 @@ class ActivityHtmlEditor extends LitElement {
 	}
 
 	_resolveUrl() {
-		return resolveUrl('../../../');
+		return `${import.meta.url}/../../../`;
 	}
 
 	getContent() {


### PR DESCRIPTION
In #436 I moved the `d2l-activities-html-editor` component up one level, but didn't update this value. Strangely, changing it to just `../../` instead doesn't work, and is likely related to LitElement and `resolveUrl` not being friends. However, using `import.meta.url` does indeed work, and surprisingly also works for the demo! Confirmed that this works with a bundled and unbundled version of BSI.

This also removes the addition of `this.token`, which was thought to be required, but is not.