### PR TITLE
Use new siren-sdk functionality

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -9,10 +9,10 @@ import { ErrorHandlingMixin } from '../error-handling-mixin.js';
 import { getLocalizeResources } from './localization.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
-import { SirenFetchMixinLit } from 'siren-sdk/src/mixin/siren-fetch-mixin-lit.js';
+import { SaveStatusMixin } from '../save-status-mixin.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 
-class AssignmentEditorDetail extends ErrorHandlingMixin(SirenFetchMixinLit(EntityMixinLit(LocalizeMixin(LitElement)))) {
+class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMixinLit(LocalizeMixin(LitElement)))) {
 
 	static get properties() {
 		return {
@@ -69,19 +69,11 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SirenFetchMixinLit(Entit
 	}
 
 	_saveName(value) {
-		if (super._entity.canEditName()) {
-			const action = super._entity.getSaveNameAction();
-			const fields = [{ name: 'name', value: value }];
-			this._performSirenAction(action, fields);
-		}
+		this.save(super._entity.setName(value));
 	}
 
 	_saveInstructions(value) {
-		if (super._entity.canEditInstructions()) {
-			const action = super._entity.getSaveInstructionsAction();
-			const fields = [{ name: 'instructions', value: value }];
-			this._performSirenAction(action, fields);
-		}
+		this.save(super._entity.setInstructions(value));
 	}
 
 	_saveNameOnInput(e) {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -69,11 +69,11 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 	}
 
 	_saveName(value) {
-		this.save(super._entity.setName(value));
+		this.wrapSaveAction(super._entity.setName(value));
 	}
 
 	_saveInstructions(value) {
-		this.save(super._entity.setInstructions(value));
+		this.wrapSaveAction(super._entity.setInstructions(value));
 	}
 
 	_saveNameOnInput(e) {

--- a/components/d2l-activity-editor/d2l-activity-due-date-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-due-date-editor.js
@@ -2,9 +2,9 @@ import 'd2l-datetime-picker/d2l-datetime-picker';
 import { css, html, LitElement } from 'lit-element/lit-element';
 import { ActivityUsageEntity } from 'siren-sdk/src/activities/ActivityUsageEntity';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
-import { SirenFetchMixinLit } from 'siren-sdk/src/mixin/siren-fetch-mixin-lit';
+import { SaveStatusMixin } from './save-status-mixin';
 
-class ActivityDueDateEditor extends SirenFetchMixinLit(EntityMixinLit(LitElement)) {
+class ActivityDueDateEditor extends SaveStatusMixin(EntityMixinLit(LitElement)) {
 
 	static get properties() {
 		return {
@@ -46,7 +46,7 @@ class ActivityDueDateEditor extends SirenFetchMixinLit(EntityMixinLit(LitElement
 	}
 
 	_onDatetimePickerDatetimeCleared() {
-		this._updateDueDate('');
+		this.save(super._entity.setDueDate(''));
 	}
 
 	_onDatetimePickerDatetimeChanged(e) {
@@ -54,17 +54,7 @@ class ActivityDueDateEditor extends SirenFetchMixinLit(EntityMixinLit(LitElement
 			return;
 		}
 
-		this._updateDueDate(e.detail.toISOString());
-	}
-
-	_updateDueDate(dateString) {
-		if (!super._entity.canEditDueDate()) {
-			return;
-		}
-
-		const action = super._entity.saveDueDateAction();
-		const fields = [{ name: 'dueDate', value: dateString }];
-		this._performSirenAction(action, fields);
+		this.save(super._entity.setDueDate(e.detail.toISOString()));
 	}
 
 	render() {

--- a/components/d2l-activity-editor/d2l-activity-due-date-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-due-date-editor.js
@@ -46,7 +46,7 @@ class ActivityDueDateEditor extends SaveStatusMixin(EntityMixinLit(LitElement)) 
 	}
 
 	_onDatetimePickerDatetimeCleared() {
-		this.save(super._entity.setDueDate(''));
+		this.wrapSaveAction(super._entity.setDueDate(''));
 	}
 
 	_onDatetimePickerDatetimeChanged(e) {
@@ -54,7 +54,7 @@ class ActivityDueDateEditor extends SaveStatusMixin(EntityMixinLit(LitElement)) 
 			return;
 		}
 
-		this.save(super._entity.setDueDate(e.detail.toISOString()));
+		this.wrapSaveAction(super._entity.setDueDate(e.detail.toISOString()));
 	}
 
 	render() {

--- a/components/d2l-activity-editor/save-status-mixin.js
+++ b/components/d2l-activity-editor/save-status-mixin.js
@@ -1,31 +1,25 @@
 export const SaveStatusMixin = superclass => class extends superclass {
-	save(promise) {
-		this.saveStart();
-
-		return promise
-			.then(this.saveEnd)
-			.catch(err => this.saveError(err));
-	}
-
-	saveStart() {
+	wrapSaveAction(promise) {
 		this.dispatchEvent(new CustomEvent('d2l-siren-entity-save-start', {
 			bubbles: true,
 			composed: true
 		}));
-	}
 
-	saveEnd() {
-		this.dispatchEvent(new CustomEvent('d2l-siren-entity-save-end', {
-			bubbles: true,
-			composed: true
-		}));
-	}
+		return promise
+			.then(result => {
+				this.dispatchEvent(new CustomEvent('d2l-siren-entity-save-end', {
+					bubbles: true,
+					composed: true
+				}));
 
-	saveError(error) {
-		this.dispatchEvent(new CustomEvent('d2l-siren-entity-save-error', {
-			error,
-			bubbles: true,
-			composed: true
-		}));
+				return result;
+			})
+			.catch(error => {
+				this.dispatchEvent(new CustomEvent('d2l-siren-entity-save-error', {
+					error,
+					bubbles: true,
+					composed: true
+				}));
+			});
 	}
 };

--- a/components/d2l-activity-editor/save-status-mixin.js
+++ b/components/d2l-activity-editor/save-status-mixin.js
@@ -1,0 +1,31 @@
+export const SaveStatusMixin = superclass => class extends superclass {
+	save(promise) {
+		this.saveStart();
+
+		return promise
+			.then(this.saveEnd)
+			.catch(err => this.saveError(err));
+	}
+
+	saveStart() {
+		this.dispatchEvent(new CustomEvent('d2l-siren-entity-save-start', {
+			bubbles: true,
+			composed: true
+		}));
+	}
+
+	saveEnd() {
+		this.dispatchEvent(new CustomEvent('d2l-siren-entity-save-end', {
+			bubbles: true,
+			composed: true
+		}));
+	}
+
+	saveError(error) {
+		this.dispatchEvent(new CustomEvent('d2l-siren-entity-save-error', {
+			error,
+			bubbles: true,
+			composed: true
+		}));
+	}
+};

--- a/polymer.json
+++ b/polymer.json
@@ -3,7 +3,8 @@
   "lint": {
     "rules": ["polymer-3"],
     "ignoreWarnings": [
-      "not-loadable"
+      "not-loadable",
+      "could-not-resolve-reference"
     ]
   }
 }


### PR DESCRIPTION
Previously, for saving name/instructions/due date, we were getting the Siren action from the `siren-sdk`, building the field values, and calling `SirenFetchMixinLit._performSirenAction`. However, the purpose of the `siren-sdk` is to abstract out Siren almost entirely, so that there is an easy to use interface on a given entity type that can be used by consumers - e.g. just call `setName(newName)`. There are two main benefits to this:

1. The UI code becomes cleaner - ideally, to the point where the UI code knows nothing about Siren at all, and only knows how to speak in the language of `siren-sdk`.
2. Consistency - first, because ideally all clients only speak `siren-sdk` and therefore changes to the actual details of the flow need to only be changed in one place. In addition, this reduces the possibility of different UIs doing slightly different things to accomplish the same task.

One caveat of this change is that the `siren-sdk` doesn't have knowledge of the events that drive a `d2l-save-status` element, as this is a UI concern. In order to overcome this, the `SaveStatusMixin` was also added here.

See also https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/78