### PR TITLE
Allow for better partial re-rendering

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -22,6 +22,7 @@ class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LitElement))
 			 */
 			trustedSitesEndpoint: { type: String },
 			_assignmentHref: { type: String },
+			_initialLoadComplete: { type: Boolean }
 		};
 	}
 
@@ -60,13 +61,20 @@ class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LitElement))
 		}
 	}
 
+	_onPendingResolved() {
+		// Once we've loaded the page once, this prevents us from ever showing
+		// the "Loading..." div again, even if page components are (re)loading
+		this._initialLoadComplete = true;
+	}
+
 	render() {
 		return html`
 			<d2l-activity-editor
-				?loading="${this._hasPendingChildren}"
+				?loading="${this._hasPendingChildren && !this._initialLoadComplete}"
 				unfurlEndpoint="${this.unfurlEndpoint}"
 				trustedSitesEndpoint="${this.trustedSitesEndpoint}"
-				@d2l-request-provider="${this._onRequestProvider}">
+				@d2l-request-provider="${this._onRequestProvider}"
+				@d2l-pending-resolved="${this._onPendingResolved}">
 
 				<d2l-activity-assignment-editor-detail
 					href="${this._assignmentHref}"

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachment.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachment.js
@@ -23,6 +23,7 @@ class ActivityAttachment extends EntityMixinLit(LitElement) {
 	constructor() {
 		super();
 		this._setEntityType(AttachmentEntity);
+		this._attachment = {};
 	}
 
 	set _entity(entity) {


### PR DESCRIPTION
With BrightspaceHypermediaComponents/siren-sdk#109, we can now more precisely control partial re-renders of the page as things load. This change makes it so that when the page is first loading, we show the "Loading" text in place of the full editor. Once the page has finished loading once (which we know by `d2l-pending-resolved` being fired), we won't ever show that text again. This allows for lower-level components on the page to re-fetch data without the whole page looking like it's reloading.

This approach is also more compatible with lower-level `PendingContainer` elements - previously, when we were fetching a new attachment, the whole page would go to the "Loading" state, which meant we wouldn't even see the nice attachment skeleton that `d2l-labs-attachment` has!