### PR TITLE
US112361 Add file selector dialog for attachments

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-attachments/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/lang/en.js
@@ -2,7 +2,11 @@
 
 export default {
 	"addGoogleDriveLink": "Attach from Google Drive", // Tooltip for a button that adds a link to a Google Drive file
+	"addFile": "File Upload", // Tooltip for a button that opens a file upload dialog
 	"addLink": "Attach Weblink", // Tooltip for a button that adds a link to a URL
 	"addOneDriveLink": "Attach from OneDrive", // Tooltip for a button that adds a link to a OneDrive file
 	"addQuicklink": "Attach Link to Existing Activity", // Tooltip for a button that adds a link to an existing activity
+	"back": "Back", // Text for a back button
+	"closeFilePickerDialog": "Close Dialog", // ARIA text for button to close file picker dialog
+	"save": "Save", // Text for a save button
 };


### PR DESCRIPTION
Similar to change made in #500 for link attachments, this adds and connects a button to open a file picker dialog. Also similar to #500, this required getting deep into LMS dialog JavaScript, which is ugly and not very maintainable.

This approach assumes we are living on an LMS page that has this JS available - fine since that is currently the case, but not great. The code is also very finicky, with a bunch of mystery parameters and such. A better solution, which is currently in the works, is for us to have a `d2l-dialog` that supports a filepicker and use that - in the short term, it will likely still mean this code exists somewhere (within the `d2l-dialog`), but for our use case here, it will mean we're just interacting with a WC with a clean API.