### PR TITLE
Fix lang file format

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ar.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ar.js
@@ -1,5 +1,7 @@
+/* eslint quotes: 0 */
+
 export default {
-	emptyNameError: 'الاسم مطلوب', // Error message to inform user that the assignment name is a required field
-	instructions: 'الإرشادات', // Label for the instruction field when creating/editing an assignment
-	name: 'الاسم', // Label for the name field when creating/editing an activity
+	"emptyNameError": "الاسم مطلوب", // Error message to inform user that the assignment name is a required field
+	"instructions": "الإرشادات", // Label for the instruction field when creating/editing an assignment
+	"name": "الاسم", // Label for the name field when creating/editing an activity
 };

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/de.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/de.js
@@ -1,5 +1,7 @@
+/* eslint quotes: 0 */
+
 export default {
-	emptyNameError: 'Name erforderlich', // Error message to inform user that the assignment name is a required field
-	instructions: 'Anweisungen', // Label for the instruction field when creating/editing an assignment
-	name: 'Name', // Label for the name field when creating/editing an activity
+	"emptyNameError": "Name erforderlich", // Error message to inform user that the assignment name is a required field
+	"instructions": "Anweisungen", // Label for the instruction field when creating/editing an assignment
+	"name": "Name", // Label for the name field when creating/editing an activity
 };

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
@@ -1,8 +1,10 @@
+/* eslint quotes: 0 */
+
 export default {
-	completionType: 'Marked as completed', // Label for the completion type field when creating/editing an assignment
-	dueDate: 'Due Date', // ARIA label for the due date field when creating/editing an activity
-	emptyNameError: 'Name is required', // Error message to inform user that the assignment name is a required field
-	instructions: 'Instructions', // Label for the instruction field when creating/editing an assignment
-	name: 'Name', // Label for the name field when creating/editing an activity
-	submissionType: 'Submission Type', // Label for the submission type field when creating/editing an assignment
+	"completionType": "Marked as completed", // Label for the completion type field when creating/editing an assignment
+	"dueDate": "Due Date", // ARIA label for the due date field when creating/editing an activity
+	"emptyNameError": "Name is required", // Error message to inform user that the assignment name is a required field
+	"instructions": "Instructions", // Label for the instruction field when creating/editing an assignment
+	"name": "Name", // Label for the name field when creating/editing an activity
+	"submissionType": "Submission Type", // Label for the submission type field when creating/editing an assignment
 };

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/fr.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/fr.js
@@ -1,5 +1,7 @@
+/* eslint quotes: 0 */
+
 export default {
-	emptyNameError: 'Le nom est obligatoire', // Error message to inform user that the assignment name is a required field
-	instructions: 'Instructions', // Label for the instruction field when creating/editing an assignment
-	name: 'Nom', // Label for the name field when creating/editing an activity
+	"emptyNameError": "Le nom est obligatoire", // Error message to inform user that the assignment name is a required field
+	"instructions": "Instructions", // Label for the instruction field when creating/editing an assignment
+	"name": "Nom", // Label for the name field when creating/editing an activity
 };

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ja.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ja.js
@@ -1,5 +1,7 @@
+/* eslint quotes: 0 */
+
 export default {
-	emptyNameError: '名前は必須です', // Error message to inform user that the assignment name is a required field
-	instructions: '手順', // Label for the instruction field when creating/editing an assignment
-	name: '名前', // Label for the name field when creating/editing an activity
+	"emptyNameError": "名前は必須です", // Error message to inform user that the assignment name is a required field
+	"instructions": "手順", // Label for the instruction field when creating/editing an assignment
+	"name": "名前", // Label for the name field when creating/editing an activity
 };

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ko.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ko.js
@@ -1,5 +1,7 @@
+/* eslint quotes: 0 */
+
 export default {
-	emptyNameError: '이름이 필요함', // Error message to inform user that the assignment name is a required field
-	instructions: '지시사항', // Label for the instruction field when creating/editing an assignment
-	name: '이름', // Label for the name field when creating/editing an activity
+	"emptyNameError": "이름이 필요함", // Error message to inform user that the assignment name is a required field
+	"instructions": "지시사항", // Label for the instruction field when creating/editing an assignment
+	"name": "이름", // Label for the name field when creating/editing an activity
 };

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/nl.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/nl.js
@@ -1,6 +1,8 @@
+/* eslint quotes: 0 */
+
 export default {
-	dueDate: 'Uiterste datum', // ARIA label for the due date field when creating/editing an activity
-	emptyNameError: 'Naam vereist', // Error message to inform user that the assignment name is a required field
-	instructions: 'Instructies', // Label for the instruction field when creating/editing an assignment
-	name: 'Naam', // Label for the name field when creating/editing an activity
+	"dueDate": "Uiterste datum", // ARIA label for the due date field when creating/editing an activity
+	"emptyNameError": "Naam vereist", // Error message to inform user that the assignment name is a required field
+	"instructions": "Instructies", // Label for the instruction field when creating/editing an assignment
+	"name": "Naam", // Label for the name field when creating/editing an activity
 };

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/pt.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/pt.js
@@ -1,6 +1,8 @@
+/* eslint quotes: 0 */
+
 export default {
-	dueDate: 'Prazo', // ARIA label for the due date field when creating/editing an activity
-	emptyNameError: 'O nome é obrigatório', // Error message to inform user that the assignment name is a required field
-	instructions: 'Instruções', // Label for the instruction field when creating/editing an assignment
-	name: 'Nome', // Label for the name field when creating/editing an activity
+	"dueDate": "Prazo", // ARIA label for the due date field when creating/editing an activity
+	"emptyNameError": "O nome é obrigatório", // Error message to inform user that the assignment name is a required field
+	"instructions": "Instruções", // Label for the instruction field when creating/editing an assignment
+	"name": "Nome", // Label for the name field when creating/editing an activity
 };

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/sv.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/sv.js
@@ -1,5 +1,7 @@
+/* eslint quotes: 0 */
+
 export default {
-	emptyNameError: 'Namn krävs', // Error message to inform user that the assignment name is a required field
-	instructions: 'Instruktioner', // Label for the instruction field when creating/editing an assignment
-	name: 'Namn', // Label for the name field when creating/editing an activity
+	"emptyNameError": "Namn krävs", // Error message to inform user that the assignment name is a required field
+	"instructions": "Instruktioner", // Label for the instruction field when creating/editing an assignment
+	"name": "Namn", // Label for the name field when creating/editing an activity
 };

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/tr.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/tr.js
@@ -1,5 +1,7 @@
+/* eslint quotes: 0 */
+
 export default {
-	emptyNameError: 'Ad gerekli', // Error message to inform user that the assignment name is a required field
-	instructions: 'Talimatlar', // Label for the instruction field when creating/editing an assignment
-	name: 'Ad', // Label for the name field when creating/editing an activity
+	"emptyNameError": "Ad gerekli", // Error message to inform user that the assignment name is a required field
+	"instructions": "Talimatlar", // Label for the instruction field when creating/editing an assignment
+	"name": "Ad", // Label for the name field when creating/editing an activity
 };

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/zh-tw.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/zh-tw.js
@@ -1,6 +1,8 @@
+/* eslint quotes: 0 */
+
 export default {
-	dueDate: '截止日期', // ARIA label for the due date field when creating/editing an activity
-	emptyNameError: '名稱為必填', // Error message to inform user that the assignment name is a required field
-	instructions: '指示', // Label for the instruction field when creating/editing an assignment
-	name: '名稱', // Label for the name field when creating/editing an activity
+	"dueDate": "截止日期", // ARIA label for the due date field when creating/editing an activity
+	"emptyNameError": "名稱為必填", // Error message to inform user that the assignment name is a required field
+	"instructions": "指示", // Label for the instruction field when creating/editing an assignment
+	"name": "名稱", // Label for the name field when creating/editing an activity
 };

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/zh.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/zh.js
@@ -1,6 +1,8 @@
+/* eslint quotes: 0 */
+
 export default {
-	dueDate: '截止日期', // ARIA label for the due date field when creating/editing an activity
-	emptyNameError: '需要提供名称', // Error message to inform user that the assignment name is a required field
-	instructions: '说明', // Label for the instruction field when creating/editing an assignment
-	name: '名称', // Label for the name field when creating/editing an activity
+	"dueDate": "截止日期", // ARIA label for the due date field when creating/editing an activity
+	"emptyNameError": "需要提供名称", // Error message to inform user that the assignment name is a required field
+	"instructions": "说明", // Label for the instruction field when creating/editing an assignment
+	"name": "名称", // Label for the name field when creating/editing an activity
 };

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -1,5 +1,7 @@
+/* eslint quotes: 0 */
+
 export default {
-	dueDate: 'Due Date', // ARIA label for the due date field when creating/editing an activity
-	dueTime: 'Due Time', // ARIA label for the due time field when creating/editing an activity
-	noDueDate: 'No due date', // Placeholder text for due date field when no due date is set
+	"dueDate": "Due Date", // ARIA label for the due date field when creating/editing an activity
+	"dueTime": "Due Time", // ARIA label for the due time field when creating/editing an activity
+	"noDueDate": "No due date", // Placeholder text for due date field when no due date is set
 };

