### PR TITLE
US111949 Add attachments editor

### DIFF
--- a/activities.serge.json
+++ b/activities.serge.json
@@ -125,5 +125,28 @@
       "zh-cn zh",
       "zh-tw zh-tw"
     ]
+  },{
+    "name": "attachmentsEditor",
+    "parser_plugin": {
+      "plugin": "parse_js"
+    },
+    "source_match": "en\\.js$",
+    "source_dir": "components/d2l-activity-editor/d2l-activity-attachments/lang",
+    "output_file_path": "components/d2l-activity-editor/d2l-activity-attachments/lang/%LANG%.js",
+    "output_lang_rewrite": [
+      "ar-sa ar",
+      "de-de de",
+      "es-mx es",
+      "fi-FI fi",
+      "fr-ca fr",
+      "ja-jp ja",
+      "ko-kr ko",
+      "nl-nl nl",
+      "pt-br pt",
+      "sv-se sv",
+      "tr-tr tr",
+      "zh-cn zh",
+      "zh-tw zh-tw"
+    ]
   }
 ]

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -2,6 +2,7 @@ import 'd2l-inputs/d2l-input-text.js';
 import '../d2l-activity-due-date-editor.js';
 import '../d2l-activity-text-editor.js';
 import '../d2l-activity-visibility-editor.js';
+import '../d2l-activity-attachments/d2l-activity-attachments-editor.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { AssignmentEntity } from 'siren-sdk/src/activities/assignments/AssignmentEntity.js';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
@@ -30,7 +31,8 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 			_canEditSubmissionType: { type: Boolean },
 			_completionTypes: { type: Array },
 			_canEditCompletionType: { type: Boolean },
-			_showCompletionType: { type: Boolean }
+			_showCompletionType: { type: Boolean },
+			_attachmentsHref: { type: String }
 		};
 	}
 
@@ -88,6 +90,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 		this._canEditSubmissionType = assignment.canEditSubmissionType();
 		this._completionTypes = assignment.completionTypeOptions();
 		this._canEditCompletionType = assignment.canEditCompletionType();
