### PR TITLE
US112361 Fixup

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -156,8 +156,9 @@ class ActivityAttachmentsPicker extends SaveStatusMixin(EntityMixinLit(LocalizeM
 		const callback = () => {
 			const files = D2L.LP.Web.UI.Desktop.MasterPages.Dialog.FileSelectorDialog.GetFiles(dialogId);
 			for (const file of files) {
+				const fileSystemType = file.m_fileSystemType;
 				const fileId = file.m_id;
-				this.wrapSaveAction(super._entity.addTempFileAttachment(fileId));
+				this.wrapSaveAction(super._entity.addFileAttachment(fileSystemType, fileId));
 			}
 		};
 


### PR DESCRIPTION
Change to reflect the change to `siren-sdk`, which itself was a change to reflect a change to the API. When adding files other than uploaded files, we need to be able to specify where the file we're attaching comes from, via `fileSystemType`. Fortunately, this info comes back from the dialog along with the file ID.