### PR TITLE
adding new lang term script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:polymer:local": "polymer test --skip-plugin sauce",
     "test:polymer:sauce": "polymer test --skip-plugin local",
     "test": "npm run lint && npm run test:polymer:local",
-    "serve": "polymer serve"
+    "serve": "polymer serve",
+    "clean-lang": "rm -rf components/d2l-activity-collection-editor/lang/* && rm -rf components/d2l-activity-editor/d2l-activity-assignment-editor/lang/* && rm -rf components/d2l-activity-editor/d2l-activity-attachments/lang/* && rm -rf components/d2l-activity-editor/lang/* && rm -rf components/d2l-activity-evaluation-icon/build/lang/* && rm -rf components/d2l-activity-list-item/build/lang/* && rm -rf components/d2l-quick-eval/build/lang/*"
   },
   "author": "D2L Corporation",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "test:polymer:sauce": "polymer test --skip-plugin local",
     "test": "npm run lint && npm run test:polymer:local",
     "serve": "polymer serve",
-    "clean-lang": "rm -rf components/d2l-activity-collection-editor/lang/* && rm -rf components/d2l-activity-editor/d2l-activity-assignment-editor/lang/* && rm -rf components/d2l-activity-editor/d2l-activity-attachments/lang/* && rm -rf components/d2l-activity-editor/lang/* && rm -rf components/d2l-activity-evaluation-icon/build/lang/* && rm -rf components/d2l-activity-list-item/build/lang/* && rm -rf components/d2l-quick-eval/build/lang/*"
+    "clean-lang": "rm -rf components/d2l-activity-collection-editor/lang/* components/d2l-activity-editor/d2l-activity-assignment-editor/lang/* components/d2l-activity-editor/d2l-activity-attachments/lang/* components/d2l-activity-editor/lang/* components/d2l-activity-evaluation-icon/build/lang/* components/d2l-activity-list-item/build/lang/* components/d2l-quick-eval/build/lang/*",
+    "reset-lang": "git checkout components/d2l-activity-collection-editor/lang/* components/d2l-activity-editor/d2l-activity-assignment-editor/lang/* components/d2l-activity-editor/d2l-activity-attachments/lang/* components/d2l-activity-editor/lang/* components/d2l-activity-evaluation-icon/build/lang/* components/d2l-activity-list-item/build/lang/* components/d2l-quick-eval/build/lang/*",
+    "build-no-lang": "npm run clean-lang && npm run build && npm run reset-lang" 
   },
   "author": "D2L Corporation",
   "license": "Apache-2.0",


### PR DESCRIPTION
This is a solution around the issues of adding a lang term and `npm run build` not working properly. gulp will not run because of the es6 keywords in the lang term js files. The way to solve this is to delete all of the js files for lang terms temporarily and then restore them after you have completed the build.