### PR TITLE
Fix flash of generic link icon

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachment.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachment.js
@@ -23,7 +23,6 @@ class ActivityAttachment extends EntityMixinLit(LitElement) {
 	constructor() {
 		super();
 		this._setEntityType(AttachmentEntity);
-		this._attachment = {};
 	}
 
 	set _entity(entity) {
@@ -49,6 +48,10 @@ class ActivityAttachment extends EntityMixinLit(LitElement) {
 	}
 
 	render() {
+		if (!this._attachment) {
+			return html``;
+		}
+
 		return html`
 			<d2l-labs-attachment
 				attachmentId="${this._attachment.id}"


### PR DESCRIPTION
Issue: when adding a new link, there is a brief flash of the generic-link icon, before switching to the attachment skeleton, then finally the unfurled link. This is because of a mismatch in behaviour between `d2l-activity-attachment` and `d2l-labs-attachment` - the former expects the latter to be able to handle null attributes/inputs, and the latter expects the former to never provide null attributes/inputs!

This fix changes `d2l-activity-attachment` to never pass a null `attachment` to the `d2l-labs-attachment` component, instead opting to just not render anything. This is probably a good approach to take in general, actually - it results in a faster (no-op) render when the component is first created.