### PR TITLE
Polish the Add Activity Dialogue

### DIFF
--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -197,8 +197,11 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 		this.clearAllSelected();
 	}
 
-	loadMore() {
-		this.getCandidates(this._actionCollectionEntity.getNextAction());
+	async loadMore() {
+		const lastItem = this.shadowRoot.querySelector('d2l-dialog d2l-list d2l-list-item:last-of-type');
+		await this.getCandidates(this._actionCollectionEntity.getNextAction());
+		await this.updateComplete;
+		lastItem.nextElementSibling.focus();
 	}
 
 	async open() {

--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -282,7 +282,22 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 				white-space: nowrap;
 			}
 			.d2l-add-activity-dialog {
+				align-content: start;
+				align-items: start;
+				display: grid;
+				grid-template-areas: "." "list" ".";
+				grid-template-columns: 100%;
 				min-height: 500px;
+  				grid-template-rows: auto auto auto;
+			}
+			.d2l-add-activity-dialog-list-disabled,
+			.d2l-add-activity-dialog d2l-loading-spinner,
+			.d2l-add-activity-dialog d2l-list {
+				grid-area: list;
+			}
+			.d2l-add-activity-dialog-list-disabled {
+				filter: grayscale(100%);
+				opacity: 0.6;
 			}
 			.d2l-add-activity-dialog-header {
 				align-items: baseline;
@@ -291,7 +306,7 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 				padding-bottom: 10px;
 			}
 			.d2l-add-activity-dialog-load-more {
-				padding-top: 10px;
+				margin: 10px 0;
 			}
 			.d2l-add-activity-dialog-selection-count {
 				color: var(--d2l-color-ferrite);
@@ -605,7 +620,7 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 					<d2l-list-item-content>
 						${candidate.organization.name()}
 						<div slot="secondary" class="d2l-list-item-secondary">${candidate.alreadyAdded ? html`${this.localize('alreadyAdded')}` : null}</div>
-					<d2l-list-item-content>
+					</d2l-list-item-content>
 				</d2l-list-item>
 			`;
 		});
@@ -642,9 +657,21 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 
 	_renderCandidates() {
 		this.updateComplete.then(() => {
-			this._oldDom = this.shadowRoot.querySelector('.d2l-add-activity-dialog d2l-list');
+			this._currentCandidateElement = this.shadowRoot.querySelector('.d2l-add-activity-dialog d2l-list');
 		});
-		const candidates = this._handleFirstLoad(this._renderCandidateItems.bind(this), () => html`<d2l-loading-spinner></d2l-loading-spinner>${this._oldDom}`, this._candidateFirstLoad, this._candidateLoad);
+		const candidates = this._handleFirstLoad(this._renderCandidateItems.bind(this),
+			() => {
+				this._currentCandidateElement && this._currentCandidateElement.querySelectorAll('d2l-list-item').forEach(element => element.toggleAttribute('disabled', true));
+				return html`
+					<div class="d2l-add-activity-dialog-list-disabled">
+						${this._currentCandidateElement}
+					</div>
+					<d2l-loading-spinner size="100"></d2l-loading-spinner>
+				`
+			},
+			this._candidateFirstLoad,
+			this._candidateLoad
+		);
 
 
 		const spaceKeyDown = 32;

--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -37,6 +37,7 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 		this._currentSelection = {};
 		this._specialization = {};
 		this._organizationImageChunk = {};
+		this._loaded = false;
 		this._loadedImages = [];
 		this._mainPageLoad = new Promise(() => null);
 		this._candidateLoad = new Promise(() => null);

--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -47,6 +47,7 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 		this.ariaBusy = 'true';
 		this.ariaLive = 'polite';
 		this._dialogOpen = false;
+		this._candidateItemsLoading = false;
 		this._setEntityType(ActivityUsageEntity);
 	}
 
@@ -130,11 +131,12 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 	}
 
 	async getCandidates(action, fields = null, clearList = false) {
-		if (clearList) {
-			this._candidateFirstLoad = false;
-		}
 		if (!this._collection) {
 			return;
+		}
+		this._candidateItemsLoading = true;
+		if (clearList) {
+			this._candidateFirstLoad = false;
 		}
 		const resp = await performSirenAction(this.token, action, fields, true);
 		this._actionCollectionEntity = new ActionCollectionEntity(this._collection, resp);
@@ -160,6 +162,7 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 		}
 		this._loadedImages[imageChunk].total = totalInLoadingChunk;
 		this._candidateFirstLoad = true;
+		this._candidateItemsLoading = false;
 	}
 
 	async addActivities() {
@@ -215,6 +218,7 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 			_name: { type: String },
 			_selectionCount: { type: Number },
 			_candidateLoad: { type: Object },
+			_candidateItemsLoading: {type: Boolean},
 			ariaBusy: { type: String, reflect: true, attribute: 'aria-busy' },
 			ariaLive: { type: String, reflect: true, attribute: 'aria-live' }
 		};
@@ -702,7 +706,7 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 		return html`
 			<div class="dialog-div">
 				<d2l-dialog id="dialog" title-text="${this.localize('browseActivityLibrary')}" @d2l-dialog-close=${this.clearDialog}>
-					<div class="d2l-add-activity-dialog">
+					<div class="d2l-add-activity-dialog" aria-live="polite" aria-busy="${this._candidateItemsLoading}">
 						<div class="d2l-add-activity-dialog-header">
 							<div>
 								<d2l-input-search label="${this.localize('search')}" @d2l-input-search-searched=${this.handleSearch}></d2l-input-search>

--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -2,9 +2,6 @@ import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { ifDefined } from 'lit-html/directives/if-defined';
 import { repeat } from 'lit-html/directives/repeat';
 import { until } from 'lit-html/directives/until.js';
-import { guard } from 'lit-html/directives/guard';
-import { cache } from 'lit-html/directives/cache.js';
-
 import { heading1Styles, heading4Styles, bodyCompactStyles, bodyStandardStyles, labelStyles} from '@brightspace-ui/core/components/typography/styles.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { ActivityUsageEntity } from 'siren-sdk/src/activities/ActivityUsageEntity.js';
@@ -671,7 +668,7 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 						${this._currentCandidateElement}
 					</div>
 					<d2l-loading-spinner size="100"></d2l-loading-spinner>
-				`
+				`;
 			},
 			this._candidateFirstLoad,
 			this._candidateLoad
@@ -681,12 +678,10 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 			() => this._actionCollectionEntity && this._actionCollectionEntity.getNextAction()
 				? html`<d2l-button @click=${this.loadMore}>${this.localize('loadMore')}</d2l-button>`
 				: null,
-
 			() => null,
 			this._candidateFirstLoad,
 			this._candidateLoad
 		);
