### PR TITLE
Jroach/us112192

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -126,6 +126,7 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 				<d2l-hm-filter
 					href="[[filterHref]]"
 					token="[[token]]"
+					category-whitelist="[[_filterIds]]"
 					lazy-load-options>
 				</d2l-hm-filter>
 				<d2l-hm-search
@@ -198,6 +199,10 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 			_data: {
 				type: Array,
 				value: []
+			},
+			_filterIds: {
+				type: Array,
+				computed: '_getFilterIds()'
 			},
 			_searchResultsCount: {
 				type: Number,
@@ -357,6 +362,12 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 		} else {
 			return [];
 		}
+	}
+
+	_getFilterIds() {
+		// [ 'activity-name', 'enrollments' ]
+		const filters = [ 'c806bbc6-cfb3-4b6b-ae74-d5e4e319183d', 'f2b32f03-556a-4368-945a-2614b9f41f76' ];
+		return filters;
 	}
 
 	// @override - do not change the name

--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -202,7 +202,7 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 			},
 			_filterIds: {
 				type: Array,
-				computed: '_getFilterIds()'
+				value: [ 'c806bbc6-cfb3-4b6b-ae74-d5e4e319183d', 'f2b32f03-556a-4368-945a-2614b9f41f76' ]
 			},
 			_searchResultsCount: {
 				type: Number,
@@ -362,12 +362,6 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 		} else {
 			return [];
 		}
-	}
-
-	_getFilterIds() {
-		// [ 'activity-name', 'enrollments' ]
-		const filters = [ 'c806bbc6-cfb3-4b6b-ae74-d5e4e319183d', 'f2b32f03-556a-4368-945a-2614b9f41f76' ];
-		return filters;
 	}
 
 	// @override - do not change the name

--- a/test/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -172,4 +172,8 @@ suite('d2l-quick-eval-activities', function() {
 		var alert = act.shadowRoot.querySelector('.d2l-quick-eval-activities-load-error-alert');
 		assert.equal(false, alert.hasAttribute('hidden'));
 	});
+	test('filter whitelist returns expected filters', () => {
+		const expectedFilters = [ 'c806bbc6-cfb3-4b6b-ae74-d5e4e319183d', 'f2b32f03-556a-4368-945a-2614b9f41f76' ];
+		assert.deepEqual(act._filterIds, expectedFilters);
+	});
 });


### PR DESCRIPTION
[US112192](https://rally1.rallydev.com/#/detail/userstory/353901460400?fdp=true): [Dismiss][UI] Hide dismiss filter from filter component

Thoughts on visual diff tests? Is there a way for me to have the activities list open with the filters open? I think that would be the only way it would work