### PR TITLE
US111620 Add plaintext instructions editor

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -1,6 +1,6 @@
 import 'd2l-inputs/d2l-input-text.js';
 import '../d2l-activity-due-date-editor.js';
-import '../d2l-activity-html-editor.js';
+import '../d2l-activity-text-editor.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { AssignmentEntity } from 'siren-sdk/src/activities/assignments/AssignmentEntity.js';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
@@ -17,11 +17,12 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 
 	static get properties() {
 		return {
+			htmlEditorEnabled: { type: Boolean },
 			_name: { type: String },
 			_nameError: { type: String },
 			_canEditName: { type: Boolean },
 			_instructions: { type: String },
-			_richtextEditorConfig: { type: Object },
+			_instructionsRichTextEditorConfig: { type: Object },
 			_canEditInstructions: { type: Boolean },
 			_activityUsageHref: { type: String },
 			_submissionTypes: { type: Array },
@@ -79,7 +80,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 		this._name = assignment.name();
 		this._canEditName = assignment.canEditName();
 		this._instructions = assignment.instructionsEditorHtml();
-		this._richtextEditorConfig = assignment.getRichTextEditorConfig();
+		this._instructionsRichTextEditorConfig = assignment.instructionsRichTextEditorConfig();
 		this._canEditInstructions = assignment.canEditInstructions();
 		this._activityUsageHref = assignment.activityUsageHref();
 		this._submissionTypes = assignment.submissionTypeOptions();
@@ -193,13 +194,14 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 
 			<div id="assignment-instructions-container">
 				<label class="d2l-label-text">${this.localize('instructions')}</label>
-				<d2l-activity-html-editor
+				<d2l-activity-text-editor
 					value="${this._instructions}"
-					.richtextEditorConfig="${this._richtextEditorConfig}"
-					@d2l-activity-html-editor-change="${this._saveInstructionsOnChange}"
+					?htmlEditorEnabled="${this.htmlEditorEnabled}"
+					.richtextEditorConfig="${this._instructionsRichTextEditorConfig}"
+					@d2l-activity-text-editor-change="${this._saveInstructionsOnChange}"
 					ariaLabel="${this.localize('instructions')}"
 					?disabled="${!this._canEditInstructions}">
-				</d2l-activity-html-editor>
+				</d2l-activity-text-editor>
 			</div>
 
 			<div id="assignment-submission-type-container">

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -9,6 +9,7 @@ class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LitElement))
 
 	static get properties() {
 		return {
+			htmlEditorEnabled: { type: Boolean },
 			_assignmentHref: { type: String },
 		};
 	}
@@ -46,6 +47,7 @@ class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LitElement))
 				<d2l-activity-assignment-editor-detail
 					.href="${this._assignmentHref}"
 					.token="${this.token}"
+					?htmlEditorEnabled="${this.htmlEditorEnabled}"
 					slot="editor">
 				</d2l-activity-assignment-editor-detail>
 			</d2l-activity-editor>

