### PR TITLE
US112016 Unfurling support

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -9,7 +9,14 @@ class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LitElement))
 
 	static get properties() {
 		return {
+			/**
+			 * True if the user's settings allow for rendering the WYSIWYG HTML editor
+			 */
 			htmlEditorEnabled: { type: Boolean },
+			/**
+			 * API endpoint for attachment unfurling service
+			 */
+			unfurlEndpoint: { type: String },
 			_assignmentHref: { type: String },
 		};
 	}
@@ -43,13 +50,17 @@ class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LitElement))
 
 	render() {
 		return html`
-			<d2l-activity-editor ?loading="${this._hasPendingChildren}">
+			<d2l-activity-editor
+				?loading="${this._hasPendingChildren}"
+				unfurlEndpoint="${this.unfurlEndpoint}">
+
 				<d2l-activity-assignment-editor-detail
 					.href="${this._assignmentHref}"
 					.token="${this.token}"
 					?htmlEditorEnabled="${this.htmlEditorEnabled}"
 					slot="editor">
 				</d2l-activity-assignment-editor-detail>
+
 			</d2l-activity-editor>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -6,6 +6,10 @@ class ActivityEditor extends LitElement {
 	static get properties() {
 		return {
 			loading: { type: Boolean },
+			/**
+			 * API endpoint for attachment unfurling service
+			 */
+			unfurlEndpoint: { type: String }
 		};
 	}
 
@@ -35,6 +39,13 @@ class ActivityEditor extends LitElement {
 		});
 		this.addEventListener('d2l-siren-entity-save-error', () => {
 			this.shadowRoot.querySelector('#save-status').error();
+		});
+
+		this.addEventListener('d2l-request-provider', e => {
+			if (e.detail.key === 'd2l-provider-unfurl-api-endpoint') {
+				e.detail.provider = () => this.unfurlEndpoint;
+				e.stopPropagation();
+			}
 		});
 	}
 


### PR DESCRIPTION
This adds support for attachments being able to unfurl themselves into rich previews via the AF unfurling service. This is done using the newish Requester/Provider approach, which allows the top-level `d2l-activity-editor` component to provide the configuration necesssary for the nested `d2l-labs-attachment` component via the `d2l-request-provider` event.

The behaviour that is currently being encompassed in `d2l-activity-editor`'s constructor (via `addEventListener`) will soon be provided via `BrightspaceUI/core`, but until that is merged and released, this is a simplified version of it that unblocks this change. This also relies on the LMS setting the `unfurlEndpoint` attribute on the `d2l-assignment-activity-editor` that it renders, which has now been merged.