### PR TITLE
simplify initial activity render and move PendingContainerMixin to ac…

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -7,9 +7,8 @@ import 'd2l-save-status/d2l-save-status.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { AssignmentActivityUsageEntity } from 'siren-sdk/src/activities/assignments/AssignmentActivityUsageEntity.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
-import { PendingContainerMixin } from 'siren-sdk/src/mixin/pending-container-mixin.js';
 
-class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LitElement)) {
+class AssignmentEditor extends EntityMixinLit(LitElement) {
 
 	static get properties() {
 		return {
@@ -25,8 +24,7 @@ class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LitElement))
 			 * API endpoint for determining whether a domain is trusted
 			 */
 			trustedSitesEndpoint: { type: String },
-			_assignmentHref: { type: String },
-			_initialLoadComplete: { type: Boolean }
+			_assignmentHref: { type: String }
 		};
 	}
 
@@ -132,20 +130,12 @@ class AssignmentEditor extends PendingContainerMixin(EntityMixinLit(LitElement))
 		}
 	}
 
-	_onPendingResolved() {
-		// Once we've loaded the page once, this prevents us from ever showing
-		// the "Loading..." div again, even if page components are (re)loading
-		this._initialLoadComplete = true;
-	}
-
 	render() {
 		return html`
 			<d2l-activity-editor
-				?loading="${this._hasPendingChildren && !this._initialLoadComplete}"
 				unfurlEndpoint="${this.unfurlEndpoint}"
 				trustedSitesEndpoint="${this.trustedSitesEndpoint}"
-				@d2l-request-provider="${this._onRequestProvider}"
-				@d2l-pending-resolved="${this._onPendingResolved}">
+				@d2l-request-provider="${this._onRequestProvider}">
 
 				<d2l-template-primary-secondary slot="editor">
 					<slot name="editor-nav" slot="header"></slot>

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -1,8 +1,9 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { getLocalizeResources } from './localization';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { PendingContainerMixin } from 'siren-sdk/src/mixin/pending-container-mixin.js';
 
-class ActivityEditor extends LocalizeMixin(LitElement) {
+class ActivityEditor extends PendingContainerMixin(LocalizeMixin(LitElement)) {
 
 	static get properties() {
 		return {
@@ -20,11 +21,6 @@ class ActivityEditor extends LocalizeMixin(LitElement) {
 			}
 			.d2l-activity-editor-loading {
 				padding: 20px;
-				position: fixed;
-				background-color: #fff;
-				width: 100%;
-				height: 100vh;
-				z-index: 100001;
 			}
 		`;
 	}
@@ -33,9 +29,29 @@ class ActivityEditor extends LocalizeMixin(LitElement) {
 		return getLocalizeResources(langs, import.meta.url);
 	}
 
+	constructor() {
+		super();
+		this.loading = true;
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		this.addEventListener('d2l-pending-resolved', this._onPendingResolved);
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		this.removeEventListener('d2l-pending-resolved', this._onPendingResolved);
+	}
+	_onPendingResolved() {
+		// Once we've loaded the page once, this prevents us from ever showing
+		// the "Loading..." div again, even if page components are (re)loading
+		this.loading = false;
+	}
 	render() {
-		return html`
-			<div class="d2l-activity-editor-loading" ?hidden="${!this.loading}">${this.localize('loading')}</div>
+		return this.loading ? html`
+			<div class="d2l-activity-editor-loading">${this.localize('loading')}</div>
+		` : html`
 			<div>
 				<slot name="editor"></slot>
 			</div>


### PR DESCRIPTION
…tivity editor.
In addition to simplifying rendering of "Loading..." versus editor page after fixing tabbie position issue in LMS, I moved the PendingContainerMixin to the activity editor, as that is what receives the events anyway, seemed cleaner to have those events handled directly in there. This fixes same issue as https://github.com/BrightspaceHypermediaComponents/activities/pull/594 (I didn't realize that PR was there when I did this fix).