### PR TITLE
Integrated Edit-In-Place into title and description of activity collection editor

### DIFF
--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -7,11 +7,13 @@ import { DescribableEntityMixin } from 'siren-sdk/src/entityAddons/describable-e
 import { SimpleEntity } from 'siren-sdk/src/es6/SimpleEntity.js';
 import '@brightspace-ui/core/components/icons/icon.js';
 import '@brightspace-ui/core/components/button/button.js';
+import '@brightspace-ui/core/components/button/button-subtle.js';
 import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/list/list.js';
 import '@brightspace-ui/core/components/list/list-item.js';
 import '@d2l/switch/d2l-switch.js';
 import 'd2l-organizations/components/d2l-organization-image/d2l-organization-image.js';
+import '@brightspace-ui-labs/edit-in-place/d2l-labs-edit-in-place.js';
 
 class CollectionEditor extends EntityMixinLit(LitElement) {
 
@@ -82,6 +84,16 @@ class CollectionEditor extends EntityMixinLit(LitElement) {
 				justify-content: space-between;
 				align-items: center;
 			}
+			.d2l-activity-collection-title-header {
+				min-height:52px;
+				margin-top:6px;
+				margin-bottom:6px;
+				margin-right: 6px;
+				overflow:hidden;
+			}
+			.d2l-activity-visbility-label {
+				white-space: nowrap;
+			}
 			.d2l-activity-collection-body {
 				padding: 15px 30px;
 				background-color: var(--d2l-color-regolith);
@@ -117,14 +129,16 @@ class CollectionEditor extends EntityMixinLit(LitElement) {
 			<div class="d2l-activity-collection-header">
 				<div>Edit Learning Path</div>
 				<div class="d2l-activity-collection-title">
-					<h1 class="d2l-heading-1">${this._specialization.getName()}</h1>
+					<h1 class="d2l-heading-1 d2l-activity-collection-title-header">
+						<d2l-labs-edit-in-place size="49" placeholder="Untitled Learning Path" maxlength="128" value="${this._specialization.getName()}" @change=${this._TitleChanged}></d2l-labs-edit-in-place>
+					</h1>
 					<div class="d2l-activity-collection-toggle-container">
 						<d2l-switch aria-label="Visibility Toggle" label-right @click="${this._updateVisibility}"></d2l-switch>
-						<div class="d2l-label-text"><d2l-icon icon=${icon}></d2l-icon> ${term}</div>
+						<div class="d2l-label-text d2l-activity-visbility-label"><d2l-icon icon=${icon}></d2l-icon> ${term}</div>
 					</div>
 				</div>
 				<div class="d2l-body-compact">
-					${this._specialization.getDescription()}
+					<d2l-labs-edit-in-place size="49" placeholder="Enter a description" value="${this._specialization.getDescription()}" @change=${this._DescriptionChanged}></d2l-labs-edit-in-place>
 				</div>
 			</div>
 			<div class="d2l-activity-collection-body">

--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -7,7 +7,6 @@ import { DescribableEntityMixin } from 'siren-sdk/src/entityAddons/describable-e
 import { SimpleEntity } from 'siren-sdk/src/es6/SimpleEntity.js';
 import '@brightspace-ui/core/components/icons/icon.js';
 import '@brightspace-ui/core/components/button/button.js';
-import '@brightspace-ui/core/components/button/button-subtle.js';
 import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/list/list.js';
 import '@brightspace-ui/core/components/list/list-item.js';

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   },
   "main": "d2l-activities.js",
   "dependencies": {
+    "@brightspace-ui-labs/edit-in-place": "^1.0.6",
     "@brightspace-ui/core": "^1.14.3",
     "@d2l/switch": "Brightspace/d2l-switch.git#semver:^3",
     "@polymer/iron-resizable-behavior": "^3.0.0",


### PR DESCRIPTION
### Changes
- Learning path Title and Description are now editable. Users may select and edit the text of the title and description of the activity collection editor in-place by clicking them.
- Hovering over either item will change their text colour to blue and the mouse to a pointer to denote the functionality.
- Long, one word titles shouldn't overflow. Long titles won't compress the `visible` icon and label over top each other.
- The header's margins have been compressed to more correctly match the design sample.

![image](https://user-images.githubusercontent.com/55998273/69464229-c3fbf880-0d4b-11ea-9f45-fae65d1c244e.png)
![image](https://user-images.githubusercontent.com/55998273/69463853-d3c70d00-0d4a-11ea-8a1c-81ad52b687ae.png)
![image](https://user-images.githubusercontent.com/55998273/69464251-d4ac6e80-0d4b-11ea-8472-cecd35eb6498.png)
![image](https://user-images.githubusercontent.com/55998273/69464274-de35d680-0d4b-11ea-9da9-9d61e2f445ff.png)




