### PR TITLE
US112016 Add attachment list

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachment.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachment.js
@@ -33,10 +33,7 @@ class ActivityAttachment extends EntityMixinLit(LitElement) {
 			this._attachment = {
 				id: entity.href(),
 				url: entity.href(),
-				name: entity.name(),
-				isDeleted: false,
-				isInFocus: false,
-				isNew: false
+				name: entity.name()
 			};
 			this._editing = entity.canDeleteAttachment();
 		}

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachment.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachment.js
@@ -1,0 +1,64 @@
+import '@d2l/d2l-attachment/components/attachment';
+import { css, html, LitElement } from 'lit-element/lit-element';
+import { AttachmentEntity } from 'siren-sdk/src/activities/AttachmentEntity';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
+
+class ActivityAttachment extends EntityMixinLit(LitElement) {
+	static get properties() {
+		return {
+			_attachment: { type: Object },
+			_editing: { type: Boolean }
+		};
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				display: block;
+			}
+		`;
+	}
+
+	constructor() {
+		super();
+		this._setEntityType(AttachmentEntity);
+	}
+
+	set _entity(entity) {
+		if (!this._entityHasChanged(entity)) {
+			return;
+		}
+
+		if (entity) {
+			this._attachment = {
+				id: entity.href(),
+				url: entity.href(),
+				name: entity.name(),
+				isDeleted: false,
+				isInFocus: false,
+				isNew: false
+			};
+			this._editing = entity.canDeleteAttachment();
+		}
+
+		super._entity = entity;
+	}
+
+	_onAttachmentRemoved() {
+		super._entity.deleteAttachment();
+		this._deleted = true;
+	}
+
+	render() {
+		return html`
+			<d2l-labs-attachment
+				attachmentId="${this._attachment.id}"
+				.attachment="${this._attachment}"
+				?editing="${this._editing}"
+				@d2l-attachment-removed="${this._onAttachmentRemoved}">
+			</d2l-labs-attachment>
+		`;
+	}
+}
+
+customElements.define('d2l-activity-attachment', ActivityAttachment);

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
@@ -1,3 +1,4 @@
+import './d2l-activity-attachments-list';
 import './d2l-activity-attachments-picker';
 import { css, html, LitElement } from 'lit-element/lit-element';
 import { AttachmentCollectionEntity } from 'siren-sdk/src/activities/AttachmentCollectionEntity';
@@ -14,6 +15,9 @@ class ActivityAttachmentsEditor extends EntityMixinLit(LitElement) {
 		return css`
 			:host {
 				display: block;
+			}
+			:host > * {
+				margin-bottom: 20px;
 			}
 		`;
 	}
@@ -37,6 +41,10 @@ class ActivityAttachmentsEditor extends EntityMixinLit(LitElement) {
 
 	render() {
 		return html`
+			<d2l-activity-attachments-list
+				.href="${this.href}"
+				.token="${this.token}">
+			</d2l-activity-attachments-list>
 			<d2l-activity-attachments-picker
 				?hidden="${!this._canAddAttachments}"
 				.href="${this.href}"

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-list.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-list.js
@@ -16,7 +16,7 @@ class ActivityAttachmentsList extends EntityMixinLit(LitElement) {
 			:host {
 				display: block;
 			}
-			:host > * {
+			d2l-activity-attachment {
 				margin-bottom: 20px;
 			}
 		`;
@@ -39,9 +39,8 @@ class ActivityAttachmentsList extends EntityMixinLit(LitElement) {
 					return attachment.href;
 				}
 
-				// TODO use self link not this nonsense
-				return attachment.getActionByName('delete').href;
-			})
+				return attachment.getLinkByRel('self').href;
+			});
 		}
 
 		super._entity = entity;

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-list.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-list.js
@@ -1,0 +1,62 @@
+import './d2l-activity-attachment';
+import { css, html, LitElement } from 'lit-element/lit-element';
+import { AttachmentCollectionEntity } from 'siren-sdk/src/activities/AttachmentCollectionEntity';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
+import { repeat } from 'lit-html/directives/repeat';
+
+class ActivityAttachmentsList extends EntityMixinLit(LitElement) {
+	static get properties() {
+		return {
+			_attachmentUrls: { type: Array }
+		};
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				display: block;
+			}
+			:host > * {
+				margin-bottom: 20px;
+			}
+		`;
+	}
+
+	constructor() {
+		super();
+		this._setEntityType(AttachmentCollectionEntity);
+	}
+
+	set _entity(entity) {
+		if (!this._entityHasChanged(entity)) {
+			return;
+		}
+
+		if (entity) {
+			const attachments = entity.getAttachmentEntities();
+			this._attachmentUrls = attachments.map(attachment => {
+				if (attachment.href) {
+					return attachment.href;
+				}
+
+				// TODO use self link not this nonsense
+				return attachment.getActionByName('delete').href;
+			})
+		}
+
+		super._entity = entity;
+	}
+
+	render() {
+		return html`
+			${repeat(this._attachmentUrls, href => href, href => html`
+				<d2l-activity-attachment
+					.href="${href}"
+					.token="${this.token}">
+				</d2l-activity-attachment>
+			`)}
+		`;
+	}
+}
+
+customElements.define('d2l-activity-attachments-list', ActivityAttachmentsList);

--- a/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/attachment1.json
+++ b/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/attachment1.json
@@ -1,0 +1,25 @@
+{
+  "class": [
+    "link"
+  ],
+  "properties": {
+    "name": "A Link Attachment to Example.com",
+    "href": "https://example.com"
+  },
+  "links": [
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "https://48f75f25-ef9b-47aa-b86a-d32525a5dcac.assignments.api.proddev.d2l/6613/folders/3/links/1"
+    }
+  ],
+  "actions": [
+    {
+      "title": "Delete link",
+      "href": "https://48f75f25-ef9b-47aa-b86a-d32525a5dcac.assignments.api.proddev.d2l/6613/folders/3/links/1",
+      "name": "delete",
+      "method": "DELETE"
+    }
+  ]
+}

