### PR TITLE
Use Intl instead of LocalizeMixin for dates

### DIFF
--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-subtitle.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-subtitle.js
@@ -1,4 +1,5 @@
 import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
+import {formatDateTime} from '@brightspace-ui/intl/lib/dateTime.js';
 import {QuickEvalLocalize} from '../QuickEvalLocalize.js';
 import '../../d2l-subtitle/d2l-subtitle.js';
 
@@ -39,7 +40,7 @@ class D2LQuickEvalActivityCardSubtitle extends QuickEvalLocalize(PolymerElement)
 		if (dueDate) {
 			const formattedDateTime = Date.parse(dueDate);
 			if (formattedDateTime) {
-				result.push(this.localize('due', 'date', this.formatDateTime(new Date(dueDate))));
+				result.push(this.localize('due', 'date', formatDateTime(new Date(dueDate))));
 			}
 		}
 		return result;

--- a/components/d2l-quick-eval/dismiss/d2l-quick-eval-action-dismiss-dialog.js
+++ b/components/d2l-quick-eval/dismiss/d2l-quick-eval-action-dismiss-dialog.js
@@ -1,5 +1,6 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { LitQuickEvalLocalize } from '../LitQuickEvalLocalize.js';
+import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { radioStyles } from '@brightspace-ui/core/components/inputs/input-radio-styles.js';
 import { labelStyles, bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';
@@ -111,7 +112,7 @@ class D2LQuickEvalActionDialog extends RtlMixin(LitQuickEvalLocalize(LitElement)
 	}
 
 	_getIso8601Date(date) {
-		const timezone = this.getTimezone().identifier;
+		const timezone = getDocumentLocaleSettings().timezone.identifier;
 
 		if (timezone) {
 			return date.tz(timezone).format('YYYY-MM-DD');

--- a/components/d2l-quick-eval/dismiss/d2l-quick-eval-dismissed-activities-list.js
+++ b/components/d2l-quick-eval/dismiss/d2l-quick-eval-dismissed-activities-list.js
@@ -1,3 +1,4 @@
+import { formatDateTime } from '@brightspace-ui/intl/lib/dateTime.js';
 import { html, LitElement } from 'lit-element/lit-element.js';
 import { LitQuickEvalLocalize } from '../LitQuickEvalLocalize.js';
 import '@brightspace-ui/core/components/list/list.js';
@@ -30,7 +31,7 @@ class D2LQuickEvalDismissedActivitiesList extends LitQuickEvalLocalize(LitElemen
 	_computeSubtitleText(act) {
 		const result = [act.course];
 		if (act.dismissedDate) {
-			result.push(this.localize('dismissedOn', {date: this.formatDateTime(new Date(act.dismissedDate))}));
+			result.push(this.localize('dismissedOn', {date: formatDateTime(new Date(act.dismissedDate))}));
 		}
 		return result;
 	}

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@brightspace-ui-labs/edit-in-place": "^1.0.7",
     "@brightspace-ui/core": "^1.17.0",
+    "@brightspace-ui/intl": "^3.0.1",
     "@d2l/d2l-attachment": "Brightspace/attachment#semver:^1",
     "@d2l/switch": "Brightspace/d2l-switch.git#semver:^3",
     "@polymer/iron-resizable-behavior": "^3.0.0",


### PR DESCRIPTION
I've made some improvements to our Intl library such that it's a lot easier to call into its date/time/number formatting and parsing functions.

Since these aren't free to load on every page, I want to move them out of the `LocalizeMixin` (which many many components extend) and just have components import them only when they need to. So this change just calls into Intl directly.

Once the 4 places that are using `LocalizeMixin`'s Intl stuff (of which this is one) are calling Intl directly, I'm going to remove the functions from `LocalizeMixin`.