### PR TITLE
Use QuickLinkTemplate to allow for copying

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -112,7 +112,7 @@ class ActivityAttachmentsPicker extends SaveStatusMixin(EntityMixinLit(LocalizeM
 			const quicklinkUrl = `/d2l/api/lp/unstable/${orgUnitId}/quickLinks/${event.m_typeKey}/${event.m_id}`;
 			const response = await fetch(quicklinkUrl);
 			const json = await response.json();
-			this.wrapSaveAction(superEntity.addLinkAttachment(event.m_title, json.QuickLink));
+			this.wrapSaveAction(superEntity.addLinkAttachment(event.m_title, json.QuickLinkTemplate));
 		});
 	}
 


### PR DESCRIPTION
If we use the QuickLink directly, copying the assignment to another course will end up causing issues as the copied assignment will have attachments in another course. Instead, we can use the QuickLinkTemplate so that when an assignment is copied to another course, the attachments will refer to the new org unit.