### PR TITLE
US111489 fix score not saving in Edge

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -192,8 +192,6 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 	}
 
 	_onScoreOutOfChanged() {
-		this.clearError('_emptyScoreOutOfError');
-		this.clearError('_invalidScoreOutOfError');
 		const scoreOutOf = this.shadowRoot.querySelector('#score-out-of').value;
 		if (scoreOutOf === this._scoreOutOf) {
 			return;
@@ -203,14 +201,17 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 			(isNaN(scoreOutOf) || scoreOutOf < 0.01 || scoreOutOf > 9999999999);
 
 		const scoreErrorLangterm = isScoreEmpty ? 'emptyScoreOutOfError' : 'invalidScoreOutOfError';
-		const errorProperty = isScoreEmpty ? '_emptyScoreOutOfError' : '_invalidScoreOutOfError';
+		const setErrorProperty = isScoreEmpty ? '_emptyScoreOutOfError' : '_invalidScoreOutOfError';
+		const clearErrorProperty = isScoreEmpty ? '_invalidScoreOutOfError' : '_emptyScoreOutOfError';
 		const tooltipId = 'score-tooltip';
 
 		if ((this._inGrades && isScoreEmpty) || isScoreInvalid) {
 			this._scoreOutOf = scoreOutOf;
-			this.setError(errorProperty, scoreErrorLangterm, tooltipId);
+			this.clearError(clearErrorProperty);
+			this.setError(setErrorProperty, scoreErrorLangterm, tooltipId);
 		} else {
-			this.clearError(errorProperty);
+			this.clearError('_emptyScoreOutOfError');
+			this.clearError('_invalidScoreOutOfError');
 			this._debounceJobs.scoreOutOf = Debouncer.debounce(
 				this._debounceJobs.scoreOutOf,
 				timeOut.after(500),

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -8,6 +8,7 @@ import 'd2l-tooltip/d2l-tooltip';
 import { bodyCompactStyles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html, LitElement } from 'lit-element/lit-element';
 import { ActivityUsageEntity } from 'siren-sdk/src/activities/ActivityUsageEntity';
+import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { ErrorHandlingMixin } from './error-handling-mixin.js';
 import { getLocalizeResources } from './localization';
@@ -15,6 +16,7 @@ import { inputStyles } from '@brightspace-ui/core/components/inputs/input-styles
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { SaveStatusMixin } from './save-status-mixin';
+import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 
 class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixinLit(LocalizeMixin(RtlMixin(LitElement))))) {
 
@@ -148,6 +150,7 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 		this._canEditScoreOutOf = false;
 		this._canSeeGrades = false;
 		this._canEditGrades = false;
+		this._debounceJobs = {};
 
 		this._tooltipBoundary = {
 			left: 5,
@@ -162,7 +165,7 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 
 		if (entity) {
 			if (!this._isError()) {
-				this._scoreOutOf = entity.scoreOutOf();
+				this._scoreOutOf = entity.scoreOutOf().toString();
 			}
 			this._inGrades = entity.inGrades();
 			this._gradeType = (entity.gradeType() || 'Points').toLowerCase();
@@ -208,7 +211,12 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 			this.setError(errorProperty, scoreErrorLangterm, tooltipId);
 		} else {
 			this.clearError(errorProperty);
-			this.wrapSaveAction(super._entity.setScoreOutOf(scoreOutOf, this._inGrades));
+			this._debounceJobs.scoreOutOf = Debouncer.debounce(
+				this._debounceJobs.scoreOutOf,
+				timeOut.after(500),
+				() => this.wrapSaveAction(super._entity.setScoreOutOf(scoreOutOf, this._inGrades))
+			);
+
 		}
 	}
 
@@ -262,6 +270,7 @@ class ActivityScoreEditor extends ErrorHandlingMixin(SaveStatusMixin(EntityMixin
 						value="${this._scoreOutOf}"
 						size=4
 						@change="${this._onScoreOutOfChanged}"
+						@blur="${this._onScoreOutOfChanged}"
 						aria-invalid="${this._isError() ? 'true' : ''}"
 						?disabled="${!this._canEditScoreOutOf}"
 					></d2l-input-text>


### PR DESCRIPTION
Edge was not getting the `change` event, but it does get the `blur` event. Debouncer is used to avoid 2 api calls for browsers that handle both events. Fixes https://trello.com/c/M6haUaoT/59-edge-only-add-to-grades-doesnt-autosave