### PR TITLE
Add Serge plugin for context

### DIFF
--- a/activities.serge.json
+++ b/activities.serge.json
@@ -58,6 +58,9 @@
     ]
   },{
     "name": "activityEditor",
+    "parser_plugin": {
+      "plugin": "parse_d2l_fra"
+    },
     "source_dir": "components/d2l-activity-editor/lang",
     "output_file_path": "components/d2l-activity-editor/lang/%LANG%.json",
     "output_lang_rewrite": [
@@ -77,6 +80,9 @@
     ]
   },{
     "name": "assignmentActivityEditor",
+    "parser_plugin": {
+      "plugin": "parse_d2l_fra"
+    },
     "source_dir": "components/d2l-activity-editor/d2l-activity-assignment-editor/lang",
     "output_file_path": "components/d2l-activity-editor/d2l-activity-assignment-editor/lang/%LANG%.json",
     "output_lang_rewrite": [


### PR DESCRIPTION
In the most recent translation run, we got back output that included translated `context` strings, which is not what we want. Turns out, this is due to the lack of this plugin, which translates the `context` into the expected description field for translation by Serge. This should mean that, after the next translation run, our translated files should no longer have the `context` strings in them at all, and instead be a fairly flat list of `langterm: "translation"` as expected.