### PR TITLE
Adding dismiss flag property.

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval.js
+++ b/components/d2l-quick-eval/d2l-quick-eval.js
@@ -80,6 +80,10 @@ class D2LQuickEval extends
 				type: Boolean,
 				value: false
 			},
+			dismissEnabled: {
+				type: Boolean,
+				value: false
+			},
 			loggingEndpoint: {
 				type: String
 			},


### PR DESCRIPTION
Adding this in preparation for the dismiss functionality so that the flag is ready to go once we're ready to start adding components.

Property is not yet hooked up to anything, as there are no components yet for dismiss that need to be hidden. Tests should come once we start adding components.