### PR TITLE
US112481- Get filter whitelist from the LMS

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -128,7 +128,7 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 				<d2l-hm-filter
 					href="[[filterHref]]"
 					token="[[token]]"
-					category-whitelist="[[_filterIds]]"
+					category-whitelist="[[filterIds]]"
 					lazy-load-options>
 				</d2l-hm-filter>
 				<d2l-hm-search
@@ -203,9 +203,9 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 				type: Array,
 				value: []
 			},
-			_filterIds: {
+			filterIds: {
 				type: Array,
-				value: [ 'c806bbc6-cfb3-4b6b-ae74-d5e4e319183d', 'f2b32f03-556a-4368-945a-2614b9f41f76' ]
+				value: []
 			},
 			_searchResultsCount: {
 				type: Number,
@@ -255,10 +255,6 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 			courseLevel: {
 				type: Boolean,
 				value: false
-			},
-			activityFilters: {
-				type: Array,
-				value: []
 			}
 		};
 	}

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -98,7 +98,7 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 				<d2l-hm-filter
 					href="[[filterHref]]"
 					token="[[token]]"
-					category-whitelist="[[_filterIds]]"
+					category-whitelist="[[filterIds]]"
 					result-size="[[_numberOfActivitiesToShow]]"
 					lazy-load-options>
 				</d2l-hm-filter>
@@ -188,9 +188,9 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 				computed: '_computeNumberOfActivitiesToShow(_data, _numberOfActivitiesToShow)',
 				value: 20
 			},
-			_filterIds: {
+			filterIds: {
 				type: Array,
-				computed: '_getFilterIds(masterTeacher)'
+				value: []
 			},
 			_searchResultsCount: {
 				type: Number,
@@ -267,10 +267,6 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 			courseLevelName: {
 				type: String,
 				value: ''
-			},
-			submissionFilters: {
-				type: Array,
-				value: []
 			}
 		};
 	}
@@ -479,15 +475,6 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 		} else {
 			return Promise.reject(new Error(`Could not find sortable header for ${headerId}`));
 		}
-	}
-
-	_getFilterIds(masterTeacher) {
-		// [ 'activity-name', 'enrollments', 'completion-date' ]
-		let filters = [ 'c806bbc6-cfb3-4b6b-ae74-d5e4e319183d', 'f2b32f03-556a-4368-945a-2614b9f41f76', '05de346e-c94d-4e4b-b887-9c86c9a80351' ];
-		if (masterTeacher) {
-			filters = filters.concat('35b3aca0-c10c-436d-b369-c8a3022455e3'); // [ 'primary-facilitator' ]
-		}
-		return filters;
 	}
 
 	// @override - do not change the name

--- a/components/d2l-quick-eval/d2l-quick-eval.js
+++ b/components/d2l-quick-eval/d2l-quick-eval.js
@@ -73,7 +73,7 @@ class D2LQuickEval extends
 				returning-to-quick-eval="[[returningToQuickEval]]"
 				course-level="[[courseLevel]]"
 				course-level-name="[[courseLevelName]]"
-				submission-filters="[[submissionFilters]]"></d2l-quick-eval-submissions>
+				filter-ids="[[submissionFilters]]"></d2l-quick-eval-submissions>
 			<d2l-quick-eval-activities
 				href="[[_lazyActivitiesHref]]"
 				token="[[token]]"
@@ -81,7 +81,7 @@ class D2LQuickEval extends
 				hidden$="[[!_displayActivities(toggleState, activitiesViewEnabled)]]"
 				dismiss-enabled="[[dismissEnabled]]"
 				course-level="[[courseLevel]]"
-				activity-filters="[[activityFilters]]"></d2l-quick-eval-activities>
+				filter-ids="[[activityFilters]]"></d2l-quick-eval-activities>
 		`;
 	}
 

--- a/test/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -172,8 +172,4 @@ suite('d2l-quick-eval-activities', function() {
 		var alert = act.shadowRoot.querySelector('.d2l-quick-eval-activities-load-error-alert');
 		assert.equal(false, alert.hasAttribute('hidden'));
 	});
-	test('filter whitelist returns expected filters', () => {
-		const expectedFilters = [ 'c806bbc6-cfb3-4b6b-ae74-d5e4e319183d', 'f2b32f03-556a-4368-945a-2614b9f41f76' ];
-		assert.deepEqual(act._filterIds, expectedFilters);
-	});
 });


### PR DESCRIPTION
Problem: In course mode it doesn't really make sense to have a course filter (since activities are sourced from 1 course by design)
Solution: Get the valid filters from the LMS and use that as the whitelist