### PR TITLE
resized dialog on _onDatetimePickerDatetimeChanged

### DIFF
--- a/components/d2l-quick-eval/dismiss/d2l-quick-eval-action-dismiss-dialog.js
+++ b/components/d2l-quick-eval/dismiss/d2l-quick-eval-action-dismiss-dialog.js
@@ -142,6 +142,7 @@ class D2LQuickEvalActionDialog extends RtlMixin(LitQuickEvalLocalize(LitElement)
 
 	_onDatetimePickerDatetimeChanged(e) {
 		this._date = e.detail.toISOString();
+		this._getDialog().resize();
 	}
 
 	computeAction(selectedRadio, date) {


### PR DESCRIPTION
I don't exactly love the way we are doing this. We are essentially calling the resize function at specific points where we know that the layout of this dialog changes.

This is due to the way that the dialog is designed. @dbatiste recommended that we do not overuse the resize function, but I don't see another way to fix this issue.

