### PR TITLE
Add Serge config for generic components

### DIFF
--- a/activities.serge.json
+++ b/activities.serge.json
@@ -57,6 +57,25 @@
       "zh-tw zh-tw"
     ]
   },{
+    "name": "activityEditor",
+    "source_dir": "components/d2l-activity-editor/lang",
+    "output_file_path": "components/d2l-activity-editor/lang/%LANG%.json",
+    "output_lang_rewrite": [
+      "ar-sa ar",
+      "de-de de",
+      "es-mx es",
+      "fi-FI fi",
+      "fr-ca fr",
+      "ja-jp ja",
+      "ko-kr ko",
+      "nl-nl nl",
+      "pt-br pt",
+      "sv-se sv",
+      "tr-tr tr",
+      "zh-cn zh",
+      "zh-tw zh-tw"
+    ]
+  },{
     "name": "assignmentActivityEditor",
     "source_dir": "components/d2l-activity-editor/d2l-activity-assignment-editor/lang",
     "output_file_path": "components/d2l-activity-editor/d2l-activity-assignment-editor/lang/%LANG%.json",

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -6,11 +6,13 @@ import { AssignmentEntity } from 'siren-sdk/src/activities/assignments/Assignmen
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { ErrorHandlingMixin } from '../error-handling-mixin.js';
-import { getLocalizeResources } from './localization.js';
+import { getLocalizeResources } from '../localization.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 import { SirenFetchMixinLit } from 'siren-sdk/src/mixin/siren-fetch-mixin-lit.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
+
+const baseUrl = import.meta.url;
 
 class AssignmentEditorDetail extends ErrorHandlingMixin(SirenFetchMixinLit(EntityMixinLit(LocalizeMixin(LitElement)))) {
 
@@ -39,7 +41,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SirenFetchMixinLit(Entit
 	}
 
 	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs);
+		return getLocalizeResources(langs, baseUrl);
 	}
 
 	constructor() {
@@ -148,8 +150,6 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SirenFetchMixinLit(Entit
 			<div id="duedate-container">
 				<label class="d2l-label-text">${this.localize('dueDate')}</label>
 				<d2l-activity-due-date-editor
-					dateLabel="${this.localize('dueDate')}"
-					timeLabel="${this.localize('dueTime')}"
 					.href="${this._activityUsageHref}"
 					.token="${this.token}">
 				</d2l-activity-due-date-editor>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -3,9 +3,11 @@ import './d2l-activity-assignment-editor-detail.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { AssignmentActivityUsageEntity } from 'siren-sdk/src/activities/assignments/AssignmentActivityUsageEntity.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
-import { getLocalizeResources } from './localization.js';
+import { getLocalizeResources } from '../localization.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 import { PendingContainerMixin } from 'siren-sdk/src/mixin/pending-container-mixin.js';
+
+const baseUrl = import.meta.url;
 
 class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LocalizeMixin(LitElement))) {
 
@@ -27,7 +29,7 @@ class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LocalizeMixi
 	}
 
 	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs);
+		return getLocalizeResources(langs, baseUrl);
 	}
 
 	constructor() {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.json
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.json
@@ -14,9 +14,5 @@
   "dueDate": {
     "translation": "Due Date",
     "context": "Label for the due date field when creating/editing an activity"
-  },
-  "dueTime": {
-    "translation": "Due Time",
-    "context": "Label for the due time field when creating/editing an activity"
   }
 }

--- a/components/d2l-activity-editor/d2l-activity-due-date-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-due-date-editor.js
@@ -2,14 +2,16 @@ import 'd2l-datetime-picker/d2l-datetime-picker';
 import { css, html, LitElement } from 'lit-element/lit-element';
 import { ActivityUsageEntity } from 'siren-sdk/src/activities/ActivityUsageEntity';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
+import { getLocalizeResources } from './localization';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 import { SirenFetchMixinLit } from 'siren-sdk/src/mixin/siren-fetch-mixin-lit';
 
-class ActivityDueDateEditor extends SirenFetchMixinLit(EntityMixinLit(LitElement)) {
+const baseUrl = import.meta.url;
+
+class ActivityDueDateEditor extends SirenFetchMixinLit(EntityMixinLit(LocalizeMixin(LitElement))) {
 
 	static get properties() {
 		return {
-			dateLabel: { type: String },
-			timeLabel: { type: String },
 			_date: { type: String },
 			_overrides: { type: Object }
 		};
@@ -24,6 +26,10 @@ class ActivityDueDateEditor extends SirenFetchMixinLit(EntityMixinLit(LitElement
 				display: none;
 			}
 		`;
+	}
+
+	static async getLocalizeResources(langs) {
+		return getLocalizeResources(langs, baseUrl);
 	}
 
 	constructor() {
@@ -74,8 +80,8 @@ class ActivityDueDateEditor extends SirenFetchMixinLit(EntityMixinLit(LitElement
 					hide-label
 					name="date"
 					id="date"
-					date-label="${this.dateLabel}"
-					time-label="${this.timeLabel}"
+					date-label="${this.localize('dueDate')}"
+					time-label="${this.localize('dueTime')}"
 					datetime="${this._date}"
 					overrides="${this._overrides}"
 					@d2l-datetime-picker-datetime-changed="${this._onDatetimePickerDatetimeChanged}"

--- a/components/d2l-activity-editor/lang/en.json
+++ b/components/d2l-activity-editor/lang/en.json
@@ -1,0 +1,10 @@
+{
+  "dueDate": {
+    "translation": "Due Date",
+    "context": "ARIA label for the due date field when creating/editing an activity"
+  },
+  "dueTime": {
+    "translation": "Due Time",
+    "context": "ARIA label for the due time field when creating/editing an activity"
+  }
+}

--- a/components/d2l-activity-editor/localization.js
+++ b/components/d2l-activity-editor/localization.js
@@ -2,9 +2,8 @@ import { resolveUrl } from '@polymer/polymer/lib/utils/resolve-url.js';
 
 const SUPPORTED_LANGUAGES = ['en', 'fr'];
 const cache = {};
-const baseUrl = import.meta.url;
 
-export async function getLocalizeResources(langs) {
+export async function getLocalizeResources(langs, baseUrl) {
 	const supportedLanguages = langs.reverse().filter(language => {
 		return SUPPORTED_LANGUAGES.indexOf(language) > -1;
 	});


### PR DESCRIPTION
In #440, a Serge config was added for the `assignmentActivityEditor`, but there will be several components within `d2l-activity-editor` that are not specific to assignments. To address this (based largely off [this thread](https://github.com/BrightspaceHypermediaComponents/activities/pull/446#pullrequestreview-306128414)), this adds a new config for the generic `activityEditor` langterms. There will likely be overlap in these terms, but this is the cleanest way to keep the domain-specific and domain-generic terms from cluttering each other up. This also means that eventually, when there are other specialized activity editors (e.g. `d2l-activity-survey-editor` or something), we'll have to add new Serge configs for them as well.

In order to support this, and use the same `getLocalizationResources` in all places, a minor refactor was required such that the method now takes in `import.meta.url` from any implementing class.