### PR TITLE
added experimental serge parsing

### DIFF
--- a/activities.serge.json
+++ b/activities.serge.json
@@ -57,6 +57,29 @@
       "zh-tw zh-tw"
     ]
   },{
+    "name": "quickEval_EXPERIMENTAL",
+		"parser_plugin": {
+      "plugin": "parse_js"
+    },
+    "source_match": "en\\.js$",
+    "source_dir": "components/d2l-quick-eval/lang",
+    "output_file_path": "components/d2l-quick-eval/lang-experimental/%LANG%.js",
+    "output_lang_rewrite": [
+      "ar-sa ar",
+      "de-de de",
+      "es-mx es",
+      "fi-FI fi",
+      "fr-ca fr",
+      "ja-jp ja",
+      "ko-kr ko",
+      "nl-nl nl",
+      "pt-br pt",
+      "sv-se sv",
+      "tr-tr tr",
+      "zh-cn zh",
+      "zh-tw zh-tw"
+    ]
+  },{
     "name": "activityEditor",
     "parser_plugin": {
       "plugin": "parse_d2l_fra"


### PR DESCRIPTION
I saw @ryantmer do a thing and its pretty cool.

So i wanted to pilot an experimentation new serge integration that pulls us only js files. I shamelessly stole this code from https://github.com/BrightspaceHypermediaComponents/activities/pull/468.

@ryantmer is there a way to test this? Do I have to submit a lang term, then wait and see? Any modifications do i need to get this running?