### PR TITLE
US111919 Add turnitin dialog launcher

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -1,4 +1,5 @@
 import 'd2l-inputs/d2l-input-text.js';
+import './d2l-assignment-turnitin-editor';
 import '../d2l-activity-availability-dates-editor.js';
 import '../d2l-activity-due-date-editor.js';
 import '../d2l-activity-release-conditions-editor.js';
@@ -284,6 +285,9 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 					.token="${this.token}">
 				</d2l-activity-release-conditions-editor>
 			</div>
+
+			<d2l-assignment-turnitin-editor .token="${this.token}" .href="${this.href}">
+			</d2l-assignment-turnitin-editor>
 
 			<div id="annotations-checkbox-container" ?hidden="${!this._canSeeAnnotations}">
 				<label class="d2l-label-text">${this.localize('annotationTools')}</label>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-assignment-turnitin-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-assignment-turnitin-editor.js
@@ -1,0 +1,117 @@
+import '@brightspace-ui/core/components/button/button.js';
+import { bodySmallStyles, heading4Styles } from '@brightspace-ui/core/components/typography/styles.js';
+import { css, html, LitElement } from 'lit-element/lit-element';
+import { AssignmentEntity } from 'siren-sdk/src/activities/assignments/AssignmentEntity.js';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
+import { getLocalizeResources } from '../localization';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+
+class AssignmentTurnitinEditor extends EntityMixinLit(LocalizeMixin(LitElement)) {
+
+	static get properties() {
+
+		return {
+			_hidden: { type: Boolean },
+			_url: { type: String }
+		};
+	}
+
+	static get styles() {
+
+		return [
+			bodySmallStyles,
+			heading4Styles,
+			css`
+			.d2l-heading-4 {
+				margin: 0 0 0.6rem 0;
+			}
+
+			.d2l-body-small {
+				margin: 0 0 0.3rem 0;
+			}
+
+			d2l-button-subtle {
+				margin-left: -0.6rem;
+			}
+			`
+		];
+	}
+
+	static async getLocalizeResources(langs) {
+
+		return getLocalizeResources(langs, import.meta.url);
+	}
+
+	constructor() {
+
+		super();
+		this._setEntityType(AssignmentEntity);
+	}
+
+	set _entity(entity) {
+
+		if (!this._entityHasChanged(entity)) {
+			return;
+		}
+
+		if (entity) {
+			this._hidden = !entity.canEditTurnitin();
+			this._url = entity.editTurnitinUrl();
+		}
+		super._entity = entity;
+	}
+
+	_onClickEdit() {
+
+		if (!this._url) {
+			return;
+		}
+
+		const location = new D2L.LP.Web.Http.UrlLocation(this._url);
+		const buttons = [
+			{
+				Key: 'save',
+				Text: this.localize('btnSave'),
+				ResponseType: 1, // D2L.Dialog.ResponseType.Positive
+				IsPrimary: true,
+				IsEnabled: true
+			},
+			{
+				Text: this.localize('btnCancel'),
+				ResponseType: 2, // D2L.Dialog.ResponseType.Negative
+				IsPrimary: false,
+				IsEnabled: true
+			}
+		];
+
+		// Launch into our friend, the LMS, to do the thing.
+		D2L.LP.Web.UI.Legacy.MasterPages.Dialog.Open(
+			/*               opener: */ document.body,
+			/*             location: */ location,
+			/*          srcCallback: */ 'SrcCallback',
+			/*       resizeCallback: */ '',
+			/*      responseDataKey: */ '',
+			/*                width: */ 720,
+			/*               height: */ 1280,
+			/*            closeText: */ this.localize('btnCloseDialog'),
+			/*              buttons: */ buttons,
+			/* forceTriggerOnCancel: */ false
+		);
+	}
+
+	render() {
+
+		return html`
+			<div id="assignment-turnitin-container" ?hidden="${this._hidden}">
+				<h4 class="d2l-heading-4">${this.localize('hdrTurnitin')}</h4>
+				<p class="d2l-body-small">${this.localize('hlpTurnitin')}</p>
+				<d2l-button-subtle
+					text="${this.localize('btnEditTurnitin')}"
+					@click="${this._onClickEdit}">
+				</d2l-button-subtle>
+			</div>
+		`;
+	}
+}
+
+customElements.define('d2l-assignment-turnitin-editor', AssignmentTurnitinEditor);

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
@@ -7,6 +7,12 @@ export default {
 	"dueDate": "Due Date", // ARIA label for the due date field when creating/editing an activity
 	"emptyNameError": "Name is required", // Error message to inform user that the assignment name is a required field
 	"instructions": "Instructions", // Label for the instruction field when creating/editing an assignment
+	"hdrTurnitin": "Turnitin® Integration", // turnitin heading
+	"hlpTurnitin": "The Turnitin® Integration allows you to use Originality Check® to assess student work for academic integrity and to use the GradeMark® external evaluation tool for assessment.", // turnitin help
+	"btnEditTurnitin": "Manage Turnitin® Integration", // edit turnitin button
+	"btnCloseDialog": "Close this Dialog", // close dialog button
+	"btnCancel": "Cancel", // cancel button
+	"btnSave": "Save", // save button
 	"name": "Name", // Label for the name field when creating/editing an activity
 	"submissionType": "Submission Type", // Label for the submission type field when creating/editing an assignment
 	"annotationTools": "Annotation Tools", // Label for enabling/disabling Annotation Tools when creating/editing an assignment

--- a/components/d2l-activity-editor/d2l-activity-release-conditions-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-release-conditions-editor.js
@@ -43,8 +43,10 @@ class ActivityReleaseConditionsEditor extends EntityMixinLit(LocalizeMixin(LitEl
 			return;
 		}
 
-		this._hidden = !entity.canEditReleaseConditions();
-		this._url = entity.editReleaseConditionsUrl();
+		if (entity) {
+			this._hidden = !entity.canEditReleaseConditions();
+			this._url = entity.editReleaseConditionsUrl();
+		}
 		super._entity = entity;
 	}
 


### PR DESCRIPTION
[US111919](https://rally1.rallydev.com/#/detail/userstory/350454972296?fdp=true)

This PR adds the turnitin editor, which calls into the LMS to do the thing via a legacy dialog to the existing control. It doesn't currently display anything about the turnitin state, nor does it trigger a refresh of the assignment entity, both of which will happen in a follow-up when the designs catch up.

I also added an `if (!entity) { ... }` guard because I learned that it sure can be null or whatever, here and in the release conditions editor.