### PR TITLE
Activity Editor mixins

### DIFF
--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
@@ -1,0 +1,28 @@
+export const ActivityEditorContainerMixin = superclass => class extends superclass {
+
+	constructor() {
+		super();
+		this.addEventListener('d2l-activity-editor-connected', this._registerEditor);
+		this.addEventListener('d2l-activity-editor-save', this._save);
+		this._editors = new Set();
+	}
+
+	_registerEditor(e) {
+		this._editors.add(e.detail.editor);
+		e.detail.container = this;
+		e.stopPropagation();
+	}
+
+	unregisterEditor(editor) {
+		this._editors.delete(editor);
+	}
+
+	async _save() {
+		for (const editor of this._editors) {
+			// TODO - Once we decide how we want to handle errors we may want to add error handling logic
+			// to the save
+			await editor.save();
+		}
+	}
+
+};

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
@@ -1,0 +1,56 @@
+export const ActivityEditorMixin = superclass => class extends superclass {
+
+	static get properties() {
+		return {
+			/**
+			 * Href for the component
+			 */
+			href: {
+				type: String,
+				reflect: true
+			},
+			/**
+			 * Token JWT Token for brightspace | a function that returns a JWT token for brightspace | null (defaults to cookie authentication in a browser)
+			 */
+			token: { type: String },
+		};
+	}
+
+	constructor() {
+		super();
+		this._container = null;
+	}
+
+	async save() {}
+
+	_dispatchActivityEditorEvent() {
+		const event = new CustomEvent('d2l-activity-editor-connected', {
+			detail: { editor: this },
+			bubbles: true,
+			composed: true,
+			cancelable: true
+		});
+		this.dispatchEvent(event);
+		if (event.detail.container) {
+			this._container = event.detail.container;
+		}
+	}
+
+	connectedCallback() {
+		if (super.connectedCallback) {
+			super.connectedCallback();
+		}
+
+		this._dispatchActivityEditorEvent();
+	}
+
+	disconnectedCallback() {
+		if (this._container) {
+			this._container.unregisterEditor(this);
+		}
+
+		if (super.disconnectedCallback) {
+			super.disconnectedCallback();
+		}
+	}
+};

--- a/test/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.html
+++ b/test/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-activity-editor-container-mixin tests</title>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+
+	</head>
+	<body>
+		<script type="module" src="./d2l-activity-editor-container-mixin.js"></script>
+	</body>
+</html>

--- a/test/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
+++ b/test/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
@@ -1,0 +1,44 @@
+import { defineCE, expect, fixture } from '@open-wc/testing';
+import { ActivityEditorContainerMixin} from '../../../components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js';
+
+const container = defineCE(
+	class extends ActivityEditorContainerMixin(HTMLElement) {
+	}
+);
+
+const editor = defineCE(
+	class extends HTMLElement {
+		save() {
+			this.saveCalled = true;
+		}
+	}
+);
+
+function connectedEvent(editor) {
+	return  new CustomEvent('d2l-activity-editor-connected', {
+		detail: { editor },
+		bubbles: true,
+		composed: true,
+		cancelable: true
+	});
+}
+
+const saveEvent = new CustomEvent('d2l-activity-editor-save', {
+	bubbles: true,
+	composed: true,
+	cancelable: true
+});
+
+describe('d2l-activity-editor-container-mixin', function() {
+
+	it('handles save', async() => {
+		const el = await fixture(`<${container}><${editor}></${editor}></${container}`);
+
+		const childEditor = el.firstElementChild;
+
+		childEditor.dispatchEvent(connectedEvent(childEditor));
+		childEditor.dispatchEvent(saveEvent);
+
+		expect(childEditor.saveCalled).to.be.true;
+	});
+});

--- a/test/d2l-activity-editor/mixins/d2l-activity-editor-mixin.html
+++ b/test/d2l-activity-editor/mixins/d2l-activity-editor-mixin.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-activity-editor-mixin tests</title>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+
+	</head>
+	<body>
+		<script type="module" src="./d2l-activity-editor-mixin.js"></script>
+	</body>
+</html>

--- a/test/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
+++ b/test/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
@@ -1,0 +1,24 @@
+import { defineCE, expect, fixture } from '@open-wc/testing';
+import { ActivityEditorContainerMixin } from '../../../components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js';
+import { ActivityEditorMixin} from '../../../components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js';
+
+const container = defineCE(
+	class extends ActivityEditorContainerMixin(HTMLElement) {
+	}
+);
+
+const editor = defineCE(
+	class extends ActivityEditorMixin(HTMLElement) {
+	}
+);
+
+describe('d2l-activity-editor-mixin', function() {
+
+	it('registers/unregisters editor', async() => {
+		const el = await fixture(`<${container}><${editor}></${editor}></${container}`);
+		expect(el._editors).to.include(el.firstElementChild);
+
+		el.firstElementChild.remove();
+		expect(el._editors).to.be.empty;
+	});
+});

--- a/test/index.html
+++ b/test/index.html
@@ -67,6 +67,8 @@
 			'd2l-quick-eval/d2l-quick-eval-clear-on-intial-load.html?dom=shadow',
 			'd2l-activity-editor/d2l-activity-editor.html',
 			'd2l-activity-editor/d2l-activity-editor-buttons.html',
+			'd2l-activity-editor/mixins/d2l-activity-editor-container-mixin.html',
+			'd2l-activity-editor/mixins/d2l-activity-editor-mixin.html',
 			'd2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.html',
 			'd2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.html',
 			'd2l-activity-admin-list/d2l-activity-admin-list.html',


### PR DESCRIPTION
These two mixins are intended to allow us to start co-ordinating the save behavior in FACE.

The `ActivityEditorContainerMixin` will be applied to the top level editor component (e.g. `d2l-activity-assignment-editor`) for Assignments. It handles listening on the `d2l-activity-editor-save` event which will be dispatched from the Save button where ever that happens to be rendered. It also includes an implementation to allow child editors to be registered so that when the Save button is clicked, child editors can be notified.

The `ActivityEditorMixin` will be applied to each component that supports editing capabilities.
It includes a `save()` method that will be called by the `ActivityEditorContainerMixin` when a Save is initiated. It's unlikely that every editor component will need to implement this `save()`. I anticipate that we will only implement the `save()` in the top level assignment and activity components and they will co-ordinate with the relevant MobX state to actually execute the save of the two main slices of state. However, by having every component use this mixin it gives us some flexibility in building components that could continue to operate in an autosave pattern if they detect they are not embedded by an editor container.