--- a/components/d2l-activity-editor/d2l-activity-text-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-text-editor.js
@@ -40,7 +40,6 @@ class ActivityTextEditor extends LitElement {
 				<d2l-activity-html-editor
 					ariaLabel="${this.ariaLabel}"
 					value="${this.value}"
-					?htmlEditorEnabled="${this.htmlEditorEnabled}"
 					?disabled="${this.disabled}"
 					@d2l-activity-html-editor-change="${this._onRichtextChange}"
 					.richtextEditorConfig="${this.richtextEditorConfig}">

--- a/components/d2l-activity-editor/d2l-activity-text-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-text-editor.js
@@ -1,0 +1,64 @@
+import 'd2l-inputs/d2l-input-textarea';
+import './d2l-activity-html-editor';
+import { html, LitElement } from 'lit-element/lit-element';
+
+class ActivityTextEditor extends LitElement {
+
+	static get properties() {
+		return {
+			value: { type: String },
+			htmlEditorEnabled: { type: Boolean },
+			richtextEditorConfig: { type: Object },
+			disabled: { type: Boolean },
+			ariaLabel: { type: String },
+		};
+	}
+
+	_onPlaintextChange() {
+		const content = this.shadowRoot.querySelector('d2l-input-textarea').value;
+		this._dispatchChangeEvent(content);
+	}
+
+	_onRichtextChange(e) {
+		const content = e.detail.content;
+		this._dispatchChangeEvent(content);
+	}
+
+	_dispatchChangeEvent(content) {
+		this.dispatchEvent(new CustomEvent('d2l-activity-text-editor-change', {
+			bubbles: true,
+			composed: true,
+			detail: {
+				content: content
+			}
+		}));
+	}
+
+	render() {
+		if (this.htmlEditorEnabled) {
+			return html`
+				<d2l-activity-html-editor
+					ariaLabel="${this.ariaLabel}"
+					value="${this.value}"
+					?htmlEditorEnabled="${this.htmlEditorEnabled}"
+					?disabled="${this.disabled}"
+					@d2l-activity-html-editor-change="${this._onRichtextChange}"
+					.richtextEditorConfig="${this.richtextEditorConfig}">
+				</d2l-activity-html-editor>
+			`;
+		} else {
+			return html`
+				<d2l-input-textarea
+					id="text-editor"
+					value="${this.value}"
+					?disabled="${this.disabled}"
+					@change="${this._onPlaintextChange}"
+					@input="${this._onPlaintextChange}">
+				</d2l-input-textarea>
+			`;
+		}
+	}
+
+}
+
+customElements.define('d2l-activity-text-editor', ActivityTextEditor);

--- a/demo/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.html
+++ b/demo/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.html
@@ -20,15 +20,29 @@
 			function changeLocale(locale) { // eslint-disable-line no-unused-vars
 				document.getElementsByTagName('html')[0].lang = locale;
 			}
+			function changeEditor() { // eslint-disable-line no-unused-vars
+				const editorSwitch = document.getElementById('editorSwitch');
+				const editor = document.querySelector('d2l-activity-assignment-editor-detail');
+
+				if (editorSwitch.hasAttribute('checked')) {
+					editorSwitch.removeAttribute('checked');
+					editor.setAttribute('htmlEditorEnabled', 'htmlEditorEnabled');
+				} else {
+					editorSwitch.setAttribute('checked', 'checked');
+					editor.removeAttribute('htmlEditorEnabled');
+				}
+			}
 		</script>
 		<d2l-demo-page page-title="d2l-activity-assignment-editor-detail">
 			<h2>d2l-activity-assignment-editor-detail</h2>
 			<d2l-demo-snippet>
-				<d2l-activity-assignment-editor-detail token="secret" href="./data/assignmentActivity.json"></d2l-activity-assignment-editor-detail>
+				<d2l-activity-assignment-editor-detail token="secret" href="./data/assignmentActivity.json" htmlEditorEnabled></d2l-activity-assignment-editor-detail>
 			</d2l-demo-snippet>
 
 			<button onclick="changeLocale('en')">Reset locale to "en"</button>
 			<button onclick="changeLocale('fr')">Change locale to "fr"</button>
+			<br/>
+			<label><input id="editorSwitch" type="checkbox" onchange="changeEditor()">Use plaintext editor for instructions</input></label>
 		</d2l-demo-page>
 	</body>
 </html>

--- a/demo/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.html
+++ b/demo/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.html
@@ -19,7 +19,7 @@
 		<d2l-demo-page page-title="d2l-activity-assignment-editor">
 			<h2>d2l-activity-assignment-editor</h2>
 			<d2l-demo-snippet>
-				<d2l-activity-assignment-editor token="secret" href="./data/assignmentActivityUsage.json"></d2l-activity-assignment-editor>
+				<d2l-activity-assignment-editor token="secret" href="./data/assignmentActivityUsage.json" htmlEditorEnabled></d2l-activity-assignment-editor>
 			</d2l-demo-snippet>
 		</d2l-demo-page>
 	</body>


### PR DESCRIPTION
This passes down a user config setting to determine whether to use the HTML editor or a plaintext editor for the instructions. This could be represented in an API response somehow, but after some thought and trying to flesh that out, this was a much simpler solution. It's unfortunate that the interim components needs to pass down an attribute that they don't really care about (`htmlEditorEnabled`), but it's not all that much more code or complexity, and the presence of other text editing fields in the future would be easy to support.

The new `d2l-activity-text-editor` acts more-or-less the same as the HTML editor did, but now will display a `d2l-input-textarea` when the user doesn't want to use richtext editing.

Requires https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/86