### PR TITLE
US111908 Refactor dialog openers

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -4,8 +4,8 @@ import 'd2l-tooltip/d2l-tooltip';
 import { css, html, LitElement } from 'lit-element/lit-element';
 import { AttachmentCollectionEntity } from 'siren-sdk/src/activities/AttachmentCollectionEntity';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
-import { getLocalizeResources } from '../localization.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { getLocalizeResources } from '../localization';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin';
 import { SaveStatusMixin } from '../save-status-mixin';
 
 class ActivityAttachmentsPicker extends SaveStatusMixin(EntityMixinLit(LocalizeMixin(LitElement))) {
@@ -34,9 +34,10 @@ class ActivityAttachmentsPicker extends SaveStatusMixin(EntityMixinLit(LocalizeM
 			.button-container {
 				display: flex;
 				flex-direction: row;
+				width: 100%;
 			}
 
-			.button-container > * {
+			d2l-button-icon:not([hidden]) {
 				display: inline-block;
 			}
 		`;
@@ -53,6 +54,16 @@ class ActivityAttachmentsPicker extends SaveStatusMixin(EntityMixinLit(LocalizeM
 		this._tooltipBoundary = {
 			left: 20 + 12, // padding-left applied to d2l-activity-attachments-picker + padding-left of d2l-button-icon
 			right: 0
+		};
+
+		D2L.ActivityEditor = D2L.ActivityEditor || {};
+		// Required by the server-side ActivitiesView renderer
+		D2L.ActivityEditor.FileUploadDialogCallback = files => {
+			for (const file of files) {
+				const fileSystemType = file.m_fileSystemType;
+				const fileId = file.m_id;
+				this.wrapSaveAction(super._entity.addFileAttachment(fileSystemType, fileId));
+			}
 		};
 	}
 
@@ -80,105 +91,23 @@ class ActivityAttachmentsPicker extends SaveStatusMixin(EntityMixinLit(LocalizeM
 		return orgUnitId;
 	}
 
-	_openDialog(opener, settings, callback) {
-		const params = new URLSearchParams();
-		params.set('initialViewType', 'Items');
-		params.set('canChangeType', false); // Hides the top toolbar which allows changing the dialog picker type
-		params.set('outputFormat', 'html'); // Only valid value is "html"
-
-		for (const setting in settings) {
-			params.set(setting, settings[setting]);
-		}
-
-		const location = `/d2l/lp/quicklinks/manage/${this._orgUnitId}/CreateDialog?${params.toString()}`;
-
-		const event = D2L.LP.Web.UI.Common.MasterPages.Dialog.Open(
-			opener,
-			new D2L.LP.Web.Http.UrlLocation(location)
-		);
-
-		event.AddListener(callback);
-	}
-
 	_launchAddFileDialog() {
-		const opener = this.shadowRoot.querySelector('#add-file-button');
-
-		const params = new URLSearchParams();
-		params.set('ou', this._orgUnitId);
-		params.set('af', 'mycomputer,oufiles,sharedfiles,mylocker,grouplocker'); // Area Filters
-		params.set('am', '1'); // Allow Multiple files, 1 = allow
-		params.set('fsc', '0'); // Force Save to Course files, 0 = don't force
-		params.set('asc', '0'); // Allow Save to Course files, 0 = don't allow
-		params.set('mfs', '0'); // Max File Size, 0 = don't set (use system setting)
-		params.set('afid', '0'); // Ask For Image Description, 0 = don't ask
-		params.set('uih', ''); // Upload Inline Help langterm, '' = don't show any upload help text (below file picker in My Computer)
-		params.set('f', ''); // Filetype, '' = allow all file types
-		const location = new D2L.LP.Web.Http.UrlLocation(`/d2l/common/dialogs/file/main.d2l?${params.toString()}`);
-
-		const buttons = [
-			{
-				Key: 'save',
-				Text: this.localize('save'),
-				ResponseType: 1, // D2L.Dialog.ResponseType.Positive
-				IsPrimary: true,
-				IsEnabled: true,
-				Param: 'next' // key for fileArea.js
-			},
-			{
-				Text: this.localize('back'),
-				ResponseType: 2, // D2L.Dialog.ResponseType.Negative
-				IsPrimary: false,
-				IsEnabled: true,
-				Param: 'back' // key for fileArea.js
-			}
-		];
-
-		const dialog = D2L.LP.Web.UI.Legacy.MasterPages.Dialog.Open.bind(
-			this,
-			opener,
-			location,
-			'DialogCallback', // srcCallback
-			'', // resizeCallback
-			'files', // responseDataKey
-			720, // width
-			1280, // height
-			this.localize('closeFilePickerDialog'), // closeText
-			buttons, // buttons
-			false // forceTriggerOnCancel
-		);
-
-		const dialogId = {
-			GetValue: () => 'AttachmentPickerDialog'
-		};
-
-		const callback = () => {
-			const files = D2L.LP.Web.UI.Desktop.MasterPages.Dialog.FileSelectorDialog.GetFiles(dialogId);
-			for (const file of files) {
-				const fileSystemType = file.m_fileSystemType;
-				const fileId = file.m_id;
-				this.wrapSaveAction(super._entity.addFileAttachment(fileSystemType, fileId));
-			}
-		};
-
-		D2L.LP.Web.UI.Desktop.MasterPages.Dialog.FileSelectorDialog.OpenDialog(
-			dialog,
-			dialogId,
-			callback
-		);
+		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.FileUploadDialogOpener');
+		if (opener) {
+			opener();
+		}
 	}
 
 	_launchAddQuicklinkDialog() {
-		const opener = this.shadowRoot.querySelector('#add-quicklink-button');
-		const settings = {
-			typeKey: '',
-			initialViewType: 'Default',
-			pickOnly: true // Prevents creating new items from the picker
-		};
+		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.AddQuicklinkDialogOpener');
+		if (!opener) {
+			return;
+		}
 
 		// Required for the async handler below to work in Edge
 		const superEntity = super._entity;
-
-		this._openDialog(opener, settings, async event => {
+		const event = opener();
+		event.AddListener(async event => {
 			const quicklinkUrl = `/d2l/api/lp/unstable/${this._orgUnitId}/quickLinks/${event.m_typeKey}/${event.m_id}`;
 			const response = await fetch(quicklinkUrl);
 			const json = await response.json();
@@ -187,49 +116,44 @@ class ActivityAttachmentsPicker extends SaveStatusMixin(EntityMixinLit(LocalizeM
 	}
 
 	_launchAddLinkDialog() {
-		const opener = this.shadowRoot.querySelector('#add-link-button');
-		const settings = {
-			typeKey: 'url',
-			customTitle: '', // Hides "Insert Quicklink" title on dialog
-			showCancelButton: false, // Uses urlShowCancelButtonInline instead
-			urlShowCancelButtonInline: true, // Shows the Cancel button next to Insert button
-			urlShowTarget: false // Hides ability to set URL to open in same window/new window
-		};
+		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.AddLinkDialogOpener');
+		if (!opener) {
+			return;
+		}
 
-		this._openDialog(opener, settings, event => {
+		const event = opener();
+		event.AddListener(event => {
 			this.wrapSaveAction(super._entity.addLinkAttachment(event.m_title, event.m_url));
 		});
 	}
 
 	_launchAddGoogleDriveLinkDialog() {
-		const opener = this.shadowRoot.querySelector('#add-google-drive-link-button');
-		const settings = {
-			typeKey: 'google-drive',
-			customTitleLangTerm: 'Pickers.Quicklinks.titleAddMaterials',
-			showCancelButton: false // Google Drive picker has its own cancel button
-		};
+		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.AddGoogleDriveLinkDialogOpener');
+		if (!opener) {
+			return;
+		}
 
-		this._openDialog(opener, settings, event => {
+		const event = opener();
+		event.AddListener(event => {
 			this.wrapSaveAction(super._entity.addGoogleDriveLinkAttachment(event.m_title, event.m_url));
 		});
 	}
 
 	_launchAddOneDriveLinkDialog() {
-		const opener = this.shadowRoot.querySelector('#add-onedrive-link-button');
-		const settings = {
-			typeKey: 'one-drive',
-			customTitleLangTerm: 'Pickers.Quicklinks.titleAddMaterials',
-			showCancelButton: false // OneDrive picker has its own cancel button
-		};
+		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.AddOneDriveLinkDialogOpener');
+		if (!opener) {
+			return;
+		}
 
-		this._openDialog(opener, settings, event => {
+		const event = opener();
+		event.AddListener(event => {
 			this.wrapSaveAction(super._entity.addOneDriveLinkAttachment(event.m_title, event.m_url));
 		});
 	}
 
 	render() {
 		return html`
-			<div id="button-container">
+			<div class="button-container">
 				<d2l-button-icon
 					id="add-file-button"
 					icon="d2l-tier1:upload"

--- a/components/d2l-activity-editor/d2l-activity-attachments/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/lang/en.js
@@ -7,6 +7,6 @@ export default {
 	"addOneDriveLink": "Attach from OneDrive", // Tooltip for a button that adds a link to a OneDrive file
 	"addQuicklink": "Attach Link to Existing Activity", // Tooltip for a button that adds a link to an existing activity
 	"back": "Back", // Text for a back button
-	"closeFilePickerDialog": "Close Dialog", // ARIA text for button to close file picker dialog
+	"closeDialog": "Close Dialog", // ARIA text for button to close dialog
 	"save": "Save", // Text for a save button
 };


### PR DESCRIPTION
This change is possible due to a server-side change that makes the functions to open the various dialogs available via the `ObjectRepository` on the page. This still relies on magic keys to retrieve these opener functions, but this removes the majority of the deep-LMS-knowledge code from the UI side, which is an improvement.

This is functionally identical to what already existed.