### PR TITLE
US110198 Add Submission Type select list

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -26,7 +26,8 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 			_richtextEditorConfig: { type: Object },
 			_canEditInstructions: { type: Boolean },
 			_activityUsageHref: { type: String },
-			_submissionTypes: { type: Array }
+			_submissionTypes: { type: Array },
+			_canEditSubmissionType: { type: Boolean }
 		};
 	}
 
@@ -40,6 +41,11 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 			}
 			:host > div {
 				padding-bottom: 20px;
+			}
+
+			select {
+				width: 250px;
+				display: block;
 			}
 		`];
 	}
@@ -75,6 +81,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 		this._canEditInstructions = assignment.canEditInstructions();
 		this._activityUsageHref = assignment.activityUsageHref();
 		this._submissionTypes = assignment.submissionTypeOptions();
+		this._canEditSubmissionType = assignment.canEditSubmissionType();
 	}
 
 	_saveOnChange(jobName) {
@@ -190,8 +197,12 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 			</div>
 
 			<div id="assignment-submission-type-container">
-				<label class="d2l-label-text">${this.localize('submissionType')}</label>
-				<select @change="${this._saveSubmissionTypeOnChange}">
+				<label class="d2l-label-text" for="assignment-submission-type">${this.localize('submissionType')}</label>
+				<select
+					id="assignment-submission-type"
+					@change="${this._saveSubmissionTypeOnChange}"
+					?disabled="${!this._canEditSubmissionType}">
+
 					${this._getSubmissionTypeOptions()}
 				</select>
 			</div>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.json
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.json
@@ -14,5 +14,9 @@
   "dueDate": {
     "translation": "Due Date",
     "context": "Label for the due date field when creating/editing an activity"
+  },
+  "submissionType": {
+    "translation": "Submission Type",
+    "context": "Label for the submission type field when creating/editing an assignment"
   }
 }

--- a/components/d2l-activity-editor/select-styles.js
+++ b/components/d2l-activity-editor/select-styles.js
@@ -1,0 +1,130 @@
+import { css } from 'lit-element/lit-element';
+
+export const selectStyles = css`
+	select {
+		border-radius: 0.3rem;
+		border-style: solid;
+		-webkit-box-sizing: border-box;
+		box-sizing: border-box;
+		display: inline-block;
+		height: auto;
+		margin: 0;
+		vertical-align: middle;
+		width: 100%;
+		-webkit-transition-duration: 0.5s;
+		transition-duration: 0.5s;
+		-webkit-transition-timing-function: ease;
+		transition-timing-function: ease;
+		-webkit-transition-property: background-color, border-color;
+		transition-property: background-color, border-color;
+		color: #565a5c;
+		font-family: inherit;
+		font-size: 0.8rem;
+		font-weight: 400;
+		letter-spacing: 0.02rem;
+		line-height: 1.2rem;
+	}
+	select::-webkit-input-placeholder {
+		color: #d3d9e3;
+	}
+	select::-moz-placeholder {
+		color: #d3d9e3;
+	}
+	select:-ms-input-placeholder {
+		color: #d3d9e3;
+	}
+	select::placeholder {
+		color: #d3d9e3;
+	}
+	select,
+	select:hover:disabled {
+		background-color: #fff;
+		border-color: #d3d9e3;
+		border-width: 1px;
+		-webkit-box-shadow: inset 0 2px 0 0 rgba(185, 194, 208, 0.2);
+		box-shadow: inset 0 2px 0 0 rgba(185, 194, 208, 0.2);
+		padding: 0.4rem 0.75rem;
+	}
+	select:hover,
+	select:focus,
+	select.vui-input-focus {
+		border-color: #006fbf;
+		border-width: 2px;
+		outline-width: 0;
+		padding: calc(0.4rem - 1px) calc(0.75rem - 1px);
+	}
+	select[aria-invalid='true'] {
+		border-color: #cd2026;
+	}
+	select:disabled {
+		opacity: 0.5;
+	}
+	select::-webkit-search-cancel-button {
+		display: none;
+	}
+	select::-ms-clear {
+		display: none;
+		width: 0;
+		height: 0;
+	}
+	select option {
+		font-weight: 400;
+	}
+	@media screen and (-webkit-min-device-pixel-ratio: 0),
+	screen and (min--moz-device-pixel-ratio: 0),
+	screen and (-ms-high-contrast: active),
+	(-ms-high-contrast: none) {
+		select:not([multiple]) {
+			-webkit-appearance: none;
+			-moz-appearance: none;
+			appearance: none;
+			background-position: right center;
+			background-repeat: no-repeat;
+			background-size: contain;
+			max-height: calc(2rem + 2px);
+		}
+		select:not([multiple]):focus,
+		select:not([multiple]):hover,
+		select:not([multiple]).vui-input-hover,
+		select:not([multiple]).vui-input-focus {
+			background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2242%22%20height%3D%2242%22%20viewBox%3D%220%200%2042%2042%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23e6eaf0%22%20d%3D%22M0%200h42v42H0z%22%2F%3E%3Cpath%20stroke%3D%22%23d3d9e3%22%20d%3D%22M0%200v42%22%2F%3E%3Cpath%20d%3D%22M14.99%2019.582l4.95%204.95a1.5%201.5%200%200%200%202.122%200l4.95-4.95a1.5%201.5%200%200%200-2.122-2.122L21%2021.35l-3.888-3.89a1.5%201.5%200%200%200-2.12%202.122z%22%20fill%3D%22%23565A5C%22%2F%3E%3C%2Fsvg%3E");
+			padding-right: calc(0.75rem + 42px - 1px);
+		}
+		select:not([multiple]):focus::-ms-value,
+		select:not([multiple]):hover::-ms-value,
+		select:not([multiple]).vui-input-hover::-ms-value,
+		select:not([multiple]).vui-input-focus::-ms-value {
+			background-color: transparent;
+			color: #565a5c;
+		}
+		select:not([multiple]),
+		select:not([multiple]):disabled,
+		select:not([multiple]):focus:disabled,
+		select:not([multiple]):hover:disabled {
+			background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2242%22%20height%3D%2242%22%20viewBox%3D%220%200%2042%2042%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23f2f3f5%22%20d%3D%22M0%200h42v42H0z%22%2F%3E%3Cpath%20stroke%3D%22%23d3d9e3%22%20d%3D%22M0%200v42%22%2F%3E%3Cpath%20d%3D%22M14.99%2019.582l4.95%204.95a1.5%201.5%200%200%200%202.122%200l4.95-4.95a1.5%201.5%200%200%200-2.122-2.122L21%2021.35l-3.888-3.89a1.5%201.5%200%200%200-2.12%202.122z%22%20fill%3D%22%23565A5C%22%2F%3E%3C%2Fsvg%3E");
+			padding-right: calc(0.75rem + 42px);
+		}
+		[dir='rtl'] select:not([multiple]) {
+			background-position: left center;
+		}
+		[dir='rtl'] select:not([multiple]):focus,
+		[dir='rtl'] select:not([multiple]):hover,
+		[dir='rtl'] select:not([multiple]).vui-input-hover,
+		[dir='rtl'] select:not([multiple]).vui-input-focus {
+			background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2242%22%20height%3D%2242%22%20viewBox%3D%220%200%2042%2042%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23e6eaf0%22%20d%3D%22M0%200h42v42H0z%22%2F%3E%3Cpath%20stroke%3D%22%23d3d9e3%22%20d%3D%22M42%200v42%22%2F%3E%3Cpath%20d%3D%22M14.99%2019.582l4.95%204.95a1.5%201.5%200%200%200%202.122%200l4.95-4.95a1.5%201.5%200%200%200-2.122-2.122L21%2021.35l-3.888-3.89a1.5%201.5%200%200%200-2.12%202.122z%22%20fill%3D%22%23565A5C%22%2F%3E%3C%2Fsvg%3E");
+			padding-left: calc(0.75rem + 42px - 1px);
+			padding-right: calc(0.75rem - 1px);
+		}
+		[dir='rtl'] select:not([multiple]),
+		[dir='rtl'] select:not([multiple]):disabled,
+		[dir='rtl'] select:not([multiple]):focus:disabled,
+		[dir='rtl'] select:not([multiple]):hover:disabled {
+			background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2242%22%20height%3D%2242%22%20viewBox%3D%220%200%2042%2042%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23f2f3f5%22%20d%3D%22M0%200h42v42H0z%22%2F%3E%3Cpath%20stroke%3D%22%23d3d9e3%22%20d%3D%22M42%200v42%22%2F%3E%3Cpath%20d%3D%22M14.99%2019.582l4.95%204.95a1.5%201.5%200%200%200%202.122%200l4.95-4.95a1.5%201.5%200%200%200-2.122-2.122L21%2021.35l-3.888-3.89a1.5%201.5%200%200%200-2.12%202.122z%22%20fill%3D%22%23565A5C%22%2F%3E%3C%2Fsvg%3E");
+			padding-right: 0.75rem;
+			padding-left: calc(0.75rem + 42px);
+		}
+		select::-ms-expand {
+			display: none;
+		}
+	}
+`;

--- a/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/assignmentActivity.json
+++ b/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/assignmentActivity.json
@@ -11,12 +11,12 @@
     "addToGrades": false,
     "draft": false,
     "submissionType": {
-      "title": "File submission",
-      "value": 0
+      "title": "On paper submission",
+      "value": 2
     },
     "completionType": {
-      "title": "Automatically on submission",
-      "value": 0
+      "title": "Automatically on due date",
+      "value": 1
     }
   },
   "entities": [
@@ -232,6 +232,52 @@
       "href": "https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7",
       "name": "update-name",
       "method": "PATCH"
+    },
+    {
+      "href": "https://8b4b0787-25ca-43d2-89ab-b9495546ad09.assignments.api.proddev.d2l/6613/folders/3",
+      "name": "update-submission-type",
+      "method": "PATCH",
+      "fields": [
+        {
+          "type": "radio",
+          "title": "Submission Type",
+          "name": "submissionType",
+          "value": [
+            {
+              "title": "File submission",
+              "value": 0,
+              "completionTypes": null,
+              "selected": false
+            },
+            {
+              "title": "Text submission",
+              "value": 1,
+              "completionTypes": null,
+              "selected": false
+            },
+            {
+              "title": "On paper submission",
+              "value": 2,
+              "completionTypes": [
+                1,
+                2,
+                3
+              ],
+              "selected": true
+            },
+            {
+              "title": "Observed in person",
+              "value": 3,
+              "completionTypes": [
+                1,
+                2,
+                3
+              ],
+              "selected": false
+            }
+          ]
+        }
+      ]
     }
   ],
   "rel": [


### PR DESCRIPTION
This adds a styled `select` element that presents the options for `submissionType` on the assignment. There are two caveats to this change:

1. The `completionType` dropdown is not included, which means the On Paper and Observed in Person submission types can't be used correctly (they will both just use "Automatically on due date" as the completion type for now)
2. The styles for the `select` have just been copy+pasted into a `select-styles` file, but are planned to be separated out somewhere common.

Both of these should be rectified soon - the first by another US, and the second once some further discussions occur with Gaudi et al.

This also includes some minor changes to not access `super._entity` directly for getters, which is somewhat bad form it turns out - instead, it's better to use local values that are set in the `_onAssignmentChange` handler.

Requires https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/80