### PR TITLE
Fix undefined hrefs

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -85,6 +85,8 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 
 		this._submissionTypes = [];
 		this._completionTypes = [];
+		this._activityUsageHref = '';
+		this._attachmentsHref = '';
 	}
 
 	set _entity(entity) {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -39,6 +39,7 @@ class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LitElement))
 	constructor() {
 		super();
 		this._setEntityType(AssignmentActivityUsageEntity);
+		this._assignmentHref = '';
 	}
 
 	set _entity(entity) {


### PR DESCRIPTION
This was introduced in https://github.com/BrightspaceHypermediaComponents/activities/pull/545, or more accurately was surfaced by it. HTML attributes are strings, and LitElement properties are `undefined` by default - which, when stringified, is `"undefined"`. This can result is us trying to fetch weird URLs with "undefined".

To remedy this, it's a safe idea to initialize our strings in the constructor. Not required for everything, and not really needed for booleans (unless they should default to true), but a good practise to be in.