-
 
 		const spaceKeyDown = 32;
 		const spaceKeyEnter = 13;

--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -673,6 +673,16 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 			this._candidateLoad
 		);
 
+		const loadMore = this._handleFirstLoad(
+			() => this._actionCollectionEntity && this._actionCollectionEntity.getNextAction()
+				? html`<d2l-button @click=${this.loadMore}>${this.localize('loadMore')}</d2l-button>`
+				: null,
+
+			() => null,
+			this._candidateFirstLoad,
+			this._candidateLoad
+		);
+
 
 		const spaceKeyDown = 32;
 		const spaceKeyEnter = 13;
@@ -701,7 +711,7 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 						</div>
 						${candidates}
 						<div class="d2l-add-activity-dialog-load-more">
-							${this._actionCollectionEntity && this._actionCollectionEntity.getNextAction() ? html`<d2l-button @click=${this.loadMore}>${this.localize('loadMore')}</d2l-button>` :	null}
+							${loadMore}
 						</div>
 					</div>
 


### PR DESCRIPTION
- Add Activities Dialogue: Already added courses are misaligned from those that haven't already been added to the LP.
- Add Activities Dialogue: The Clear Selection link is not accessible when using keyboard navigation. It also isn't read out by a screen reader.
- Add Activities Dialogue: Clicking on the Add button with nothing actually selected results in a 400 error being sent. This button should probably be disabled until something is selected.
- Add Activities Dialogue > Search for Activities: Selecting activities, search for more, select more activities, click Add > The first set of activities doesn't get added to the LP.
- Add Activities Dialogue > The 'Load More' button highlight (While using keyboard navigation) has the bottom part of the border cut off:
- Loading styles have been added to the Add Activities Dialogue.
