### PR TITLE
Use new announce-text attribute for all d2l-alert-toast tags

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -185,14 +185,14 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 			</d2l-dialog-confirm>
 			<d2l-quick-eval-action-dismiss-dialog></d2l-quick-eval-action-dismiss-dialog>
 			<d2l-alert-toast 
-				id="toast-dismiss-success"
+				class="toast-dismiss-success"
 				type="success"
 				announce-text="[[localize('activityDismissed')]]"
 				>
 				[[localize('activityDismissed')]]
 			</d2l-alert-toast>
 			<d2l-alert-toast 
-				id="toast-dismiss-critical"
+				class="toast-dismiss-critical"
 				type="critical"
 				announce-text="[[localize('failedToDismissActivity')]]"
 				>
@@ -479,9 +479,9 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 
 			return dismissAction.then(() => {
 				window.dispatchEvent(new CustomEvent('d2l-quick-eval-refresh'));
-				this.shadowRoot.querySelector('#toast-dismiss-success').open = true;
+				this.shadowRoot.querySelector('.toast-dismiss-success').open = true;
 			}).catch((error) => {
-				this.shadowRoot.querySelector('#toast-dismiss-critical').open = true;
+				this.shadowRoot.querySelector('.toast-dismiss-critical').open = true;
 				this._logError(error, {developerMessage: `Error dismissing activity href ${evt.detail.dismissHref}`});
 			});
 		});

--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -185,14 +185,14 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 			</d2l-dialog-confirm>
 			<d2l-quick-eval-action-dismiss-dialog></d2l-quick-eval-action-dismiss-dialog>
 			<d2l-alert-toast 
-				class="toast-dismiss-success"
+				class="d2l-quick-eval-activities-toast-dismiss-success"
 				type="success"
 				announce-text="[[localize('activityDismissed')]]"
 				>
 				[[localize('activityDismissed')]]
 			</d2l-alert-toast>
 			<d2l-alert-toast 
-				class="toast-dismiss-critical"
+				class="d2l-quick-eval-activities-toast-dismiss-critical"
 				type="critical"
 				announce-text="[[localize('failedToDismissActivity')]]"
 				>
@@ -479,9 +479,9 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 
 			return dismissAction.then(() => {
 				window.dispatchEvent(new CustomEvent('d2l-quick-eval-refresh'));
-				this.shadowRoot.querySelector('.toast-dismiss-success').open = true;
+				this.shadowRoot.querySelector('.d2l-quick-eval-activities-toast-dismiss-success').open = true;
 			}).catch((error) => {
-				this.shadowRoot.querySelector('.toast-dismiss-critical').open = true;
+				this.shadowRoot.querySelector('.d2l-quick-eval-activities-toast-dismiss-critical').open = true;
 				this._logError(error, {developerMessage: `Error dismissing activity href ${evt.detail.dismissHref}`});
 			});
 		});

--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -184,11 +184,29 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 				<d2l-button slot="footer" dialog-action="no">[[localize('no')]]</d2l-button>
 			</d2l-dialog-confirm>
 			<d2l-quick-eval-action-dismiss-dialog></d2l-quick-eval-action-dismiss-dialog>
-			<d2l-alert-toast id="toast-dismiss-success" type="success">[[localize('activityDismissed')]]</d2l-alert-toast>
-			<d2l-alert-toast id="toast-dismiss-critical" type="critical">[[localize('failedToDismissActivity')]]</d2l-alert-toast>
+			<d2l-alert-toast 
+				id="toast-dismiss-success"
+				type="success"
+				announce-text="[[localize('activityDismissed')]]"
+				>
+				[[localize('activityDismissed')]]
+			</d2l-alert-toast>
+			<d2l-alert-toast 
+				id="toast-dismiss-critical"
+				type="critical"
+				announce-text="[[localize('failedToDismissActivity')]]"
+				>
+				[[localize('failedToDismissActivity')]]
+			</d2l-alert-toast>
 			<dom-repeat items="[[_publishAllToasts]]" as="toast">
 				<template>
-					<d2l-alert-toast type="default" open>[[_publishAllToastMessage(toast)]]</d2l-alert-toast>
+					<d2l-alert-toast 
+						type="default" 
+						open 
+						announce-text="[[_publishAllToastMessage(toast)]]"
+						>
+						[[_publishAllToastMessage(toast)]]
+					</d2l-alert-toast>
 				</template>
 			</dom-repeat>
 		`;

--- a/components/d2l-quick-eval/dismiss/d2l-quick-eval-dismissed-activities.js
+++ b/components/d2l-quick-eval/dismiss/d2l-quick-eval-dismissed-activities.js
@@ -30,8 +30,8 @@ class D2LQuickEvalDismissedActivities extends mixinBehaviors(
 				loading="[[_loading]]"
 				restore-disabled= "[[_restoreDisabled]]"
 				on-d2l-quick-eval-dismissed-activity-selected="_handleListItemSelected"></d2l-quick-eval-ellipsis-dialog>
-			<d2l-alert-toast class="d2l-quick-eval-dismissed-list-success" type="success">[[successMessage]]</d2l-alert-toast>
-			<d2l-alert-toast class="d2l-quick-eval-dismissed-list-critical" type="critical">[[failedMessage]]</d2l-alert-toast>
+			<d2l-alert-toast class="d2l-quick-eval-dismissed-list-success" type="success" announce-text="[[successMessage]]">[[successMessage]]</d2l-alert-toast>
+			<d2l-alert-toast class="d2l-quick-eval-dismissed-list-critical" type="critical" announce-text="[[failedMessage]]">[[failedMessage]]</d2l-alert-toast>
 		`;
 
 		quickEvalActivitiesTemplate.setAttribute('strip-whitespace', 'strip-whitespace');


### PR DESCRIPTION
Part 2 of: [US112559](https://rally1.rallydev.com/#/detail/userstory/356908493924?fdp=true): [Dismiss][UI] A11y Quick Eval Toast message when activity is dismissed is not being read by screen readers

Part 1 is over here: https://github.com/BrightspaceUI/alert/pull/34