### PR TITLE
Trello fixes

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -23,7 +23,6 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 
 	static get properties() {
 		return {
-			htmlEditorEnabled: { type: Boolean },
 			_name: { type: String },
 			_nameError: { type: String },
 			_canEditName: { type: Boolean },
@@ -233,7 +232,6 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 				<label class="d2l-label-text">${this.localize('instructions')}</label>
 				<d2l-activity-text-editor
 					value="${this._instructions}"
-					?htmlEditorEnabled="${this.htmlEditorEnabled}"
 					.richtextEditorConfig="${this._instructionsRichTextEditorConfig}"
 					@d2l-activity-text-editor-change="${this._saveInstructionsOnChange}"
 					ariaLabel="${this.localize('instructions')}"

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -52,17 +52,24 @@ class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LitElement))
 		this._assignmentHref = assignmentActivityUsage.assignmentHref();
 	}
 
+	_onRequestProvider(e) {
+		if (e.detail.key === 'd2l-provider-html-editor-enabled') {
+			e.detail.provider = this.htmlEditorEnabled;
+			e.stopPropagation();
+		}
+	}
+
 	render() {
 		return html`
 			<d2l-activity-editor
 				?loading="${this._hasPendingChildren}"
 				unfurlEndpoint="${this.unfurlEndpoint}"
-				trustedSitesEndpoint="${this.trustedSitesEndpoint}">
+				trustedSitesEndpoint="${this.trustedSitesEndpoint}"
+				@d2l-request-provider="${this._onRequestProvider}">
 
 				<d2l-activity-assignment-editor-detail
 					.href="${this._assignmentHref}"
 					.token="${this.token}"
-					?htmlEditorEnabled="${this.htmlEditorEnabled}"
 					slot="editor">
 				</d2l-activity-assignment-editor-detail>
 

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -48,6 +48,11 @@ class ActivityAttachmentsPicker extends SaveStatusMixin(EntityMixinLit(LocalizeM
 	constructor() {
 		super();
 		this._setEntityType(AttachmentCollectionEntity);
+
+		this._tooltipBoundary = {
+			left: 20 + 12, // padding-left applied to d2l-activity-attachments-picker + padding-left of d2l-button-icon
+			right: 0
+		};
 	}
 
 	set _entity(entity) {
@@ -158,7 +163,11 @@ class ActivityAttachmentsPicker extends SaveStatusMixin(EntityMixinLit(LocalizeM
 					?hidden="${!this._canAddLink}"
 					@click="${this._launchAddQuicklinkDialog}">
 				</d2l-button-icon>
-				<d2l-tooltip for="add-quicklink-button">${this.localize('addQuicklink')}</d2l-tooltip>
+				<d2l-tooltip
+					for="add-quicklink-button"
+					.boundary="${this._tooltipBoundary}">
+					${this.localize('addQuicklink')}
+				</d2l-tooltip>
 
 				<d2l-button-icon
 					id="add-link-button"
@@ -166,7 +175,11 @@ class ActivityAttachmentsPicker extends SaveStatusMixin(EntityMixinLit(LocalizeM
 					?hidden="${!this._canAddLink}"
 					@click="${this._launchAddLinkDialog}">
 				</d2l-button-icon>
-				<d2l-tooltip for="add-link-button">${this.localize('addLink')}</d2l-tooltip>
+				<d2l-tooltip
+					for="add-link-button"
+					.boundary="${this._tooltipBoundary}">
+					${this.localize('addLink')}
+				</d2l-tooltip>
 
 				<d2l-button-icon
 					id="add-google-drive-link-button"
@@ -174,7 +187,11 @@ class ActivityAttachmentsPicker extends SaveStatusMixin(EntityMixinLit(LocalizeM
 					?hidden="${!this._canAddGoogleDriveLink}"
 					@click="${this._launchAddGoogleDriveLinkDialog}">
 				</d2l-button-icon>
-				<d2l-tooltip for="add-google-drive-link-button">${this.localize('addGoogleDriveLink')}</d2l-tooltip>
+				<d2l-tooltip
+					for="add-google-drive-link-button"
+					.boundary="${this._tooltipBoundary}">
+					${this.localize('addGoogleDriveLink')}
+				</d2l-tooltip>
 
 				<d2l-button-icon
 					id="add-onedrive-link-button"
@@ -182,7 +199,11 @@ class ActivityAttachmentsPicker extends SaveStatusMixin(EntityMixinLit(LocalizeM
 					?hidden="${!this._canAddOneDriveLink}"
 					@click="${this._launchAddOneDriveLinkDialog}">
 				</d2l-button-icon>
-				<d2l-tooltip for="add-onedrive-link-button">${this.localize('addOneDriveLink')}</d2l-tooltip>
+				<d2l-tooltip
+					for="add-onedrive-link-button"
+					.boundary="${this._tooltipBoundary}">
+					${this.localize('addOneDriveLink')}
+				</d2l-tooltip>
 			</div>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -105,11 +105,14 @@ class ActivityAttachmentsPicker extends SaveStatusMixin(EntityMixinLit(LocalizeM
 			pickOnly: true // Prevents creating new items from the picker
 		};
 
+		// Required for the async handler below to work in Edge
+		const superEntity = super._entity;
+
 		const orgUnitId = this._openDialog(opener, settings, async event => {
 			const quicklinkUrl = `/d2l/api/lp/unstable/${orgUnitId}/quickLinks/${event.m_typeKey}/${event.m_id}`;
 			const response = await fetch(quicklinkUrl);
 			const json = await response.json();
-			this.wrapSaveAction(super._entity.addLinkAttachment(event.m_title, json.QuickLink));
+			this.wrapSaveAction(superEntity.addLinkAttachment(event.m_title, json.QuickLink));
 		});
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-text-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-text-editor.js
@@ -7,7 +7,6 @@ class ActivityTextEditor extends LitElement {
 	static get properties() {
 		return {
 			value: { type: String },
-			htmlEditorEnabled: { type: Boolean },
 			richtextEditorConfig: { type: Object },
 			disabled: { type: Boolean },
 			ariaLabel: { type: String },
@@ -35,7 +34,17 @@ class ActivityTextEditor extends LitElement {
 	}
 
 	render() {
-		if (this.htmlEditorEnabled) {
+		const event = new CustomEvent('d2l-request-provider', {
+			detail: { key: 'd2l-provider-html-editor-enabled' },
+			bubbles: true,
+			composed: true,
+			cancelable: true
+		});
+		this.dispatchEvent(event);
+
+		const htmlEditorEnabled = event.detail.provider;
+
+		if (htmlEditorEnabled) {
 			return html`
 				<d2l-activity-html-editor
 					ariaLabel="${this.ariaLabel}"

--- a/demo/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.html
+++ b/demo/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.html
@@ -20,29 +20,15 @@
 			function changeLocale(locale) { // eslint-disable-line no-unused-vars
 				document.getElementsByTagName('html')[0].lang = locale;
 			}
-			function changeEditor() { // eslint-disable-line no-unused-vars
-				const editorSwitch = document.getElementById('editorSwitch');
-				const editor = document.querySelector('d2l-activity-assignment-editor-detail');
-
-				if (editorSwitch.hasAttribute('checked')) {
-					editorSwitch.removeAttribute('checked');
-					editor.setAttribute('htmlEditorEnabled', 'htmlEditorEnabled');
-				} else {
-					editorSwitch.setAttribute('checked', 'checked');
-					editor.removeAttribute('htmlEditorEnabled');
-				}
-			}
 		</script>
 		<d2l-demo-page page-title="d2l-activity-assignment-editor-detail">
 			<h2>d2l-activity-assignment-editor-detail</h2>
 			<d2l-demo-snippet>
-				<d2l-activity-assignment-editor-detail token="secret" href="./data/assignmentActivity.json" htmlEditorEnabled></d2l-activity-assignment-editor-detail>
+				<d2l-activity-assignment-editor-detail token="secret" href="./data/assignmentActivity.json"></d2l-activity-assignment-editor-detail>
 			</d2l-demo-snippet>
 
 			<button onclick="changeLocale('en')">Reset locale to "en"</button>
 			<button onclick="changeLocale('fr')">Change locale to "fr"</button>
-			<br/>
-			<label><input id="editorSwitch" type="checkbox" onchange="changeEditor()">Use plaintext editor for instructions</input></label>
 		</d2l-demo-page>
 	</body>
 </html>


### PR DESCRIPTION
- Fix alignment of tooltip: The "Add link to existing activity" tooltip was being cut off, due to the boundary not being set. This applies the boundary to each tooltip - not strictly necessary, but this means that the order doesn't really matter. (If the styling were applied using CSS, we could `first-of-type`, but that doesn't allow for the computation that `d2l-tooltip` does with `boundary`.)
- Make QuickLink insertion work in Edge: For an unidentifiable reason, Edge doesn't like the call to `super._entity` within the `async` callback here. The other, non-`async` callbacks work fine, but this one seems to think `super._entity` is undefined within the callback. To avoid this, we can just create a reference to it.
- Fix HTML Editor in Edge: Sadly, the root cause here was weird DOM stuff by Edge, where the `d2l-activity-editor` somehow ends up as a child of the `d2l-activity-assignment-editor`, which is... odd. This means that properties were not being fully propagated through the elements. Rather than adding the `htmlEditorEnabled` property to even more elements that don't actually care about it, this instead uses the new Provider/Requester approach to pass the property down to the `d2l-activity-text-editor` component, which is the only one that actually cares about it. This functionality has been added to BrightspaceUI/core, but not yet released - once it is, that will be used to replace most of this code.