### PR TITLE
[US105733] Fix the "You are all caught up" bug

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -400,16 +400,14 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 	async _handleFilterLoad() {
 		// When the filter finishes loading, we check to see if the filter is empty
 		// If the filter is empty, we remove all filters
+		this._loading = true;
 		if(this._initialLoad) {
-			this._loading = true;
-			await this._handleEmptyFilter().then (() => {
-				this._loading = false;
-			});
+			await this._handleEmptyFilter();
 		}
+		this._loading = false;
 	}
 
 	async _handleEmptyFilter() {
-		console.log(this.entity);
 		// Remove filter if we have no elements within the current filter.
 		if(this.entity && this.entity.entities && this.entity.getSubEntities().length === 0) {
 			await this._clearFilterAndSearch();

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -283,7 +283,7 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 			await this._clearFilterAndSearch();
 			this._initialLoad = false;
 			return;
-		}	
+		}
 
 		try {
 			if (entity.entities) {
@@ -401,7 +401,7 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 		// When the filter finishes loading, we check to see if the filter is empty
 		// If the filter is empty, we remove all filters
 		this._loading = true;
-		if(this._initialLoad) {
+		if (this._initialLoad) {
 			await this._handleEmptyFilter();
 		}
 		this._loading = false;
@@ -409,7 +409,7 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 
 	async _handleEmptyFilter() {
 		// Remove filter if we have no elements within the current filter.
-		if(this.entity && this.entity.entities && this.entity.getSubEntities().length === 0) {
+		if (this.entity && this.entity.entities && this.entity.getSubEntities().length === 0) {
 			await this._clearFilterAndSearch();
 		}
 	}

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -98,6 +98,7 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 					token="[[token]]"
 					category-whitelist="[[_filterIds]]"
 					result-size="[[_numberOfActivitiesToShow]]"
+					on-d2l-hm-filter-filters-loaded="_handleFilterLoad"
 					lazy-load-options>
 				</d2l-hm-filter>
 				<d2l-hm-search
@@ -265,23 +266,14 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 	}
 
 	async _loadData(entity) {
+		this._loading = true;
 		if (!entity) {
 			return Promise.resolve();
 		}
-		this._loading = true;
 
 		if (this._initialLoad) {
 			this.filterAppliedShortcut();
 			this.searchAppliedShortcut();
-		}
-
-		if (this._initialLoad &&
-			entity.hasClass('empty') &&
-			(this.searchApplied || this.filterApplied)
-		) {
-			await this._clearFilterAndSearch();
-			this._initialLoad = false;
-			return;
 		}
 
 		try {
@@ -393,6 +385,21 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 		}
 		if (this.searchApplied) {
 			await this.clearSearchResults();
+		}
+	}
+
+	async _handleFilterLoad() {
+		if(this._initialLoad) {
+			this._loading = true;
+			await this._filterLoadHandler().then ( () => {
+				this._loading = false;
+			} )
+		}
+	}
+
+	async _filterLoadHandler() {
+		if(this.entity && this.entity.getSubEntities().length == 0) {
+			await this._clearFilterAndSearch();
 		}
 	}
 

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -400,6 +400,8 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 	async _handleFilterLoad() {
 		// When the filter finishes loading, we check to see if the filter is empty
 		// If the filter is empty, we remove all filters
+		console.log(this._loading)
+		console.log(this._initialLoad)
 		this._loading = true;
 		if (this._initialLoad) {
 			await this._handleEmptyFilter();
@@ -409,6 +411,9 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 
 	async _handleEmptyFilter() {
 		// Remove filter if we have no elements within the current filter.
+		console.log(this.entity)
+		console.log(this.entity.entities)
+		console.log(this.entities.getSubEntities())
 		if (this.entity && this.entity.entities && this.entity.getSubEntities().length === 0) {
 			await this._clearFilterAndSearch();
 		}

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -266,15 +266,24 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 	}
 
 	async _loadData(entity) {
-		this._loading = true;
 		if (!entity) {
 			return Promise.resolve();
 		}
+		this._loading = true;
 
 		if (this._initialLoad) {
 			this.filterAppliedShortcut();
 			this.searchAppliedShortcut();
 		}
+
+		if (this._initialLoad &&
+			entity.hasClass('empty') &&
+			(this.searchApplied || this.filterApplied)
+		) {
+			await this._clearFilterAndSearch();
+			this._initialLoad = false;
+			return;
+		}	
 
 		try {
 			if (entity.entities) {
@@ -398,7 +407,7 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 	}
 
 	async _filterLoadHandler() {
-		if(this.entity && this.entity.getSubEntities().length == 0) {
+		if(this.entity && this.entity.getSubEntities().length === 0) {
 			await this._clearFilterAndSearch();
 		}
 	}

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -400,8 +400,6 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 	async _handleFilterLoad() {
 		// When the filter finishes loading, we check to see if the filter is empty
 		// If the filter is empty, we remove all filters
-		console.log(this._loading)
-		console.log(this._initialLoad)
 		this._loading = true;
 		if (this._initialLoad) {
 			await this._handleEmptyFilter();
@@ -411,10 +409,7 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 
 	async _handleEmptyFilter() {
 		// Remove filter if we have no elements within the current filter.
-		console.log(this.entity)
-		console.log(this.entity.entities)
-		console.log(this.entities.getSubEntities())
-		if (this.entity && this.entity.entities && this.entity.getSubEntities().length === 0) {
+		if (this.entity && this.entity.hasClass("empty")) {
 			await this._clearFilterAndSearch();
 		}
 	}

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -398,16 +398,20 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 	}
 
 	async _handleFilterLoad() {
+		// When the filter finishes loading, we check to see if the filter is empty
+		// If the filter is empty, we remove all filters
 		if(this._initialLoad) {
 			this._loading = true;
-			await this._filterLoadHandler().then ( () => {
+			await this._handleEmptyFilter().then (() => {
 				this._loading = false;
-			} )
+			});
 		}
 	}
 
-	async _filterLoadHandler() {
-		if(this.entity && this.entity.getSubEntities().length === 0) {
+	async _handleEmptyFilter() {
+		console.log(this.entity);
+		// Remove filter if we have no elements within the current filter.
+		if(this.entity && this.entity.entities && this.entity.getSubEntities().length === 0) {
 			await this._clearFilterAndSearch();
 		}
 	}


### PR DESCRIPTION
Having an empty filter applied will clear filters, and return you to a quick eval list without any filters.

Known issue: the "You are all caught up" cat appears on every initial load for a split second.