### PR TITLE
Adding new activities to an LP will now asynchronously batch in groups of 5.

### DIFF
--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -173,11 +173,18 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 	}
 
 	async addActivities() {
-		this._reloadOnOpen = true;
-		const addAction = this._actionCollectionEntity.getExecuteMultipleAction();
 		const keys = this._selectedActivities();
-		const fields = [{ name: 'actionStates', value: keys }];
-		await performSirenAction(this.token, addAction, fields, true);
+		const addAction = this._actionCollectionEntity.getExecuteMultipleAction();
+		const sirenActions = [];
+
+		this._reloadOnOpen = true;
+		while(keys.length > 0) {
+			const keyBatch = keys.splice(0,5);
+			const fields  = [{ name: 'actionStates', value: keyBatch }];
+			sirenActions.push(Promise.resolve(performSirenAction(this.token, addAction, fields, true)));
+		}
+
+		await Promise.all(sirenActions);
 	}
 
 	handleSearch(event) {

--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -178,8 +178,8 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 		const sirenActions = [];
 
 		this._reloadOnOpen = true;
-		while(keys.length > 0) {
-			const keyBatch = keys.splice(0,5);
+		while (keys.length > 0) {
+			const keyBatch = keys.splice(0, 5);
 			const fields  = [{ name: 'actionStates', value: keyBatch }];
 			sirenActions.push(Promise.resolve(performSirenAction(this.token, addAction, fields, true)));
 		}


### PR DESCRIPTION
This prevents the server from returning a 502 and not reloading activities when adding and reloading a large number of activities within the Edit My Learning page with a single call to getExecuteMultipleAction(), which seemed to happen on 17 or 18 activities maximum previously.