### PR TITLE
add aria instructions for editor toolbar use

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-html-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-editor.js
@@ -1,9 +1,11 @@
 import 'd2l-html-editor/d2l-html-editor.js';
 import 'd2l-html-editor/d2l-html-editor-client.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { getLocalizeResources } from './localization.js';
 import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 
-class ActivityHtmlEditor extends LitElement {
+class ActivityHtmlEditor extends LocalizeMixin(LitElement) {
 
 	static get properties() {
 		return {
@@ -115,6 +117,10 @@ class ActivityHtmlEditor extends LitElement {
 		`;
 	}
 
+	static async getLocalizeResources(langs) {
+		return getLocalizeResources(langs, import.meta.url);
+	}
+
 	constructor() {
 		super();
 		this._htmlEditorUniqueId = `htmleditor-${getUniqueId()}`;
@@ -177,11 +183,12 @@ class ActivityHtmlEditor extends LitElement {
 				toolbar="bold italic bullist d2l_isf"
 				plugins="lists paste d2l_isf">
 
-				<div id="toolbar-shortcut-${this._htmlEditorUniqueId}" hidden=""></div>
+				<div id="toolbar-shortcut-${this._htmlEditorUniqueId}" hidden="">${this.localize('ariaToolbarShortcutInstructions')}</div>
 				<div
 					class="d2l-html-editor-container"
 					id="${this._htmlEditorUniqueId}"
 					aria-label="${this.ariaLabel}"
+					aria-describedby="toolbar-shortcut-${this._htmlEditorUniqueId}"
 					?disabled="${this.disabled}"
 					role="textbox"
 					prevent-submit>

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -27,4 +27,5 @@ export default {
 	"loading": "Loading...", // Message displayed while page is loading
 	"ok": "Ok", // Text of dialog button to commit action
 	"cancel": "Cancel", // Text of dialog button to cancel action
+	"ariaToolbarShortcutInstructions": "Press ALT-F10 for toolbar, and press ESC to exit toolbar once inside." // Instructions for screenreader users on how to enter and exit the html editor toolbar
 };


### PR DESCRIPTION
Addresses https://trello.com/c/mrm60BMG/69-facea11y1-the-instructions-html-editor-toolbar-appeared-to-be-at-the-end-of-the-page-and-the-toolbar-doesnt-have-a-skip-link-cap by adding instructions on how to enter and exit the toolbar when using a screenreader.