### PR TITLE
Us111489 ui tweaks

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -7,7 +7,7 @@ import 'd2l-dropdown/d2l-dropdown-menu.js';
 import 'd2l-tooltip/d2l-tooltip';
 import { css, html, LitElement } from 'lit-element/lit-element';
 import { ActivityUsageEntity } from 'siren-sdk/src/activities/ActivityUsageEntity';
-import { bodySmallStyles } from '@brightspace-ui/core/components/typography/styles.js';
+import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { ErrorHandlingMixin } from './error-handling-mixin.js';
 import { getLocalizeResources } from './localization';
@@ -34,7 +34,7 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 
 	static get styles() {
 		return [
-			bodySmallStyles,
+			bodyCompactStyles,
 			inputStyles,
 			css`
 			:host {
@@ -56,6 +56,17 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 			:host([dir="rtl"]) #ungraded {
 				--d2l-input-padding: 0.4rem 0.75rem 0.4rem 1.65rem;
 				--d2l-input-padding-focus: calc(0.4rem - 1px) calc(0.75rem - 1px) calc(0.4rem - 1px) calc(1.65rem - 1px);
+			}
+			#score-info-container,
+			#score-out-of-container {
+				display: flex;
+				align-items: baseline;
+			}
+			.grade-type-text {
+				margin: 0 0.6rem;
+			}
+			#grade-info-container {
+				border-left: solid 1px var(--d2l-color-galena);
 			}
 			.grade-info {
 				border: 1px solid transparent;
@@ -121,7 +132,7 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 				this._scoreOutOf = entity.scoreOutOf();
 			}
 			this._inGrades = entity.inGrades();
-			this._gradeType = entity.gradeType() || 'Points';
+			this._gradeType = (entity.gradeType() || 'Points').toLowerCase();
 			this._isUngraded = !this._inGrades && !this._scoreOutOf;
 			this._canEditScoreOutOf = entity.canEditScoreOutOf();
 			this._canSeeGrades = entity.canSeeGrades();
@@ -210,54 +221,57 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 			</div>
 
 			<div id="score-info-container" ?hidden="${this._isUngraded}">
-				<d2l-input-text
-					id="score-out-of"
-					label="${this.localize('scoreOutOf')}"
-					label-hidden
-					value="${this._scoreOutOf}"
-					size=4
-					@change="${this._onScoreOutOfChanged}"
-					aria-invalid="${this._isError() ? 'true' : ''}"
-					?disabled="${!this._canEditScoreOutOf}"
-				></d2l-input-text>
-				<d2l-tooltip
-					?hidden="${!this._isError()}"
-					id="score-tooltip"
-					for="score-out-of"
-					position="bottom"
-					?showing="${this._isError()}"
-					.boundary="${this._tooltipBoundary}"
-				>
-					<span ?hidden="${!this._emptyScoreOutOfError}">${this._emptyScoreOutOfError}</span>
-					<span ?hidden="${!this._invalidScoreOutOfError}">${this._invalidScoreOutOfError}</span>
-				</d2l-tooltip>
-				<span class="d2l-body-small">${this._gradeType}</span>
-				<d2l-icon ?hidden="${!this._canSeeGrades}" icon="tier1:divider-solid"></d2l-icon>
-				<d2l-dropdown ?hidden="${!this._canSeeGrades}">
-					<button class="grade-info d2l-dropdown-opener">
-						<d2l-icon icon="tier1:grade" ?hidden="${!this._inGrades}"></d2l-icon>
-						<span>${this._inGrades ? this.localize('inGrades') : this.localize('notInGrades')}</span>
-						<d2l-icon icon="tier1:chevron-down"></d2l-icon>
-					</button>
-					<d2l-dropdown-menu id="grade-dropdown">
-						<d2l-menu label="${this._inGrades ? this.localize('inGrades') : this.localize('notInGrades')}">
-							<d2l-menu-item
-								text="${this.localize('addToGrades')}"
-								?hidden="${this._inGrades || !this._canEditGrades}"
-								@d2l-menu-item-select="${this._addToGrades}"
-							></d2l-menu-item>
-							<d2l-menu-item
-								text="${this.localize('removeFromGrades')}"
-								?hidden="${!this._inGrades || !this._canEditGrades}"
-								@d2l-menu-item-select="${this._removeFromGrades}"
-							></d2l-menu-item>
-							<d2l-menu-item
-								text="${this.localize('setUngraded')}"
-								@d2l-menu-item-select="${this._setUngraded}"
-							></d2l-menu-item>
-						</d2l-menu>
-					</d2l-dropdown-menu>
-				</d2l-dropdown>
+				<div id="score-out-of-container">
+					<d2l-input-text
+						id="score-out-of"
+						label="${this.localize('scoreOutOf')}"
+						label-hidden
+						value="${this._scoreOutOf}"
+						size=4
+						@change="${this._onScoreOutOfChanged}"
+						aria-invalid="${this._isError() ? 'true' : ''}"
+						?disabled="${!this._canEditScoreOutOf}"
+					></d2l-input-text>
+					<d2l-tooltip
+						?hidden="${!this._isError()}"
+						id="score-tooltip"
+						for="score-out-of"
+						position="bottom"
+						?showing="${this._isError()}"
+						.boundary="${this._tooltipBoundary}"
+					>
+						<span ?hidden="${!this._emptyScoreOutOfError}">${this._emptyScoreOutOfError}</span>
+						<span ?hidden="${!this._invalidScoreOutOfError}">${this._invalidScoreOutOfError}</span>
+					</d2l-tooltip>
+					<div class="d2l-body-compact grade-type-text">${this._gradeType}</div>
+				</div>
+				<div id="grade-info-container" ?hidden="${!this._canSeeGrades}">
+					<d2l-dropdown>
+						<button class="grade-info d2l-dropdown-opener">
+							<d2l-icon icon="tier1:grade" ?hidden="${!this._inGrades}"></d2l-icon>
+							<span>${this._inGrades ? this.localize('inGrades') : this.localize('notInGrades')}</span>
+							<d2l-icon icon="tier1:chevron-down"></d2l-icon>
+						</button>
+						<d2l-dropdown-menu id="grade-dropdown">
+							<d2l-menu label="${this._inGrades ? this.localize('inGrades') : this.localize('notInGrades')}">
+								<d2l-menu-item
+									text="${this.localize('addToGrades')}"
+									?hidden="${this._inGrades || !this._canEditGrades}"
+									@d2l-menu-item-select="${this._addToGrades}"
+								></d2l-menu-item>
+								<d2l-menu-item
+									text="${this.localize('removeFromGrades')}"
+									?hidden="${!this._inGrades || !this._canEditGrades}"
+									@d2l-menu-item-select="${this._removeFromGrades}"
+								></d2l-menu-item>
+								<d2l-menu-item
+									text="${this.localize('setUngraded')}"
+									@d2l-menu-item-select="${this._setUngraded}"
+								></d2l-menu-item>
+							</d2l-menu>
+						</d2l-dropdown-menu>
+					</d2l-dropdown>
+				</div>
 			</div>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -58,15 +58,26 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 				--d2l-input-padding-focus: calc(0.4rem - 1px) calc(0.75rem - 1px) calc(0.4rem - 1px) calc(1.65rem - 1px);
 			}
 			#score-info-container,
-			#score-out-of-container {
+			#score-out-of-container,
+			#grade-info-container {
 				display: flex;
 				align-items: baseline;
 			}
 			.grade-type-text {
-				margin: 0 0.6rem;
+				margin: 0 0.75rem 0 0.6rem;
 			}
-			#grade-info-container {
+			:host([dir="rtl"]) .grade-type-text {
+				margin: 0 0.6rem 0 0.75rem;
+			}
+			.divider {
+				height: 1.5rem;
+				align-self: center;
 				border-left: solid 1px var(--d2l-color-galena);
+				margin-right: 0.3rem;
+			}
+			:host([dir="rtl"]) .divider {
+				margin-right: 0;
+				margin-left: 0.3rem;
 			}
 			.grade-info {
 				border: 1px solid transparent;
@@ -246,6 +257,7 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 					<div class="d2l-body-compact grade-type-text">${this._gradeType}</div>
 				</div>
 				<div id="grade-info-container" ?hidden="${!this._canSeeGrades}">
+					<div class="divider"></div>
 					<d2l-dropdown>
 						<button class="grade-info d2l-dropdown-opener">
 							<d2l-icon icon="tier1:grade" ?hidden="${!this._inGrades}"></d2l-icon>

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -64,19 +64,22 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 				display: flex;
 				align-items: baseline;
 			}
+			#score-info-container {
+				flex-wrap: wrap;
+			}
 			.grade-type-text {
 				margin: 0 0.75rem 0 0.6rem;
 			}
 			:host([dir="rtl"]) .grade-type-text {
 				margin: 0 0.6rem 0 0.75rem;
 			}
-			.divider {
+			#divider {
 				height: 1.5rem;
 				align-self: center;
 				border-left: solid 1px var(--d2l-color-galena);
 				margin-right: 0.3rem;
 			}
-			:host([dir="rtl"]) .divider {
+			:host([dir="rtl"]) #divider {
 				margin-right: 0;
 				margin-left: 0.3rem;
 			}
@@ -87,6 +90,14 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 				border-radius: 0.3rem;
 				padding: .5rem .6rem;
 				cursor: pointer;
+				display: flex;
+				flex-wrap: nowrap;
+			}
+			.grade-info div {
+				flex-shrink: 1;
+			}
+			.grade-info d2l-icon {
+				flex-shrink: 0;
 			}
 			.grade-info > * {
 				margin-right: 0.3rem;
@@ -268,11 +279,11 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 					<div class="d2l-body-compact grade-type-text">${this._gradeType}</div>
 				</div>
 				<div id="grade-info-container" ?hidden="${!this._canSeeGrades}">
-					<div class="divider"></div>
+					<div id="divider"></div>
 					<d2l-dropdown>
 						<button class="d2l-label-text grade-info d2l-dropdown-opener">
 							<d2l-icon icon="tier1:grade" ?hidden="${!this._inGrades}"></d2l-icon>
-							<span>${this._inGrades ? this.localize('inGrades') : this.localize('notInGrades')}</span>
+							<div>${this._inGrades ? this.localize('inGrades') : this.localize('notInGrades')}</div>
 							<d2l-icon icon="tier1:chevron-down"></d2l-icon>
 						</button>
 						<d2l-dropdown-menu id="grade-dropdown" align="start" no-pointer vertical-offset="3px">

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -5,9 +5,9 @@ import '@brightspace-ui/core/components/inputs/input-text.js';
 import 'd2l-dropdown/d2l-dropdown.js';
 import 'd2l-dropdown/d2l-dropdown-menu.js';
 import 'd2l-tooltip/d2l-tooltip';
+import { bodyCompactStyles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html, LitElement } from 'lit-element/lit-element';
 import { ActivityUsageEntity } from 'siren-sdk/src/activities/ActivityUsageEntity';
-import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { ErrorHandlingMixin } from './error-handling-mixin.js';
 import { getLocalizeResources } from './localization';
@@ -35,6 +35,7 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 	static get styles() {
 		return [
 			bodyCompactStyles,
+			labelStyles,
 			inputStyles,
 			css`
 			:host {
@@ -84,19 +85,11 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 				background: none;
 				outline: none;
 				border-radius: 0.3rem;
-				padding: .5rem .75rem .4rem;
+				padding: .5rem .6rem;
 				cursor: pointer;
 			}
-			.grade-info:hover,
-			.grade-info:focus {
-				border-color: var(--d2l-color-mica);
-			}
-			.grade-info:hover span,
-			.grade-info:focus span {
-				color: var(--d2l-color-celestine);
-			}
 			.grade-info > * {
-				margin-right: 0.5rem;
+				margin-right: 0.3rem;
 			}
 			.grade-info > *:last-child {
 				margin-right: 0;
@@ -107,6 +100,24 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 			}
 			:host([dir="rtl"]) .grade-info > *:last-child {
 				margin-left: 0;
+			}
+			.grade-info:hover,
+			.grade-info[active] {
+				border-color: var(--d2l-color-mica);
+			}
+			.grade-info:focus {
+				border-color: var(--d2l-color-celestine);
+				border-width: 2px;
+				padding: calc(.5rem - 1px) calc(.6rem - 1px);
+			}
+			.grade-info:hover > *,
+			.grade-info:focus > * {
+				color: var(--d2l-color-celestine-minus-1);
+			}
+			button {
+				/* needed otherwise user agent style overrides this */
+				font-family: inherit;
+				color: inherit;
 			}
 			`
 		];
@@ -259,7 +270,7 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 				<div id="grade-info-container" ?hidden="${!this._canSeeGrades}">
 					<div class="divider"></div>
 					<d2l-dropdown>
-						<button class="grade-info d2l-dropdown-opener">
+						<button class="d2l-label-text grade-info d2l-dropdown-opener">
 							<d2l-icon icon="tier1:grade" ?hidden="${!this._inGrades}"></d2l-icon>
 							<span>${this._inGrades ? this.localize('inGrades') : this.localize('notInGrades')}</span>
 							<d2l-icon icon="tier1:chevron-down"></d2l-icon>

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -45,11 +45,17 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 				display: none;
 			}
 			d2l-input-text,
-			.ungraded {
+			#ungraded {
 				width: auto;
 			}
-			.ungraded {
+			#ungraded {
 				cursor: pointer;
+				--d2l-input-padding: 0.4rem 1.65rem 0.4rem 0.75rem;
+				--d2l-input-padding-focus: calc(0.4rem - 1px) calc(1.65rem - 1px) calc(0.4rem - 1px) calc(0.75rem - 1px);
+			}
+			:host([dir="rtl"]) #ungraded {
+				--d2l-input-padding: 0.4rem 0.75rem 0.4rem 1.65rem;
+				--d2l-input-padding-focus: calc(0.4rem - 1px) calc(0.75rem - 1px) calc(0.4rem - 1px) calc(1.65rem - 1px);
 			}
 			.grade-info {
 				border: 1px solid transparent;
@@ -195,8 +201,8 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 
 	render() {
 		return html`
-      		<div id="ungraded-button-container" ?hidden="${!this._isUngraded}">
-				<button id="ungraded" class="ungraded d2l-input"
+			<div id="ungraded-button-container" ?hidden="${!this._isUngraded}">
+				<button id="ungraded" class="d2l-input"
 					@click="${this._setGraded}"
 				>
 					${this.localize('ungraded')}

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -275,7 +275,7 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 							<span>${this._inGrades ? this.localize('inGrades') : this.localize('notInGrades')}</span>
 							<d2l-icon icon="tier1:chevron-down"></d2l-icon>
 						</button>
-						<d2l-dropdown-menu id="grade-dropdown">
+						<d2l-dropdown-menu id="grade-dropdown" align="start" no-pointer vertical-offset="3px">
 							<d2l-menu label="${this._inGrades ? this.localize('inGrades') : this.localize('notInGrades')}">
 								<d2l-menu-item
 									text="${this.localize('addToGrades')}"

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -118,7 +118,7 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 			}
 			this._inGrades = entity.inGrades();
 			this._gradeType = entity.gradeType() || 'Points';
-			this._isUngraded = !this._inGrades && this._scoreOutOf.length === 0;
+			this._isUngraded = !this._inGrades && !this._scoreOutOf;
 			this._canEditScoreOutOf = entity.canEditScoreOutOf();
 			this._canSeeGrades = entity.canSeeGrades();
 			this._canEditGrades = entity.canEditGrades();
@@ -172,7 +172,7 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 
 	_removeFromGrades() {
 		this.clearError('_emptyScoreOutOfError');
-		if (this._scoreOutOf.length === 0) {
+		if (!this._scoreOutOf) {
 			this._inGrades = false;
 		} else {
 			this.wrapSaveAction(super._entity.removeFromGrades());

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -43,7 +43,7 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 			}
 			:host([hidden]),
 			[hidden] {
-				display: none;
+				display: none !important;
 			}
 			d2l-input-text,
 			#ungraded {

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -44,9 +44,7 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 			[hidden] {
 				display: none;
 			}
-			d2l-input-text {
-				width: 4rem;
-			}
+			d2l-input-text,
 			.ungraded {
 				width: auto;
 			}
@@ -196,8 +194,6 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 	}
 
 	render() {
-		const minScore = 0.01;
-		const maxScore = 9999999999;
 		return html`
       		<div id="ungraded-button-container" ?hidden="${!this._isUngraded}">
 				<button id="ungraded" class="ungraded d2l-input"
@@ -210,13 +206,10 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 			<div id="score-info-container" ?hidden="${this._isUngraded}">
 				<d2l-input-text
 					id="score-out-of"
-					type="number"
 					label="${this.localize('scoreOutOf')}"
 					label-hidden
 					value="${this._scoreOutOf}"
-					min="${minScore}"
-					max="${maxScore}"
-					step="any"
+					size=4
 					@change="${this._onScoreOutOfChanged}"
 					aria-invalid="${this._isError() ? 'true' : ''}"
 					?disabled="${!this._canEditScoreOutOf}"


### PR DESCRIPTION
This addresses:
https://trello.com/c/m2iseQGI/55-ungraded-text-field-button-paddin
https://trello.com/c/Xh6IOgdm/49-typography-and-padding-around-points-next-to-the-numerical-entry-field
https://trello.com/c/DBOZlShj/50-divider-line-between-points-and-the-button
https://trello.com/c/HbunTVF1/51-in-grades-button-alignment-with-sort-menu
https://trello.com/c/gJa1SFZl/53-left-align-menu-with-in-grades-button
And part of:
https://trello.com/c/KryvT8X3/54-button-text-field-are-not-yet-responsive

