### PR TITLE
Fixed undefined search default.

### DIFF
--- a/components/d2l-quick-eval/behaviors/d2l-hm-search-behavior.js
+++ b/components/d2l-quick-eval/behaviors/d2l-hm-search-behavior.js
@@ -62,7 +62,7 @@ D2L.PolymerBehaviors.QuickEval.D2LHMSearchBehaviourImpl = {
 			this.searchApplied = true;
 		}
 
-		return searchTerm;
+		return searchTerm || '';
 	},
 
 	onSearchResultsLoading: function() {


### PR DESCRIPTION
This fixes `undefined` showing up in the search box under these conditions (https://rally1.rallydev.com/#/238990806412d/detail/userstory/355308987036), but I'm still not sure why it's happening. 