### PR TITLE
Added spacing and flex alignment to selection count

### DIFF
--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -335,6 +335,8 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 			.d2l-add-activity-dialog-selection-count {
 				color: var(--d2l-color-ferrite);
 				font-size: 16px;
+				margin-left: 0.5rem;
+    			align-self: center;
 			}
 			.d2l-list-item-secondary {
 				color: var(--d2l-color-olivine-minus-1);


### PR DESCRIPTION
[DE37544](https://rally1.rallydev.com/#/detail/defect/363034010104?fdp=true)

Spacing and flex alignment has been added to the selection count in add activity dialogue to fix ugliness in mobile.

![Screen Shot 2020-01-23 at 4 06 08 PM](https://user-images.githubusercontent.com/2412740/73023836-4fe8da00-3dfa-11ea-913f-20315b384441.png)