### PR TITLE
US112016 Add trustedSitesEndpoint

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -17,6 +17,10 @@ class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LitElement))
 			 * API endpoint for attachment unfurling service
 			 */
 			unfurlEndpoint: { type: String },
+			/**
+			 * API endpoint for determining whether a domain is trusted
+			 */
+			trustedSitesEndpoint: { type: String },
 			_assignmentHref: { type: String },
 		};
 	}
@@ -52,7 +56,8 @@ class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LitElement))
 		return html`
 			<d2l-activity-editor
 				?loading="${this._hasPendingChildren}"
-				unfurlEndpoint="${this.unfurlEndpoint}">
+				unfurlEndpoint="${this.unfurlEndpoint}"
+				trustedSitesEndpoint="${this.trustedSitesEndpoint}">
 
 				<d2l-activity-assignment-editor-detail
 					.href="${this._assignmentHref}"

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachment.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachment.js
@@ -43,7 +43,6 @@ class ActivityAttachment extends EntityMixinLit(LitElement) {
 
 	_onAttachmentRemoved() {
 		super._entity.deleteAttachment();
-		this._deleted = true;
 	}
 
 	render() {

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -9,7 +9,11 @@ class ActivityEditor extends LitElement {
 			/**
 			 * API endpoint for attachment unfurling service
 			 */
-			unfurlEndpoint: { type: String }
+			unfurlEndpoint: { type: String },
+			/**
+			 * API endpoint for determining whether a domain is trusted
+			 */
+			trustedSitesEndpoint: { type: String },
 		};
 	}
 
@@ -40,13 +44,55 @@ class ActivityEditor extends LitElement {
 		this.addEventListener('d2l-siren-entity-save-error', () => {
 			this.shadowRoot.querySelector('#save-status').error();
 		});
+	}
 
-		this.addEventListener('d2l-request-provider', e => {
-			if (e.detail.key === 'd2l-provider-unfurl-api-endpoint') {
-				e.detail.provider = () => this.unfurlEndpoint;
-				e.stopPropagation();
-			}
-		});
+	_onRequestProvider(e) {
+		// Provides unfurl API endpoint for d2l-labs-attachment component
+		// https://github.com/Brightspace/attachment/blob/e44cab1f0cecc55dd93acf59212fabc6872c0bd3/components/attachment.js#L110
+		if (e.detail.key === 'd2l-provider-unfurl-api-endpoint') {
+			e.detail.provider = () => this.unfurlEndpoint;
+			e.stopPropagation();
+			return;
+		}
+
+		// Provides function to validate if a URL is trusted for d2l-labs-attachment
+		// https://github.com/Brightspace/attachment/blob/e44cab1f0cecc55dd93acf59212fabc6872c0bd3/components/attachment.js#L115
+		if (e.detail.key === 'd2l-provider-trusted-site-fn') {
+			e.detail.provider = () => url => {
+				const origin = new URL(url).origin;
+				const unfilteredContent = `<iframe src="${origin}"></iframe>`;
+
+				return new Promise((resolve, reject) => {
+					const params = {
+						filterMode: 1, // strict mode for html filtering. Refer to D2L.LP.TextProcessing.FilterModes
+						html: unfilteredContent
+					};
+					const options = {
+						success: resolve,
+						failure: reject
+					};
+					D2L.LP.Web.UI.Rpc.Connect(
+						D2L.LP.Web.UI.Rpc.Verbs.POST,
+						new D2L.LP.Web.Http.UrlLocation(this.trustedSitesEndpoint),
+						params,
+						options
+					);
+				}).then(filteredContent => {
+					const matchSrc = function(str) {
+						// excludes matching query string as filterHtml may modify the query string
+						return str.match(/src=["']([^?"']+)/i);
+					};
+					const unfilteredMatch = matchSrc(unfilteredContent);
+					const unfilteredSrc = unfilteredMatch && unfilteredMatch.length === 2 && unfilteredMatch[1];
+
+					const filteredMatch = matchSrc(filteredContent);
+					const filteredSrc = filteredMatch && filteredMatch.length === 2 && filteredMatch[1];
+
+					return unfilteredSrc === filteredSrc;
+				});
+			};
+			e.stopPropagation();
+		}
 	}
 
 	render() {
@@ -55,8 +101,12 @@ class ActivityEditor extends LitElement {
 				id="save-status">
 			</d2l-save-status>
 			<div ?hidden="${!this.loading}">Loading ...</div>
-			<div ?hidden="${this.loading}">
+			<div
+				?hidden="${this.loading}"
+				@d2l-request-provider="${this._onRequestProvider}">
+
 				<slot name="editor"></slot>
+
 			</div>
 		`;
 	}


### PR DESCRIPTION
This is a method of determining whether or not a given link attachment is a trusted site or not. Sadly, the actual Trusted Sites tool doesn't have its own API, but we can instead engage the HTML Editor API to determine if a link is trusted. The approach is a bit hackish, but it more-or-less mimics the behaviour provided by the `filterHtml` ifrau service.