### PR TITLE
hide tooltip from screenreader since it already has button descriptions

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -199,11 +199,10 @@ class ActivityAttachmentsPicker extends SaveStatusMixin(EntityMixinLit(LocalizeM
 				</d2l-button-icon>
 				<d2l-tooltip
 					for="add-file-button"
+					aria-hidden="true"
 					disable-focus-lock
-					.boundary="${this._tooltipBoundary}">
-					${this.localize('addFile')}
-				</d2l-tooltip>
-
+					.boundary="${this._tooltipBoundary}">${this.localize('addFile')}</d2l-tooltip>
+					<!-- Important: keep tooltip content inline, otherwise screenreader gets confused -->
 				<d2l-button-icon
 					id="add-quicklink-button"
 					icon="d2l-tier1:quicklink"
@@ -213,10 +212,9 @@ class ActivityAttachmentsPicker extends SaveStatusMixin(EntityMixinLit(LocalizeM
 				</d2l-button-icon>
 				<d2l-tooltip
 					for="add-quicklink-button"
+					aria-hidden="true"
 					disable-focus-lock
-					.boundary="${this._tooltipBoundary}">
-					${this.localize('addQuicklink')}
-				</d2l-tooltip>
+					.boundary="${this._tooltipBoundary}">${this.localize('addQuicklink')}</d2l-tooltip>
 
 				<d2l-button-icon
 					id="add-link-button"
@@ -227,10 +225,9 @@ class ActivityAttachmentsPicker extends SaveStatusMixin(EntityMixinLit(LocalizeM
 				</d2l-button-icon>
 				<d2l-tooltip
 					for="add-link-button"
+					aria-hidden="true"
 					disable-focus-lock
-					.boundary="${this._tooltipBoundary}">
-					${this.localize('addLink')}
-				</d2l-tooltip>
+					.boundary="${this._tooltipBoundary}">${this.localize('addLink')}</d2l-tooltip>
 
 				<d2l-button-icon
 					id="add-google-drive-link-button"
@@ -241,10 +238,9 @@ class ActivityAttachmentsPicker extends SaveStatusMixin(EntityMixinLit(LocalizeM
 				</d2l-button-icon>
 				<d2l-tooltip
 					for="add-google-drive-link-button"
+					aria-hidden="true"
 					disable-focus-lock
-					.boundary="${this._tooltipBoundary}">
-					${this.localize('addGoogleDriveLink')}
-				</d2l-tooltip>
+					.boundary="${this._tooltipBoundary}">${this.localize('addGoogleDriveLink')}</d2l-tooltip>
 
 				<d2l-button-icon
 					id="add-onedrive-link-button"
@@ -255,10 +251,9 @@ class ActivityAttachmentsPicker extends SaveStatusMixin(EntityMixinLit(LocalizeM
 				</d2l-button-icon>
 				<d2l-tooltip
 					for="add-onedrive-link-button"
+					aria-hidden="true"
 					disable-focus-lock
-					.boundary="${this._tooltipBoundary}">
-					${this.localize('addOneDriveLink')}
-				</d2l-tooltip>
+					.boundary="${this._tooltipBoundary}">${this.localize('addOneDriveLink')}</d2l-tooltip>
 
 				<div class="button-container-right">
 					<d2l-button-subtle


### PR DESCRIPTION
Fixes https://trello.com/c/OH0fyVUE/82-a11y-previous-tooltip-is-announced-when-tabbing-through-attachments