### PR TITLE
US110196 Fixup: HTML editor change event

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -101,8 +101,8 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SirenFetchMixinLit(Entit
 		}
 	}
 
-	_saveInstructionsOnInput(e) {
-		const instructions = e.target.getContent();
+	_saveInstructionsOnChange(e) {
+		const instructions = e.detail.content;
 
 		this._debounceJobs.instructions = Debouncer.debounce(
 			this._debounceJobs.instructions,
@@ -148,8 +148,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SirenFetchMixinLit(Entit
 					id="assignment-instructions"
 					value="${this._instructions}"
 					.richtextEditorConfig="${this._richtextEditorConfig}"
-					@change="${this._saveOnChange('instructions')}"
-					@input="${this._saveInstructionsOnInput}"
+					@change="${this._saveInstructionsOnChange}"
 					aria-label="${this.localize('instructions')}"
 					?disabled="${super._entity && !super._entity.canEditInstructions()}">
 				</d2l-activity-html-editor>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -148,7 +148,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SirenFetchMixinLit(Entit
 					id="assignment-instructions"
 					value="${this._instructions}"
 					.richtextEditorConfig="${this._richtextEditorConfig}"
-					@change="${this._saveInstructionsOnChange}"
+					@d2l-activity-html-editor-change="${this._saveInstructionsOnChange}"
 					aria-label="${this.localize('instructions')}"
 					?disabled="${super._entity && !super._entity.canEditInstructions()}">
 				</d2l-activity-html-editor>

--- a/components/d2l-activity-editor/d2l-activity-html-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-editor.js
@@ -151,11 +151,9 @@ class ActivityHtmlEditor extends LitElement {
 		return `${import.meta.url}/../../../`;
 	}
 
-	_onContentChange(e) {
-		e.stopPropagation();
-
+	_onContentChange() {
 		const content = this.shadowRoot.querySelector('d2l-html-editor').getContent();
-		this.dispatchEvent(new CustomEvent('change', {
+		this.dispatchEvent(new CustomEvent('d2l-activity-html-editor-change', {
 			bubbles: true,
 			composed: true,
 			detail: {

--- a/components/d2l-activity-editor/d2l-activity-html-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-editor.js
@@ -151,8 +151,17 @@ class ActivityHtmlEditor extends LitElement {
 		return `${import.meta.url}/../../../`;
 	}
 
-	getContent() {
-		return this.shadowRoot.querySelector('d2l-html-editor').getContent();
+	_onContentChange(e) {
+		e.stopPropagation();
+
+		const content = this.shadowRoot.querySelector('d2l-html-editor').getContent();
+		this.dispatchEvent(new CustomEvent('change', {
+			bubbles: true,
+			composed: true,
+			detail: {
+				content: content
+			}
+		}));
 	}
 
 	render() {
@@ -161,8 +170,10 @@ class ActivityHtmlEditor extends LitElement {
 				id="assignment-instructions"
 				editor-id="${this._htmlEditorUniqueId}"
 				app-root="${this._resolveUrl()}"
+				@change="${this._onContentChange}"
+				@input="${this._onContentChange}"
 				inline="1"
-				min-rows="1"
+				min-rows="3"
 				max-rows="1000"
 				fullpage-enabled="0"
 				toolbar="bold italic bullist d2l_isf"


### PR DESCRIPTION
This adds a more predictable `change` event to the `d2l-activity-html-editor`, which is internally hooked up to both the `input` and `change` event from `d2l-html-editor`. This ensures the outer component generates an event for all changes within the HTML editor, whereas the previous implementation wouldn't pick up e.g. inserting an image or changing the text format until the input text was also changed. This means that the parent component (`d2l-activity-assignment-editor-detail` in this case) only has to listen for this `change` event, and can use that to drive auto-saving the instructions value.

This also updates the size of the editor to be a minimum of 3 rows, which matches the design.