--- a/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/attachment2.json
+++ b/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/attachment2.json
@@ -1,0 +1,25 @@
+{
+  "class": [
+    "link"
+  ],
+  "properties": {
+    "name": "A Quicklink to another Assignment",
+    "href": "/d2l/common/dialogs/quickLink/quickLink.d2l?ou=6613&type=dropbox&rcode=Dev-4"
+  },
+  "links": [
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "https://48f75f25-ef9b-47aa-b86a-d32525a5dcac.assignments.api.proddev.d2l/6613/folders/3/links/1"
+    }
+  ],
+  "actions": [
+    {
+      "title": "Delete link",
+      "href": "https://48f75f25-ef9b-47aa-b86a-d32525a5dcac.assignments.api.proddev.d2l/6613/folders/3/links/1",
+      "name": "delete",
+      "method": "DELETE"
+    }
+  ]
+}

--- a/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/attachmentsCollection.json
+++ b/demo/d2l-activity-editor/d2l-activity-assignment-editor/data/attachmentsCollection.json
@@ -9,14 +9,14 @@
         "item",
         "https://assignments.api.brightspace.com/rels/link"
       ],
-      "href": "./attachment.json"
+      "href": "./data/attachment1.json"
     },
     {
       "rel": [
         "item",
         "https://assignments.api.brightspace.com/rels/link"
       ],
-      "href": "attachment.json"
+      "href": "./data/attachment2.json"
     }
   ],
   "links": [

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@brightspace-ui-labs/edit-in-place": "^1.0.7",
     "@brightspace-ui/core": "^1.17.0",
+    "@d2l/d2l-attachment": "Brightspace/attachment#semver:^1",
     "@d2l/switch": "Brightspace/d2l-switch.git#semver:^3",
     "@polymer/iron-resizable-behavior": "^3.0.0",
     "@polymer/polymer": "^3.0.0",
@@ -93,6 +94,7 @@
     "d2l-users": "BrightspaceHypermediaComponents/users#semver:^2",
     "del": "^3.0.0",
     "fastdom": "^1.0.8",
+    "lit-html": "^1.1.2",
     "merge-stream": "^1.0.1",
     "require-dir": "^1.2.0",
     "siren-sdk": "BrightspaceHypermediaComponents/siren-sdk#semver:^1"

--- a/package.json
+++ b/package.json
@@ -97,6 +97,6 @@
     "lit-html": "^1.1.2",
     "merge-stream": "^1.0.1",
     "require-dir": "^1.2.0",
-    "siren-sdk": "BrightspaceHypermediaComponents/siren-sdk#semver:^1"
+    "siren-sdk": "BrightspaceHypermediaComponents/siren-sdk#semver:^1.7.18"
   }
 }


### PR DESCRIPTION
This adds a list view of (link) attachments in the editor, as well as support for removing them.

Thanks to the entity store and a small change in the LMS that adds `Link` headers to the add/delete attachment routes, this approach automatically re-renders the list when an attachment is added or removed without any additional effort. It's likely that once autosave is figured out a bit more, we'll have to add better interim states, but that remains to be seen.