### PR TITLE
aria bool attributes should be strings.

### DIFF
--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
@@ -280,8 +280,8 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 										<d2l-menu-item 
 											text="[[localize('publishAll')]]" 
 											on-d2l-menu-item-select="_dispatchPublishAllEvent" 
-											disabled$="[[_disablePublishAllButton(publishAll)]]"
-											aria-disabled$="[[_disablePublishAllButton(publishAll)]]"></d2l-menu-item>
+											disabled="[[_disablePublishAllButton(publishAll)]]"
+											aria-disabled$="[[_disablePublishAllButtonString(publishAll)]]"></d2l-menu-item>
 										<d2l-menu-item text="[[localize('dismissUntil')]]" on-d2l-menu-item-select="_dispatchDismissUntilEvent"></d2l-menu-item>
 										<d2l-menu-item text="[[localize('editActivity')]]" on-d2l-menu-item-select="_dispatchEditActivityEvent"></d2l-menu-item>
 									</d2l-quick-eval-activity-card-action-button-more>
@@ -520,6 +520,9 @@ class D2LQuickEvalActivityCard extends QuickEvalLocalize(PolymerElement) {
 
 	_disablePublishAllButton() {
 		return !this.publishAll;
+	}
+	_disablePublishAllButtonString() {
+		return this._disablePublishAllButton().toString();
 	}
 }
 


### PR DESCRIPTION
Screen reader was not properly identifying the disabled publish all menu item. Should now list the item as "unavailable" when it's set to disabled.

Also changed the actual `disabled` assignment from an attribute to a property as the menu item has a disabled property.