--- a/components/d2l-activity-editor/lang/fr.js
+++ b/components/d2l-activity-editor/lang/fr.js
@@ -1,5 +1,7 @@
+/* eslint quotes: 0 */
+
 export default {
-	dueDate: 'Due Date', // ARIA label for the due date field when creating/editing an activity
-	dueTime: 'Due Time', // ARIA label for the due time field when creating/editing an activity
-	noDueDate: 'No due date', // Placeholder text for due date field when no due date is set
+	"dueDate": "Due Date", // ARIA label for the due date field when creating/editing an activity
+	"dueTime": "Due Time", // ARIA label for the due time field when creating/editing an activity
+	"noDueDate": "No due date", // Placeholder text for due date field when no due date is set
 };

--- a/components/d2l-activity-editor/lang/nl.js
+++ b/components/d2l-activity-editor/lang/nl.js
@@ -1,3 +1,5 @@
+/* eslint quotes: 0 */
+
 export default {
-	dueDate: 'Uiterste datum', // ARIA label for the due date field when creating/editing an activity
+	"dueDate": "Uiterste datum", // ARIA label for the due date field when creating/editing an activity
 };

--- a/components/d2l-activity-editor/lang/pt.js
+++ b/components/d2l-activity-editor/lang/pt.js
@@ -1,3 +1,5 @@
+/* eslint quotes: 0 */
+
 export default {
-	dueDate: 'Prazo', // ARIA label for the due date field when creating/editing an activity
+	"dueDate": "Prazo", // ARIA label for the due date field when creating/editing an activity
 };

--- a/components/d2l-activity-editor/lang/zh-tw.js
+++ b/components/d2l-activity-editor/lang/zh-tw.js
@@ -1,3 +1,5 @@
+/* eslint quotes: 0 */
+
 export default {
-	dueDate: '截止日期', // ARIA label for the due date field when creating/editing an activity
+	"dueDate": "截止日期", // ARIA label for the due date field when creating/editing an activity
 };

--- a/components/d2l-activity-editor/lang/zh.js
+++ b/components/d2l-activity-editor/lang/zh.js
@@ -1,3 +1,5 @@
+/* eslint quotes: 0 */
+
 export default {
-	dueDate: '截止日期', // ARIA label for the due date field when creating/editing an activity
+	"dueDate": "截止日期", // ARIA label for the due date field when creating/editing an activity
 };


### PR DESCRIPTION
Sadly, support for single quotes and non-quoted keys was only added to Serge's `parse_js` parser in evernote/serge@8d42a5d#diff-ab91cf35eb431bb9c7e44e833b0a724f (in August), and hasn't yet been released - despite the documentation saying it's supported. So, we need to use the double-quotes-everywhere syntax for now.