### PR TITLE
US110582 Fixup: pass config in correctly

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-due-date-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-due-date-editor.js
@@ -30,7 +30,7 @@ class ActivityDueDateEditor extends SirenFetchMixinLit(EntityMixinLit(LitElement
 		super();
 		this._setEntityType(ActivityUsageEntity);
 		this._date = '';
-		this._overrides = document.documentElement.intlOverrides || '{}';
+		this._overrides = document.documentElement.dataset.intlOverrides || '{}';
 	}
 
 	set _entity(entity) {


### PR DESCRIPTION
It's `documentElement.dataset.intlOverrides`, not `documentElement.intlOverrides`!