### PR TITLE
make visibility text more descriptive

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-visibility-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-visibility-editor.js
@@ -66,11 +66,12 @@ class ActivityVisibilityEditor extends SaveStatusMixin(EntityMixinLit(LocalizeMi
 	render() {
 
 		const switchVisibilityText = (this._isDraft ? this.localize('hidden') : this.localize('visible'));
+		const switchVisibilityTextAria = (this._isDraft ? this.localize('ariaHidden') : this.localize('ariaVisible'));
 		const icon = (this._isDraft ? 'tier1:visibility-hide' : 'tier1:visibility-show');
 		const switchEnabled = this._canEditDraft && !this.disabled
 			? html`
 				<d2l-switch
-					aria-label="${switchVisibilityText}"
+					aria-label="${switchVisibilityTextAria}"
 					label-right
 					.checked=${!this._isDraft}
 					@click="${this._updateVisibility}">

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -8,11 +8,11 @@ export default {
 	"dueTime": "Due Time", // ARIA label for the due time field when creating/editing an activity
 	"endTime": "End Time", // ARIA label for the due time field when creating/editing an activity
 	"startTime": "Start Time", // ARIA label for the due time field when creating/editing an activity
-	"hidden": "Hidden", // Label displayed with the visibility switch when hidden
+	"hidden": "Hidden from students", // Label displayed with the visibility switch when hidden
 	"noDueDate": "No due date", // Placeholder text for due date field when no due date is set
 	"noEndDate": "No end date", // Placeholder text for due date field when no due date is set
 	"noStartDate": "No start date", // Placeholder text for due date field when no due date is set
-	"visible": "Visible", // Label displayed with the visibility switch when visible
+	"visible": "Visible to students", // Label displayed with the visibility switch when visible
 	"ungraded": "Ungraded", // State of score field when there is no score and no grade item, when creating/editing an activity
 	"inGrades": "In Grades", // State of the grades field when there is a score, and an associated grade item
 	"notInGrades": "Not in Grades", // State of the grades field when there is a score, but no associated grade item

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -8,11 +8,13 @@ export default {
 	"dueTime": "Due Time", // ARIA label for the due time field when creating/editing an activity
 	"endTime": "End Time", // ARIA label for the due time field when creating/editing an activity
 	"startTime": "Start Time", // ARIA label for the due time field when creating/editing an activity
-	"hidden": "Hidden from students", // Label displayed with the visibility switch when hidden
+	"hidden": "Hidden", // Label displayed with the visibility switch when hidden
+	"ariaHidden": "Hidden from students", // Aria Label for the visibility switch when hidden
 	"noDueDate": "No due date", // Placeholder text for due date field when no due date is set
 	"noEndDate": "No end date", // Placeholder text for due date field when no due date is set
 	"noStartDate": "No start date", // Placeholder text for due date field when no due date is set
-	"visible": "Visible to students", // Label displayed with the visibility switch when visible
+	"visible": "Visible", // Label displayed with the visibility switch when visible
+	"ariaVisible": "Visible to students", // Aria Label for the visibility switch when visible
 	"ungraded": "Ungraded", // State of score field when there is no score and no grade item, when creating/editing an activity
 	"inGrades": "In Grades", // State of the grades field when there is a score, and an associated grade item
 	"notInGrades": "Not in Grades", // State of the grades field when there is a score, but no associated grade item


### PR DESCRIPTION
Fixes https://trello.com/c/WDvmeiLc/74-a11y-label-of-visibility-control. The text needs to be more descriptive for screen reader users, as it is unclear what is "hidden".