### PR TITLE
Update the gulpfile to export from en.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "async": "^1.5.2",
     "axe-core": "^3.3.2",
     "babel-eslint": "^10.0.1",
+    "babel-preset-env": "^1.7.0",
+    "babel-register": "^6.26.0",
     "chai": "^4.2.0",
     "eslint": "^5.1.0",
     "eslint-config-brightspace": "^0.6",

--- a/templates/lang-mixin.ejs
+++ b/templates/lang-mixin.ejs
@@ -1,2 +1,1 @@
-export const Lang<%- data.properLang %> = <%- data.resources %>;
-
+export const <%- data.properLang %> = <%- data.resources %>;


### PR DESCRIPTION
Since json lang files are being phased out, I updated the `gulpfile` to fill in any missing lang terms in the other js files from `en.js`. It is supposed replace the need for https://github.com/BrightspaceHypermediaComponents/activities/pull/451 but this is meant for js files.

This PR should be merged first though: https://github.com/BrightspaceHypermediaComponents/activities/pull/611