### PR TITLE
Fix siren-sdk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,6 @@
     "fastdom": "^1.0.8",
     "merge-stream": "^1.0.1",
     "require-dir": "^1.2.0",
-    "siren-sdk": "BrightspaceHypermediaComponents/siren-sdk#semver:^1.4.2"
+    "siren-sdk": "BrightspaceHypermediaComponents/siren-sdk#semver:^1"
   }
 }


### PR DESCRIPTION
Due to magic I don't entirely understand, BSI requires all dependencies to only specify the major version. This change was introduced in #441, but breaks the BSI build when `activities` is updated there.

It seems like this was put in place to ensure getting at least a specific version of `siren-sdk` that presumably has some new functionality, but BSI will always get the newest version anyway (until a breaking/major version change).