### PR TITLE
US111908 Add Record Video button

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-attachments/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/lang/en.js
@@ -8,5 +8,6 @@ export default {
 	"addQuicklink": "Attach Link to Existing Activity", // Tooltip for a button that adds a link to an existing activity
 	"back": "Back", // Text for a back button
 	"closeDialog": "Close Dialog", // ARIA text for button to close dialog
+	"recordVideo": "Record Video", // Text for a button that opens a dialog to record video
 	"save": "Save", // Text for a save button
 };


### PR DESCRIPTION
Per title, this adds the "Record Video" button to the attachments picker, and hooks up the dialog opener and dialog callback. This workflow is very similar to the workflow for adding files.