### PR TITLE
Guarded editors from closing on property change

### DIFF
--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -2,6 +2,7 @@ import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { ifDefined } from 'lit-html/directives/if-defined';
 import { repeat } from 'lit-html/directives/repeat';
 import { until } from 'lit-html/directives/until.js';
+import { guard } from 'lit-html/directives/guard';
 import { heading1Styles, heading4Styles, bodyCompactStyles, bodyStandardStyles, labelStyles} from '@brightspace-ui/core/components/typography/styles.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { ActivityUsageEntity } from 'siren-sdk/src/activities/ActivityUsageEntity.js';
@@ -548,8 +549,10 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 					<div class="d2l-heading-4 d2l-activity-collection-sub-header">${this.localize('editLearningPath')}</div>
 					<div class="d2l-activity-collection-base-info">
 						<div class="d2l-activity-collection-header-col1" style="position: relative">
-							${until(learningPathTitle, learningPathTitleSketeton)}
-							${until(learningPathDescription, learningPathDescriptionSketeton)}
+							${guard([this._loaded], () => html`
+								${until(learningPathTitle, learningPathTitleSketeton)}
+								${until(learningPathDescription, learningPathDescriptionSketeton)}
+							`)}
 						</div>
 						${learningPathVisibilityToggle}
 					</div>


### PR DESCRIPTION
Guard has been introduced around the `edit-in-place` components.

Currently, the title and description are reset each time a property is assigned due to being rendered asynchronously via promise fulfillment.
To the user, adding activities, saving either the title or description, or toggling visibility, would close any other open edit mode title or description.

This guard prevents re-rendering and resetting the components except when the page has finished loading, ensuring the edit in place editors do not close unexpectedly during use.

