### PR TITLE
.href -> href

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -201,7 +201,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 		return html`
 			<div id="assignment-visibility-container">
 				<d2l-activity-visibility-editor
-					.href="${this._activityUsageHref}"
+					href="${this._activityUsageHref}"
 					.token="${this.token}">
 				</d2l-activity-visibility-editor>
 			</div>
@@ -223,7 +223,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 			<div id="duedate-container">
 				<label class="d2l-label-text">${this.localize('dueDate')}</label>
 				<d2l-activity-due-date-editor
-					.href="${this._activityUsageHref}"
+					href="${this._activityUsageHref}"
 					.token="${this.token}">
 				</d2l-activity-due-date-editor>
 			</div>
@@ -241,7 +241,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 
 			<div id="assignment-attachments-editor-container" ?hidden="${!this._attachmentsHref}">
 				<d2l-activity-attachments-editor
-					.href="${this._attachmentsHref}"
+					href="${this._attachmentsHref}"
 					.token="${this.token}">
 				</d2l-activity-attachments-editor>
 			</div>
@@ -270,7 +270,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 
 			<div id="availability-dates-container">
 				<d2l-activity-availability-dates-editor
-					.href="${this._activityUsageHref}"
+					href="${this._activityUsageHref}"
 					.token="${this.token}">
 				</d2l-activity-availability-dates-editor>
 			</div>
@@ -279,12 +279,12 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 				<h3 class="d2l-heading-4">${this.localize('hdrReleaseConditions')}</h3>
 				<p class="d2l-body-small">${this.localize('hlpReleaseConditions')}</p>
 				<d2l-activity-release-conditions-editor
-					.href="${this._activityUsageHref}"
+					href="${this._activityUsageHref}"
 					.token="${this.token}">
 				</d2l-activity-release-conditions-editor>
 			</div>
 
-			<d2l-assignment-turnitin-editor .token="${this.token}" .href="${this.href}">
+			<d2l-assignment-turnitin-editor .token="${this.token}" href="${this.href}">
 			</d2l-assignment-turnitin-editor>
 
 			<div id="annotations-checkbox-container" ?hidden="${!this._canSeeAnnotations}">

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -68,7 +68,7 @@ class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LitElement))
 				@d2l-request-provider="${this._onRequestProvider}">
 
 				<d2l-activity-assignment-editor-detail
-					.href="${this._assignmentHref}"
+					href="${this._assignmentHref}"
 					.token="${this.token}"
 					slot="editor">
 				</d2l-activity-assignment-editor-detail>

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
@@ -42,12 +42,12 @@ class ActivityAttachmentsEditor extends EntityMixinLit(LitElement) {
 	render() {
 		return html`
 			<d2l-activity-attachments-list
-				.href="${this.href}"
+				href="${this.href}"
 				.token="${this.token}">
 			</d2l-activity-attachments-list>
 			<d2l-activity-attachments-picker
 				?hidden="${!this._canAddAttachments}"
-				.href="${this.href}"
+				href="${this.href}"
 				.token="${this.token}">
 			</d2l-activity-attachments-picker>
 		`;

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-list.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-list.js
@@ -55,7 +55,7 @@ class ActivityAttachmentsList extends EntityMixinLit(LitElement) {
 				${repeat(this._attachmentUrls, href => href, href => html`
 					<li slot="attachment" class="panel">
 						<d2l-activity-attachment
-							.href="${href}"
+							href="${href}"
 							.token="${this.token}">
 						</d2l-activity-attachment>
 					</li>


### PR DESCRIPTION
The property binding is not required here, and just adds some confusion. It is still required for the token, as that can be a string, object, function, or undefined.