+		this._attachmentsHref = assignment.attachmentsCollectionHref();
 	}
 
 	_saveOnChange(jobName) {
@@ -231,6 +234,13 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 
 					${this._getCompletionTypeOptions()}
 				</select>
+			</div>
+
+			<div id="assignment-attachments-editor-container" ?hidden="${!this._attachmentsHref}">
+				<d2l-activity-attachments-editor
+					.href="${this._attachmentsHref}"
+					.token="${this.token}">
+				</d2l-activity-attachments-editor>
 			</div>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
@@ -1,0 +1,48 @@
+import './d2l-activity-attachments-picker';
+import { css, html, LitElement } from 'lit-element/lit-element';
+import { AttachmentCollectionEntity } from 'siren-sdk/src/activities/AttachmentCollectionEntity';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
+
+class ActivityAttachmentsEditor extends EntityMixinLit(LitElement) {
+	static get properties() {
+		return {
+			_canAddAttachments: { type: Boolean }
+		};
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				display: block;
+			}
+		`;
+	}
+
+	constructor() {
+		super();
+		this._setEntityType(AttachmentCollectionEntity);
+	}
+
+	set _entity(entity) {
+		if (!this._entityHasChanged(entity)) {
+			return;
+		}
+
+		if (entity) {
+			this._canAddAttachments = entity.canAddAttachments();
+		}
+
+		super._entity = entity;
+	}
+
+	render() {
+		return html`
+			<d2l-activity-attachments-picker
+				?hidden="${!this._canAddAttachments}"
+				.href="${this.href}"
+				.token="${this.token}">
+			</d2l-activity-attachments-picker>
+		`;
+	}
+}
+customElements.define('d2l-activity-attachments-editor', ActivityAttachmentsEditor);

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -1,0 +1,100 @@
+import '@brightspace-ui/core/components/button/button';
+import '@brightspace-ui/core/components/colors/colors';
+import 'd2l-tooltip/d2l-tooltip';
+import { css, html, LitElement } from 'lit-element/lit-element';
+import { AttachmentCollectionEntity } from 'siren-sdk/src/activities/AttachmentCollectionEntity';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
+import { getLocalizeResources } from '../localization.js';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+
+class ActivityAttachmentsPicker extends EntityMixinLit(LocalizeMixin(LitElement)) {
+	static get properties() {
+		return {
+			_canAddLink: { type: Boolean },
+			_canAddGoogleDriveLink: { type: Boolean },
+			_canAddOneDriveLink: { type: Boolean }
+		};
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				display: flex;
+				flex-direction: row;
+				justify-content: space-between;
+				align-items: center;
+				background: var(--d2l-color-regolith);
+				border-radius: 6px;
+				border: 1px solid var(--d2l-color-mica);
+				padding: 12px;
+			}
+
+			.button-container {
+				display: flex;
+				flex-direction: row;
+			}
+
+			.button-container > * {
+				display: inline-block;
+			}
+		`;
+	}
+
+	static async getLocalizeResources(langs) {
+		return getLocalizeResources(langs, import.meta.url);
+	}
+
+	constructor() {
+		super();
+		this._setEntityType(AttachmentCollectionEntity);
+	}
+
+	set _entity(entity) {
+		if (!this._entityHasChanged(entity)) {
+			return;
+		}
+
+		if (entity) {
+			this._canAddLink  = entity.canAddLinkAttachment();
+			this._canAddGoogleDriveLink = entity.canAddGoogleDriveLinkAttachment();
+			this._canAddOneDriveLink = entity.canAddOneDriveLinkAttachment();
+		}
+
+		super._entity = entity;
+	}
+
+	render() {
+		return html`
+			<div id="button-container">
+				<d2l-button-icon
+					id="add-quicklink-button"
+					icon="d2l-tier1:quicklink"
+					?hidden="${!this._canAddLink}">
+				</d2l-button-icon>
+				<d2l-tooltip for="add-quicklink-button">${this.localize('addQuicklink')}</d2l-tooltip>
+
+				<d2l-button-icon
+					id="add-link-button"
+					icon="d2l-tier1:link"
+					?hidden="${!this._canAddLink}">
+				</d2l-button-icon>
+				<d2l-tooltip for="add-link-button">${this.localize('addLink')}</d2l-tooltip>
+
+				<d2l-button-icon
+					id="add-google-drive-link-button"
+					icon="d2l-tier1:google-drive"
+					?hidden="${!this._canAddGoogleDriveLink}">
+				</d2l-button-icon>
+				<d2l-tooltip for="add-google-drive-link-button">${this.localize('addGoogleDriveLink')}</d2l-tooltip>
+
+				<d2l-button-icon
+					id="add-onedrive-link-button"
+					icon="d2l-tier1:one-drive"
+					?hidden="${!this._canAddOneDriveLink}">
+				</d2l-button-icon>
+				<d2l-tooltip for="add-onedrive-link-button">${this.localize('addOneDriveLink')}</d2l-tooltip>
+			</div>
+		`;
+	}
+}
+customElements.define('d2l-activity-attachments-picker', ActivityAttachmentsPicker);

--- a/components/d2l-activity-editor/d2l-activity-attachments/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/lang/en.js
@@ -1,0 +1,8 @@
+/* eslint quotes: 0 */
+
+export default {
+	"addGoogleDriveLink": "Attach from Google Drive", // Tooltip for a button that adds a link to a Google Drive file
+	"addLink": "Attach Weblink", // Tooltip for a button that adds a link to a URL
+	"addOneDriveLink": "Attach from OneDrive", // Tooltip for a button that adds a link to a OneDrive file
+	"addQuicklink": "Attach Link to Existing Activity", // Tooltip for a button that adds a link to an existing activity
+};

