### PR TITLE
Small fixes

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -83,6 +83,53 @@ class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LitElement))
 			e.detail.provider = this.htmlEditorEnabled;
 			e.stopPropagation();
 		}
+
+		// Provides unfurl API endpoint for d2l-labs-attachment component
+		// https://github.com/Brightspace/attachment/blob/e44cab1f0cecc55dd93acf59212fabc6872c0bd3/components/attachment.js#L110
+		if (e.detail.key === 'd2l-provider-unfurl-api-endpoint') {
+			e.detail.provider = () => this.unfurlEndpoint;
+			e.stopPropagation();
+			return;
+		}
+
+		// Provides function to validate if a URL is trusted for d2l-labs-attachment
+		// https://github.com/Brightspace/attachment/blob/e44cab1f0cecc55dd93acf59212fabc6872c0bd3/components/attachment.js#L115
+		if (e.detail.key === 'd2l-provider-trusted-site-fn') {
+			e.detail.provider = () => url => {
+				const origin = new URL(url).origin;
+				const unfilteredContent = `<iframe src="${origin}"></iframe>`;
+
+				return new Promise((resolve, reject) => {
+					const params = {
+						filterMode: 1, // strict mode for html filtering. Refer to D2L.LP.TextProcessing.FilterModes
+						html: unfilteredContent
+					};
+					const options = {
+						success: resolve,
+						failure: reject
+					};
+					D2L.LP.Web.UI.Rpc.Connect(
+						D2L.LP.Web.UI.Rpc.Verbs.POST,
+						new D2L.LP.Web.Http.UrlLocation(this.trustedSitesEndpoint),
+						params,
+						options
+					);
+				}).then(filteredContent => {
+					const matchSrc = function(str) {
+						// excludes matching query string as filterHtml may modify the query string
+						return str.match(/src=["']([^?"']+)/i);
+					};
+					const unfilteredMatch = matchSrc(unfilteredContent);
+					const unfilteredSrc = unfilteredMatch && unfilteredMatch.length === 2 && unfilteredMatch[1];
+
+					const filteredMatch = matchSrc(filteredContent);
+					const filteredSrc = filteredMatch && filteredMatch.length === 2 && filteredMatch[1];
+
+					return unfilteredSrc === filteredSrc;
+				});
+			};
+			e.stopPropagation();
+		}
 	}
 
 	_onPendingResolved() {

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -1,18 +1,12 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { getLocalizeResources } from './localization';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 
-class ActivityEditor extends LitElement {
+class ActivityEditor extends LocalizeMixin(LitElement) {
 
 	static get properties() {
 		return {
-			loading: { type: Boolean },
-			/**
-			 * API endpoint for attachment unfurling service
-			 */
-			unfurlEndpoint: { type: String },
-			/**
-			 * API endpoint for determining whether a domain is trusted
-			 */
-			trustedSitesEndpoint: { type: String },
+			loading: { type: Boolean }
 		};
 	}
 
@@ -35,60 +29,14 @@ class ActivityEditor extends LitElement {
 		`;
 	}
 
-	_onRequestProvider(e) {
-		// Provides unfurl API endpoint for d2l-labs-attachment component
-		// https://github.com/Brightspace/attachment/blob/e44cab1f0cecc55dd93acf59212fabc6872c0bd3/components/attachment.js#L110
-		if (e.detail.key === 'd2l-provider-unfurl-api-endpoint') {
-			e.detail.provider = () => this.unfurlEndpoint;
-			e.stopPropagation();
-			return;
-		}
-
-		// Provides function to validate if a URL is trusted for d2l-labs-attachment
-		// https://github.com/Brightspace/attachment/blob/e44cab1f0cecc55dd93acf59212fabc6872c0bd3/components/attachment.js#L115
-		if (e.detail.key === 'd2l-provider-trusted-site-fn') {
-			e.detail.provider = () => url => {
-				const origin = new URL(url).origin;
-				const unfilteredContent = `<iframe src="${origin}"></iframe>`;
-
-				return new Promise((resolve, reject) => {
-					const params = {
-						filterMode: 1, // strict mode for html filtering. Refer to D2L.LP.TextProcessing.FilterModes
-						html: unfilteredContent
-					};
-					const options = {
-						success: resolve,
-						failure: reject
-					};
-					D2L.LP.Web.UI.Rpc.Connect(
-						D2L.LP.Web.UI.Rpc.Verbs.POST,
-						new D2L.LP.Web.Http.UrlLocation(this.trustedSitesEndpoint),
-						params,
-						options
-					);
-				}).then(filteredContent => {
-					const matchSrc = function(str) {
-						// excludes matching query string as filterHtml may modify the query string
-						return str.match(/src=["']([^?"']+)/i);
-					};
-					const unfilteredMatch = matchSrc(unfilteredContent);
-					const unfilteredSrc = unfilteredMatch && unfilteredMatch.length === 2 && unfilteredMatch[1];
-
-					const filteredMatch = matchSrc(filteredContent);
-					const filteredSrc = filteredMatch && filteredMatch.length === 2 && filteredMatch[1];
-
-					return unfilteredSrc === filteredSrc;
-				});
-			};
-			e.stopPropagation();
-		}
+	static async getLocalizeResources(langs) {
+		return getLocalizeResources(langs, import.meta.url);
 	}
 
 	render() {
 		return html`
-			<div class="d2l-activity-editor-loading" ?hidden="${!this.loading}">Loading ...</div>
-			<div
-				@d2l-request-provider="${this._onRequestProvider}">
+			<div class="d2l-activity-editor-loading" ?hidden="${!this.loading}">${this.localize('loading')}</div>
+			<div>
 				<slot name="editor"></slot>
 			</div>
 		`;

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -21,5 +21,6 @@ export default {
 	"setUngraded": "Set Ungraded", // Menu item for setting the activity to ungraded
 	"scoreOutOf": "Score Out Of", // ARIA label for the score out of field, when creating/editing an activity
 	"emptyScoreOutOfError": "A points value must be specified for activities in Grades", // Error message to inform user that the score out of value is a required field when a grade item is associated
-	"invalidScoreOutOfError": "Score Out Of must be greater than or equal to 0.01 and less than or equal to 9,999,999,999" // Error message when an invalid score out of value is entered
+	"invalidScoreOutOfError": "Score Out Of must be greater than or equal to 0.01 and less than or equal to 9,999,999,999", // Error message when an invalid score out of value is entered
+	"loading": "Loading...", // Message displayed while page is loading
 };


### PR DESCRIPTION
- Localize the "Loading..." message when the page first loads (this isn't the final loading state, but this was 30 seconds to fix so figured might as well)
- Move the providing of `unfurlEndpoint` and `trustedSitesEndpoint` up one level, so that `d2l-activity-editor` doesn't need to know about it