### PR TITLE
pass property as property instead of attribute

### DIFF
--- a/components/d2l-quick-eval/dismiss/d2l-quick-eval-ellipsis-menu.js
+++ b/components/d2l-quick-eval/dismiss/d2l-quick-eval-ellipsis-menu.js
@@ -42,7 +42,7 @@ class D2LQuickEvalEllipsisMenu extends LitQuickEvalLocalize(LitElement) {
 		</d2l-dropdown-more>
 		<d2l-quick-eval-dismissed-activities
 			href="${this._computeLazyHref()}"
-			token="${this.token}"
+			.token="${this.token}"
 			.opened="${this.opened}"
 			@d2l-dialog-close="${this._close.bind(this)}"
 			></d2l-quick-eval-dismissed-activities>


### PR DESCRIPTION
Context is here: https://d2l.slack.com/archives/C0PHG3QB0/p1576179194361700

Basically, we were passing token as a string instead of an object. And token is an object in the LMS which is why it worked locally (where we use string tokens) but not in QUAD.