### PR TITLE
Allow opt-out tabbie to calculate its position

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -26,6 +26,11 @@ class ActivityEditor extends LitElement {
 			}
 			.d2l-activity-editor-loading {
 				padding: 20px;
+				position: fixed;
+				background-color: #fff;
+				width: 100%;
+				height: 100vh;
+				z-index: 100001;
 			}
 		`;
 	}
@@ -83,7 +88,6 @@ class ActivityEditor extends LitElement {
 		return html`
 			<div class="d2l-activity-editor-loading" ?hidden="${!this.loading}">Loading ...</div>
 			<div
-				?hidden="${this.loading}"
 				@d2l-request-provider="${this._onRequestProvider}">
 				<slot name="editor"></slot>
 			</div>


### PR DESCRIPTION
There is JavaScript in the LMS that calculates where to place the opt out tabbie so that it sits under the immersive nav bar. When FACE is loading, the editor (including the immersive nav) is hidden and has a height of 0. Thus, it is unable to calculate where to place the opt-out tabbie. This commit changes it so that the loading screen becomes a fixed overlay over the editor and the editor compoonents render beneath it.