### PR TITLE
Add refresh capabilities to all 3 controllers

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -449,9 +449,9 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 			}
 
 			return dismissAction.then(() => {
-				const selfHref = this._getSelfLink(this.entity);
-				// bypass cache and reload
-				window.D2L.Siren.EntityStore.fetch(selfHref, this.token, true);
+				window.dispatchEvent(new CustomEvent('d2l-quick-eval-refresh-activities'));
+				window.dispatchEvent(new CustomEvent('d2l-quick-eval-refresh-submissions'));
+				window.dispatchEvent(new CustomEvent('d2l-quick-eval-refresh-dismissed'));
 				this.shadowRoot.querySelector('#toast-dismiss-success').open = true;
 			}).catch((error) => {
 				this.shadowRoot.querySelector('#toast-dismiss-critical').open = true;
@@ -528,6 +528,28 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 			this._loading = false;
 			this._handleLoadFailure();
 		});
+	}
+
+	constructor() {
+		super();
+		this._boundRefresh = this.refresh.bind(this);
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		window.addEventListener('d2l-quick-eval-refresh-activities', this._boundRefresh);
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		window.removeEventListener('d2l-quick-eval-refresh-activities', this._boundRefresh);
+	}
+
+	refresh() {
+		const selfHref = this._getSelfLink(this.entity);
+		if (selfHref) {
+			window.D2L.Siren.EntityStore.fetch(selfHref, this.token, true);
+		}
 	}
 }
 window.customElements.define('d2l-quick-eval-activities', D2LQuickEvalActivities);

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -548,6 +548,28 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 			this._handleFullLoadFailure();
 		}.bind(this));
 	}
+
+	constructor() {
+		super();
+		this._boundRefresh = this.refresh.bind(this);
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		window.addEventListener('d2l-quick-eval-refresh-submissions', this._boundRefresh);
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		window.removeEventListener('d2l-quick-eval-refresh-submissions', this._boundRefresh);
+	}
+
+	refresh() {
+		const selfHref = this._getSelfLink(this.entity);
+		if (selfHref) {
+			window.D2L.Siren.EntityStore.fetch(selfHref, this.token, true);
+		}
+	}
 }
 
 window.customElements.define('d2l-quick-eval-submissions', D2LQuickEvalSubmissions);

--- a/components/d2l-quick-eval/d2l-quick-eval.js
+++ b/components/d2l-quick-eval/d2l-quick-eval.js
@@ -121,7 +121,8 @@ class D2LQuickEval extends
 				value: submissions
 			},
 			dismissedActivitiesHref: {
-				type: String
+				type: String,
+				value: ''
 			},
 			token: {
 				type: Object,

--- a/components/d2l-quick-eval/dismiss/d2l-quick-eval-dismissed-activities.js
+++ b/components/d2l-quick-eval/dismiss/d2l-quick-eval-dismissed-activities.js
@@ -179,6 +179,10 @@ class D2LQuickEvalDismissedActivities extends mixinBehaviors(
 				} else {
 					this.shadowRoot.querySelector('.d2l-quick-eval-dismissed-list-success').open = true;
 				}
+			}).then(() => {
+				window.dispatchEvent(new CustomEvent('d2l-quick-eval-refresh-activities'));
+				window.dispatchEvent(new CustomEvent('d2l-quick-eval-refresh-submissions'));
+				window.dispatchEvent(new CustomEvent('d2l-quick-eval-refresh-dismissed'));
 			});
 		}
 	}
@@ -192,6 +196,28 @@ class D2LQuickEvalDismissedActivities extends mixinBehaviors(
 			this._loading = false;
 			this._handleLoadFailure();
 		});
+	}
+
+	constructor() {
+		super();
+		this._boundRefresh = this.refresh.bind(this);
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		window.addEventListener('d2l-quick-eval-refresh-dismissed', this._boundRefresh);
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		window.removeEventListener('d2l-quick-eval-refresh-dismissed', this._boundRefresh);
+	}
+
+	refresh() {
+		const selfHref = this._getSelfLink(this.entity);
+		if (selfHref) {
+			window.D2L.Siren.EntityStore.fetch(selfHref, this.token, true);
+		}
 	}
 }
 window.customElements.define('d2l-quick-eval-dismissed-activities', D2LQuickEvalDismissedActivities);


### PR DESCRIPTION
My approach here is to use events. We can fire global events when refreshes are needed and the controllers can listen for them. I was going to write this as a behaviour, but since that's polymer 1 stuff and we're on Lit now I decided rather than entangle myself in a framework I'd just get it done.

While testing this I noticed a weird bug where the UI does not match what the API is returning. Peggy reported a similar defect in slack. I'm wondering if we're not making observable changes to `this.entity`.