--- a/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/assignmentActivity.json
+++ b/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/assignmentActivity.json
@@ -151,6 +151,12 @@
       "href": "https://ids.brightspace.com/activities/dropbox/F074BF85-DA75-4C60-B5E9-181E7D731372-13"
     },
     {
+    "rel": [
+      "https://assignments.api.brightspace.com/rels/attachments"
+      ],
+      "href": "./data/attachmentsCollection.json"
+    },
+    {
       "rel": [
         "https://activities.api.brightspace.com/rels/activity-usage"
       ],

--- a/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/attachmentsCollection.json
+++ b/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/attachmentsCollection.json
@@ -1,0 +1,89 @@
+{
+  "class": [
+    "collection",
+    "attachments"
+  ],
+  "entities": [
+    {
+      "rel": [
+        "item",
+        "https://assignments.api.brightspace.com/rels/link"
+      ],
+      "href": "./attachment.json"
+    },
+    {
+      "rel": [
+        "item",
+        "https://assignments.api.brightspace.com/rels/link"
+      ],
+      "href": "attachment.json"
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "up",
+        "https://assignments.api.brightspace.com/rels/assignment"
+      ],
+      "href": "https://8b4b0787-25ca-43d2-89ab-b9495546ad09.assignments.api.proddev.d2l/6613/folders/3"
+    }
+  ],
+  "actions": [
+    {
+      "type": "multipart/form-data",
+      "title": "Add file",
+      "href": "https://8b4b0787-25ca-43d2-89ab-b9495546ad09.assignments.api.proddev.d2l/6613/folders/3/attach-file",
+      "name": "add-file",
+      "method": "POST"
+    },
+    {
+      "type": "application/x-www-form-urlencoded",
+      "title": "Attach a link to the assignment folder",
+      "href": "https://8b4b0787-25ca-43d2-89ab-b9495546ad09.assignments.api.proddev.d2l/6613/folders/3/attach-link",
+      "name": "add-link",
+      "method": "POST",
+      "fields": [
+        {
+          "type": "text",
+          "name": "name"
+        },
+        {
+          "type": "url",
+          "name": "href"
+        }
+      ]
+    },
+    {
+      "type": "application/x-www-form-urlencoded",
+      "href": "https://8b4b0787-25ca-43d2-89ab-b9495546ad09.assignments.api.proddev.d2l/6613/folders/3/attach-link",
+      "name": "add-google-drive-link",
+      "method": "POST",
+      "fields": [
+        {
+          "type": "text",
+          "name": "name"
+        },
+        {
+          "type": "url",
+          "name": "href"
+        }
+      ]
+    },
+    {
+      "type": "application/x-www-form-urlencoded",
+      "href": "https://8b4b0787-25ca-43d2-89ab-b9495546ad09.assignments.api.proddev.d2l/6613/folders/3/attach-link",
+      "name": "add-onedrive-link",
+      "method": "POST",
+      "fields": [
+        {
+          "type": "text",
+          "name": "name"
+        },
+        {
+          "type": "url",
+          "name": "href"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This adds the first phase of components that provide the ability to add/remove attachments associated with an assignment. As of this change, the `d2l-activity-attachments-editor` is quite simple and bare, and intentionally designed such that it could be used with the concept of activity attachments (as well the existing assignment attachments).

What this does do:

- Display an attachment-picker component in FACE
- Show action buttons with tooltips based on what types of (link) attachments are available to be added

What this doesn't do:

- Do stuff when you click on a button - coming soon (next user story), still figuring that out
- Do anything related to file attachments, as these are being handled separately (but should be compatible with these changes)

This was added as a new folder/Serge config since it's _probably_ generic enough that it could be moved up in the repo, outside of `d2l-activity-editor`, but I didn't want to go that far just yet. In particular, if we do decide to make file attachments an activities-wide concept, then moving this up might make sense. (Link attachments are still only supported in the assignments domain, but file attachments are supported elsewhere.)

Requires https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/96, will fail until that's merged.