### PR TITLE
get rid of lang-experimental export

### DIFF
--- a/activities.serge.json
+++ b/activities.serge.json
@@ -63,7 +63,7 @@
     },
     "source_match": "en\\.js$",
     "source_dir": "components/d2l-quick-eval/build/lang",
-    "output_file_path": "components/d2l-quick-eval/lang-experimental/%LANG%.js",
+    "output_file_path": "components/d2l-quick-eval/build/lang/%LANG%.js",
     "output_lang_rewrite": [
       "ar-sa ar",
       "de-de de",


### PR DESCRIPTION
This should direct the serge to export into the quick-eval build directory, since it seems that there are less issues with the `parse_js` plugin. This means you wouldn't have to convert the json files into js (though the json files will still get all the new lang terms).