### PR TITLE
Manually update entity

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -567,7 +567,7 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 	refresh() {
 		const selfHref = this._getSelfLink(this.entity);
 		if (selfHref) {
-			window.D2L.Siren.EntityStore.fetch(selfHref, this.token, true);
+			window.D2L.Siren.EntityStore.fetch(selfHref, this.token, true).then(x => this.entity = x.entity);
 		}
 	}
 }


### PR DESCRIPTION
I could not figure out why submissions does not work but activities and dismissed do. However, the workaround is relatively simple, just manually update `this.entity` when the response comes back.

I'm not a huge fan of this change but we can mitigate the risk by continuing to manually test things. Tomorrow we should take another look at this to determine the root cause to judge the riskiness of the release. For now, let's just let the testers be able to test the workflow.