### PR TITLE
US110582 Add due date editor

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -1,4 +1,5 @@
 import 'd2l-inputs/d2l-input-text.js';
+import '../d2l-activity-due-date-editor.js';
 import '../d2l-activity-html-editor.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { AssignmentEntity } from 'siren-sdk/src/activities/assignments/AssignmentEntity.js';
@@ -18,7 +19,8 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SirenFetchMixinLit(Entit
 			_name: { type: String },
 			_nameError: { type: String },
 			_instructions: { type: String },
-			_richtextEditorConfig: { type: Object }
+			_richtextEditorConfig: { type: Object },
+			_activityUsageHref: { type: String }
 		};
 	}
 
@@ -58,6 +60,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SirenFetchMixinLit(Entit
 			this._name = assignment.name();
 			this._instructions = assignment.instructionsEditorHtml();
 			this._richtextEditorConfig = assignment.getRichTextEditorConfig();
+			this._activityUsageHref = assignment.activityUsageHref();
 		}
 	}
 
@@ -68,7 +71,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SirenFetchMixinLit(Entit
 	_saveName(value) {
 		if (super._entity.canEditName()) {
 			const action = super._entity.getSaveNameAction();
-			const fields = [{ 'name': 'name', 'value': value }];
+			const fields = [{ name: 'name', value: value }];
 			this._performSirenAction(action, fields);
 		}
 	}
@@ -140,6 +143,14 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SirenFetchMixinLit(Entit
 					prevent-submit>
 				</d2l-input-text>
 				${this._getNameTooltip()}
+			</div>
+
+			<div id="duedate-container">
+				<label class="d2l-label-text" for="due-date">${this.localize('dueDate')}</label>
+				<d2l-activity-due-date-editor
+					.href="${this._activityUsageHref}"
+					.token="${this.token}">
+				</d2l-activity-due-date-editor>
 			</div>
 
 			<div id="assignment-instructions-container">

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -146,21 +146,22 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SirenFetchMixinLit(Entit
 			</div>
 
 			<div id="duedate-container">
-				<label class="d2l-label-text" for="due-date">${this.localize('dueDate')}</label>
+				<label class="d2l-label-text">${this.localize('dueDate')}</label>
 				<d2l-activity-due-date-editor
+					dateLabel="${this.localize('dueDate')}"
+					timeLabel="${this.localize('dueTime')}"
 					.href="${this._activityUsageHref}"
 					.token="${this.token}">
 				</d2l-activity-due-date-editor>
 			</div>
 
 			<div id="assignment-instructions-container">
-				<label class="d2l-label-text" for="assignment-instructions">${this.localize('instructions')}</label>
+				<label class="d2l-label-text">${this.localize('instructions')}</label>
 				<d2l-activity-html-editor
-					id="assignment-instructions"
 					value="${this._instructions}"
 					.richtextEditorConfig="${this._richtextEditorConfig}"
 					@d2l-activity-html-editor-change="${this._saveInstructionsOnChange}"
-					aria-label="${this.localize('instructions')}"
+					ariaLabel="${this.localize('instructions')}"
 					?disabled="${super._entity && !super._entity.canEditInstructions()}">
 				</d2l-activity-html-editor>
 			</div>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -44,9 +44,6 @@ class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LocalizeMixi
 
 	_onAssignmentActivityUsageChange(assignmentActivityUsage) {
 		this._assignmentHref = assignmentActivityUsage.assignmentHref();
-		// assignmentActivityUsage.onAssignmentChange((assignment) => {
-		// 	this._name = assignment.name();
-		// });
 	}
 
 	render() {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.json
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.json
@@ -14,5 +14,9 @@
   "dueDate": {
     "translation": "Due Date",
     "context": "Label for the due date field when creating/editing an activity"
+  },
+  "dueTime": {
+    "translation": "Due Time",
+    "context": "Label for the due time field when creating/editing an activity"
   }
 }

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.json
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.json
@@ -10,5 +10,9 @@
   "instructions": {
     "translation": "Instructions",
     "context": "Label for the instruction field when creating/editing an activity"
+  },
+  "dueDate": {
+    "translation": "Due Date",
+    "context": "Label for the due date field when creating/editing an activity"
   }
 }

--- a/components/d2l-activity-editor/d2l-activity-due-date-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-due-date-editor.js
@@ -2,13 +2,14 @@ import 'd2l-datetime-picker/d2l-datetime-picker';
 import { css, html, LitElement } from 'lit-element/lit-element';
 import { ActivityUsageEntity } from 'siren-sdk/src/activities/ActivityUsageEntity';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
-import { PendingContainerMixin } from 'siren-sdk/src/mixin/pending-container-mixin';
 import { SirenFetchMixinLit } from 'siren-sdk/src/mixin/siren-fetch-mixin-lit';
 
-class ActivityDueDateEditor extends PendingContainerMixin(SirenFetchMixinLit(EntityMixinLit(LitElement))) {
+class ActivityDueDateEditor extends SirenFetchMixinLit(EntityMixinLit(LitElement)) {
 
 	static get properties() {
 		return {
+			dateLabel: { type: String },
+			timeLabel: { type: String },
 			_date: { type: String },
 			_overrides: { type: Object }
 		};
@@ -73,6 +74,8 @@ class ActivityDueDateEditor extends PendingContainerMixin(SirenFetchMixinLit(Ent
 					hide-label
 					name="date"
 					id="date"
+					date-label="${this.dateLabel}"
+					time-label="${this.timeLabel}"
 					datetime="${this._date}"
 					overrides="${this._overrides}"
 					@d2l-datetime-picker-datetime-changed="${this._onDatetimePickerDatetimeChanged}"

--- a/components/d2l-activity-editor/d2l-activity-due-date-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-due-date-editor.js
@@ -1,0 +1,86 @@
+import 'd2l-datetime-picker/d2l-datetime-picker';
+import { css, html, LitElement } from 'lit-element/lit-element';
+import { ActivityUsageEntity } from 'siren-sdk/src/activities/ActivityUsageEntity';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
+import { PendingContainerMixin } from 'siren-sdk/src/mixin/pending-container-mixin';
+import { SirenFetchMixinLit } from 'siren-sdk/src/mixin/siren-fetch-mixin-lit';
+
+class ActivityDueDateEditor extends PendingContainerMixin(SirenFetchMixinLit(EntityMixinLit(LitElement))) {
+
+	static get properties() {
+		return {
+			_date: { type: String },
+			_overrides: { type: Object }
+		};
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				display: block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+		`;
+	}
+
+	constructor() {
+		super();
+		this._setEntityType(ActivityUsageEntity);
+		this._date = '';
+		this._overrides = document.documentElement.intlOverrides || '{}';
+	}
+
+	set _entity(entity) {
+		if (!this._entityHasChanged(entity)) {
+			return;
+		}
+
+		if (entity) {
+			this._date = entity.dueDate();
+		}
+
+		super._entity = entity;
+	}
+
+	_onDatetimePickerDatetimeCleared() {
+		this._updateDueDate('');
+	}
+
+	_onDatetimePickerDatetimeChanged(e) {
+		if (e.detail.isSame(this._date)) {
+			return;
+		}
+
+		this._updateDueDate(e.detail.toISOString());
+	}
+
+	_updateDueDate(dateString) {
+		if (!super._entity.canEditDueDate()) {
+			return;
+		}
+
+		const action = super._entity.saveDueDateAction();
+		const fields = [{ name: 'dueDate', value: dateString }];
+		this._performSirenAction(action, fields);
+	}
+
+	render() {
+		return html`
+			<div id="datetime-picker-container">
+				<d2l-datetime-picker
+					hide-label
+					name="date"
+					id="date"
+					datetime="${this._date}"
+					overrides="${this._overrides}"
+					@d2l-datetime-picker-datetime-changed="${this._onDatetimePickerDatetimeChanged}"
+					@d2l-datetime-picker-datetime-cleared="${this._onDatetimePickerDatetimeCleared}">
+				</d2l-datetime-picker>
+			</div>
+		`;
+	}
+
+}
+customElements.define('d2l-activity-due-date-editor', ActivityDueDateEditor);

--- a/demo/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.html
+++ b/demo/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.html
@@ -7,6 +7,9 @@
 			import '@brightspace-ui/core/components/demo/demo-page.js';
 			import '../../../components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js';
 		</script>
+		<script type="text/javascript" src="https://s.brightspace.com/lib/moment.js/2.15.2/moment.min.js"></script>
+		<script type="text/javascript" src="https://s.brightspace.com/lib/moment-timezone/0.5.10/moment-timezone-with-data.min.js"></script>
+
 		<title>d2l-activity-assignment-editor</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta http-equiv="X-UA-Compatible" content="ie=edge">

--- a/demo/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.html
+++ b/demo/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.html
@@ -7,6 +7,9 @@
 			import '@brightspace-ui/core/components/demo/demo-page.js';
 			import '../../../components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js';
 		</script>
+		<script type="text/javascript" src="https://s.brightspace.com/lib/moment.js/2.15.2/moment.min.js"></script>
+		<script type="text/javascript" src="https://s.brightspace.com/lib/moment-timezone/0.5.10/moment-timezone-with-data.min.js"></script>
+
 		<title>d2l-activity-assignment-editor</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta http-equiv="X-UA-Compatible" content="ie=edge">

--- a/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/assignmentActivity.json
+++ b/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/assignmentActivity.json
@@ -1,240 +1,240 @@
 {
-	"class": [
-		"assignment"
-	],
-	"properties": {
-		"name": "Extra Special Assignment",
-		"instructions": "<p>Assignment instructions 6613</p><p><d2l-richtext-image><img loading=\"lazy\" src=\"http://kl81-rmahler.desire2learn.d2l:44444/components/d2l-activities/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/city_small.jpg?_&amp;d2lSessionVal=g0cqWWI1pZYJFYNYB6DMpaAAS\" alt=\"city\" title=\"city\"/></d2l-richtext-image></p>",
-		"instructionsText": "Assignment instructions 6613",
-		"dueDate": "2019-09-20T03:59:00.000Z",
-		"outOf": 100.000000000,
-		"addToGrades": false,
-		"draft": false,
-		"submissionType": {
-			"title": "File submission",
-			"value": 0
-		},
-		"completionType": {
-			"title": "Automatically on submission",
-			"value": 0
-		}
-	},
-	"entities": [
-		{
-			"class": [
-				"date",
-				"due-date"
-			],
-			"rel": [
-				"https://api.brightspace.com/rels/date"
-			],
-			"properties": {
-				"date": "2019-09-20T03:59:00.000Z"
-			}
-		},
-		{
-			"class": [
-				"submission-metrics"
-			],
-			"rel": [
-				"https://assignments.api.brightspace.com/rels/submission-metrics"
-			],
-			"properties": {
-				"totalUsers": 1,
-				"totalUsersWithSubmissions": 0
-			}
-		},
-		{
-			"class": [
-				"attachments"
-			],
-			"rel": [
-				"https://assignments.api.brightspace.com/rels/attachments"
-			],
-			"actions": [
-				{
-					"type": "multipart/form-data",
-					"title": "Add file",
-					"href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7/attach-file",
-					"name": "add-file",
-					"method": "POST"
-				},
-				{
-					"type": "application/x-www-form-urlencoded",
-					"title": "Attach a link to the assignment folder",
-					"href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7/attach-link",
-					"name": "add-link",
-					"method": "POST",
-					"fields": [
-						{
-							"type": "text",
-							"name": "name"
-						},
-						{
-							"type": "text",
-							"name": "href"
-						}
-					]
-				}
-			]
-		},
-		{
-			"class": [
-				"richtext",
-				"instructions",
-				"annotated"
-			],
-			"rel": [
-				"item",
-				"https://assignments.api.brightspace.com/rels/instructions"
-			],
-			"properties": {
-				"text": "Assignment instructions 6613",
-				"html": "<p>Assignment instructions 6613</p><p><d2l-richtext-image><img loading=\"lazy\" src=\"http://kl81-rmahler.desire2learn.d2l:44444/components/d2l-activities/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/city_small.jpg?_&amp;d2lSessionVal=g0cqWWI1pZYJFYNYB6DMpaAAS\" alt=\"city\" title=\"city\"/></d2l-richtext-image></p>"
-			},
-			"actions": [
-				{
-					"type": "application/x-www-form-urlencoded",
-					"href": "https://8b4b0787-25ca-43d2-89ab-b9495546ad09.assignments.api.proddev.d2l/6613/folders/3",
-					"name": "update-instructions",
-					"method": "PATCH",
-					"fields": [
-						{
-							"type": "text",
-							"name": "instructions",
-							"value": "<p>Assignment instructions {orgUnitId}</p><p><img loading=\"lazy\" src=\"/components/d2l-activities/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/city_small.jpg\" alt=\"city\" title=\"city\"/></p>"
-						}
-					]
-				}
-			],
-			"entities": [
-				{
-					"class": [
-						"richtext-editor-config"
-					],
-					"rel": [
-						"https://api.brightspace.com/rels/richtext-editor-config"
-					],
-					"properties": {
-						"orgUnit": {
-							"OrgId": "6606",
-							"OrgUnitId": "6613"
-						},
-						"d2l_filter": {
-							"endpoint": "/d2l/lp/htmleditor/converttoabsolute?ou=6613"
-						},
-						"d2l_isf": {
-							"endpoint": "/d2l/common/dialogs/isf/selectItem.d2l?ou=6613&filterMode=Strict"
-						}
-					}
-				}
-			]
-		}
-	],
-	"links": [
-		{
-			"rel": [
-				"self"
-			],
-			"href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7"
-		},
-		{
-			"rel": [
-				"service"
-			],
-			"href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065"
-		},
-		{
-			"rel": [
-				"https://activities.api.brightspace.com/rels/internal-activity-id"
-			],
-			"href": "https://ids.brightspace.com/activities/dropbox/F074BF85-DA75-4C60-B5E9-181E7D731372-13"
-		},
-		{
-			"rel": [
-				"https://activities.api.brightspace.com/rels/activity-usage"
-			],
-			"href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.activities.api.dev.brightspace.com/activities/6606_2000_7/usages/123065"
-		},
-		{
-			"rel": [
-				"https://api.brightspace.com/rels/organization"
-			],
-			"href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.organizations.api.dev.brightspace.com/123065"
-		},
-		{
-			"rel": [
-				"alternate"
-			],
-			"type": "text/html",
-			"href": "https://alafqa.devlms.brightspace.com/d2l/lms/dropbox/admin/mark/folder_submissions_users.d2l?ou=123065&db=7"
-		}
-	],
-	"actions": [
-		{
-			"class": [
-				"link-attachment"
-			],
-			"type": "application/x-www-form-urlencoded",
-			"title": "Edit an assignment folder with defaults",
-			"href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7",
-			"name": "quick-create-folder",
-			"method": "PUT",
-			"fields": [
-				{
-					"class": [
-						"required"
-					],
-					"type": "text",
-					"title": "Folder name",
-					"name": "name",
-					"value": "A111"
-				},
-				{
-					"type": "text",
-					"title": "Instructions",
-					"name": "instructions",
-					"value": ""
-				},
-				{
-					"type": "date",
-					"title": "Due date",
-					"name": "dueDate",
-					"value": "2019-09-20T03:59:00.000Z"
-				},
-				{
-					"type": "checkbox",
-					"title": "Draft",
-					"name": "draft",
-					"value": false
-				},
-				{
-					"type": "checkbox",
-					"title": "Create a grade item for the folder",
-					"name": "addToGrades",
-					"value": false
-				},
-				{
-					"type": "number",
-					"title": "Specify how many points the assignment is worth",
-					"name": "outOf",
-					"value": 100.000000000
-				}
-			]
-		},
-		{
-			"title": "Delete an assignment folder",
-			"href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7",
-			"name": "delete-folder",
-			"method": "DELETE"
-		},
-		{
-			"href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7",
-			"name": "update-name",
-			"method": "PATCH"
-		}
-	],
-	"rel": [
-		"https://assignments.api.brightspace.com/rels/assignment"
-	]
+  "class": [
+    "assignment"
+  ],
+  "properties": {
+    "name": "Extra Special Assignment",
+    "instructions": "<p>Assignment instructions 6613</p><p><d2l-richtext-image><img loading=\"lazy\" src=\"http://kl81-rmahler.desire2learn.d2l:44444/components/d2l-activities/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/city_small.jpg?_&amp;d2lSessionVal=g0cqWWI1pZYJFYNYB6DMpaAAS\" alt=\"city\" title=\"city\"/></d2l-richtext-image></p>",
+    "instructionsText": "Assignment instructions 6613",
+    "dueDate": "2019-09-20T03:59:00.000Z",
+    "outOf": 100.000000000,
+    "addToGrades": false,
+    "draft": false,
+    "submissionType": {
+      "title": "File submission",
+      "value": 0
+    },
+    "completionType": {
+      "title": "Automatically on submission",
+      "value": 0
+    }
+  },
+  "entities": [
+    {
+      "class": [
+        "date",
+        "due-date"
+      ],
+      "rel": [
+        "https://api.brightspace.com/rels/date"
+      ],
+      "properties": {
+        "date": "2019-09-20T03:59:00.000Z"
+      }
+    },
+    {
+      "class": [
+        "submission-metrics"
+      ],
+      "rel": [
+        "https://assignments.api.brightspace.com/rels/submission-metrics"
+      ],
+      "properties": {
+        "totalUsers": 1,
+        "totalUsersWithSubmissions": 0
+      }
+    },
+    {
+      "class": [
+        "attachments"
+      ],
+      "rel": [
+        "https://assignments.api.brightspace.com/rels/attachments"
+      ],
+      "actions": [
+        {
+          "type": "multipart/form-data",
+          "title": "Add file",
+          "href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7/attach-file",
+          "name": "add-file",
+          "method": "POST"
+        },
+        {
+          "type": "application/x-www-form-urlencoded",
+          "title": "Attach a link to the assignment folder",
+          "href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7/attach-link",
+          "name": "add-link",
+          "method": "POST",
+          "fields": [
+            {
+              "type": "text",
+              "name": "name"
+            },
+            {
+              "type": "text",
+              "name": "href"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "class": [
+        "richtext",
+        "instructions",
+        "annotated"
+      ],
+      "rel": [
+        "item",
+        "https://assignments.api.brightspace.com/rels/instructions"
+      ],
+      "properties": {
+        "text": "Assignment instructions 6613",
+        "html": "<p>Assignment instructions 6613</p><p><d2l-richtext-image><img loading=\"lazy\" src=\"http://kl81-rmahler.desire2learn.d2l:44444/components/d2l-activities/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/city_small.jpg?_&amp;d2lSessionVal=g0cqWWI1pZYJFYNYB6DMpaAAS\" alt=\"city\" title=\"city\"/></d2l-richtext-image></p>"
+      },
+      "actions": [
+        {
+          "type": "application/x-www-form-urlencoded",
+          "href": "https://8b4b0787-25ca-43d2-89ab-b9495546ad09.assignments.api.proddev.d2l/6613/folders/3",
+          "name": "update-instructions",
+          "method": "PATCH",
+          "fields": [
+            {
+              "type": "text",
+              "name": "instructions",
+              "value": "<p>Assignment instructions {orgUnitId}</p><p><img loading=\"lazy\" src=\"/components/d2l-activities/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/city_small.jpg\" alt=\"city\" title=\"city\"/></p>"
+            }
+          ]
+        }
+      ],
+      "entities": [
+        {
+          "class": [
+            "richtext-editor-config"
+          ],
+          "rel": [
+            "https://api.brightspace.com/rels/richtext-editor-config"
+          ],
+          "properties": {
+            "orgUnit": {
+              "OrgId": "6606",
+              "OrgUnitId": "6613"
+            },
+            "d2l_filter": {
+              "endpoint": "/d2l/lp/htmleditor/converttoabsolute?ou=6613"
+            },
+            "d2l_isf": {
+              "endpoint": "/d2l/common/dialogs/isf/selectItem.d2l?ou=6613&filterMode=Strict"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7"
+    },
+    {
+      "rel": [
+        "service"
+      ],
+      "href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065"
+    },
+    {
+      "rel": [
+        "https://activities.api.brightspace.com/rels/internal-activity-id"
+      ],
+      "href": "https://ids.brightspace.com/activities/dropbox/F074BF85-DA75-4C60-B5E9-181E7D731372-13"
+    },
+    {
+      "rel": [
+        "https://activities.api.brightspace.com/rels/activity-usage"
+      ],
+      "href": "./data/assignmentActivityUsage.json"
+    },
+    {
+      "rel": [
+        "https://api.brightspace.com/rels/organization"
+      ],
+      "href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.organizations.api.dev.brightspace.com/123065"
+    },
+    {
+      "rel": [
+        "alternate"
+      ],
+      "type": "text/html",
+      "href": "https://alafqa.devlms.brightspace.com/d2l/lms/dropbox/admin/mark/folder_submissions_users.d2l?ou=123065&db=7"
+    }
+  ],
+  "actions": [
+    {
+      "class": [
+        "link-attachment"
+      ],
+      "type": "application/x-www-form-urlencoded",
+      "title": "Edit an assignment folder with defaults",
+      "href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7",
+      "name": "quick-create-folder",
+      "method": "PUT",
+      "fields": [
+        {
+          "class": [
+            "required"
+          ],
+          "type": "text",
+          "title": "Folder name",
+          "name": "name",
+          "value": "A111"
+        },
+        {
+          "type": "text",
+          "title": "Instructions",
+          "name": "instructions",
+          "value": ""
+        },
+        {
+          "type": "date",
+          "title": "Due date",
+          "name": "dueDate",
+          "value": "2019-09-20T03:59:00.000Z"
+        },
+        {
+          "type": "checkbox",
+          "title": "Draft",
+          "name": "draft",
+          "value": false
+        },
+        {
+          "type": "checkbox",
+          "title": "Create a grade item for the folder",
+          "name": "addToGrades",
+          "value": false
+        },
+        {
+          "type": "number",
+          "title": "Specify how many points the assignment is worth",
+          "name": "outOf",
+          "value": 100.000000000
+        }
+      ]
+    },
+    {
+      "title": "Delete an assignment folder",
+      "href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7",
+      "name": "delete-folder",
+      "method": "DELETE"
+    },
+    {
+      "href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7",
+      "name": "update-name",
+      "method": "PATCH"
+    }
+  ],
+  "rel": [
+    "https://assignments.api.brightspace.com/rels/assignment"
+  ]
 }

--- a/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/assignmentActivityUsage.json
+++ b/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/assignmentActivityUsage.json
@@ -1,74 +1,88 @@
 {
-	"class": [
-		"assignment-activity",
-		"published"
-	],
-	"entities": [
-		{
-			"class": [
-				"due-date",
-				"date"
-			],
-			"rel": [
-				"https://api.brightspace.com/rels/date"
-			],
-			"properties": {
-				"date": "2019-09-20T03:59:00.000Z",
-				"localizedDate": "2019-09-19T23:59:00.000"
-			}
-		}
-	],
-	"links": [
-		{
-			"rel": [
-				"https://activities.api.brightspace.com/rels/activity-usage",
-				"self"
-			],
-			"href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.activities.api.dev.brightspace.com/activities/6606_2000_7/usages/123065"
-		},
-		{
-			"rel": [
-				"https://activities.api.brightspace.com/rels/user-activity-usage",
-				"https://activities.api.brightspace.com/rels/my-activity-usage"
-			],
-			"href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.activities.api.dev.brightspace.com/activities/6606_2000_7/usages/123065/users/169"
-		},
-		{
-			"rel": [
-				"https://activities.api.brightspace.com/rels/evaluation-status"
-			],
-			"href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.activities.api.dev.brightspace.com/activities/6606_2000_7/usages/123065/evaluation-status"
-		},
-		{
-			"rel": [
-				"https://api.brightspace.com/rels/organization"
-			],
-			"href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.organizations.api.dev.brightspace.com/123065"
-		},
-		{
-			"rel": [
-				"https://api.brightspace.com/rels/assignment"
-			],
-			"href": "./data/assignmentActivity.json"
-		},
-		{
-			"rel": [
-				"https://alignments.api.brightspace.com/rels/alignments"
-			],
-			"href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.alignments.api.dev.brightspace.com/activity-usage/6606_2000_7/123065"
-		},
-		{
-			"rel": [
-				"https://conditions.api.brightspace.com/rels/conditions"
-			],
-			"href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.conditions.api.dev.brightspace.com/activity-usage/TmpZd05sOHlNREF3WHpjLjEyMzA2NQ"
-		}
-	],
-	"actions": [
-		{
-			"href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7/setDraft/1",
-			"name": "set-draft",
-			"method": "POST"
-		}
-	]
+  "class": [
+    "assignment-activity",
+    "published"
+  ],
+  "entities": [
+    {
+      "class": [
+        "due-date",
+        "date"
+      ],
+      "rel": [
+        "https://api.brightspace.com/rels/date"
+      ],
+      "properties": {
+        "date": "2019-09-20T03:59:00.000Z",
+        "localizedDate": "2019-09-19T23:59:00.000"
+      },
+      "actions": [
+        {
+          "href": "https://8b4b0787-25ca-43d2-89ab-b9495546ad09.activities.api.proddev.d2l/activities/6606_2000_3/usages/6613",
+          "name": "update",
+          "method": "PATCH",
+          "fields": [
+            {
+              "type": "text",
+              "name": "dueDate",
+              "value": "2019-10-28T18:50:00.000Z"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "https://activities.api.brightspace.com/rels/activity-usage",
+        "self"
+      ],
+      "href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.activities.api.dev.brightspace.com/activities/6606_2000_7/usages/123065"
+    },
+    {
+      "rel": [
+        "https://activities.api.brightspace.com/rels/user-activity-usage",
+        "https://activities.api.brightspace.com/rels/my-activity-usage"
+      ],
+      "href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.activities.api.dev.brightspace.com/activities/6606_2000_7/usages/123065/users/169"
+    },
+    {
+      "rel": [
+        "https://activities.api.brightspace.com/rels/evaluation-status"
+      ],
+      "href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.activities.api.dev.brightspace.com/activities/6606_2000_7/usages/123065/evaluation-status"
+    },
+    {
+      "rel": [
+        "https://api.brightspace.com/rels/organization"
+      ],
+      "href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.organizations.api.dev.brightspace.com/123065"
+    },
+    {
+      "rel": [
+        "https://api.brightspace.com/rels/assignment"
+      ],
+      "href": "./data/assignmentActivity.json"
+    },
+    {
+      "rel": [
+        "https://alignments.api.brightspace.com/rels/alignments"
+      ],
+      "href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.alignments.api.dev.brightspace.com/activity-usage/6606_2000_7/123065"
+    },
+    {
+      "rel": [
+        "https://conditions.api.brightspace.com/rels/conditions"
+      ],
+      "href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.conditions.api.dev.brightspace.com/activity-usage/TmpZd05sOHlNREF3WHpjLjEyMzA2NQ"
+    }
+  ],
+  "actions": [
+    {
+      "href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7/setDraft/1",
+      "name": "set-draft",
+      "method": "POST"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "d2l-colors": "BrightspaceUI/colors#semver:^4",
     "d2l-common": "BrightspaceHypermediaComponents/common#semver:^2",
     "d2l-course-image": "Brightspace/course-image#semver:^3",
+    "d2l-datetime-picker": "BrightspaceUI/datetime-picker#semver:^4",
     "d2l-fetch": "Brightspace/d2l-fetch.git#semver:^2",
     "d2l-html-editor": "Brightspace/d2l-html-editor#semver:^2",
     "d2l-hypermedia-constants": "Brightspace/d2l-hypermedia-constants#semver:^6",

--- a/polymer.json
+++ b/polymer.json
@@ -1,6 +1,9 @@
 {
   "npm": true,
   "lint": {
-    "rules": ["polymer-3"]
+    "rules": ["polymer-3"],
+    "ignoreWarnings": [
+      "not-loadable"
+    ]
   }
 }


### PR DESCRIPTION
This `d2l-datetime-picker` control will show the current due date for the activity, and can be used to set a new due date for the activity. There are a few caveats to this currently that are worth noting:

- The `d2l-datetime-picker` component in use here is obsolete, and is going to be replaced in the near future, but there is not currently a timeline for this change. Once a new component exists, we should switch to use it.
- There is a change in the LMS to pull in `moment.js` to allow this component to work, as it doesn't do it itself. When we switch to a new picker component, this change can be removed, as it's two network calls to large-ish libraries that we won't need to make anymore.