### PR TITLE
Fixed activity loading spinner being cut off

### DIFF
--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -144,6 +144,12 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 		this._candidateItemsLoading = true;
 		if (clearList) {
 			this._candidateFirstLoad = false;
+		} else {
+			// wait for the spinner, then scroll to the bottom
+			await this.updateComplete;
+			const dialogScroll = this.shadowRoot.querySelector('#dialog').shadowRoot.querySelector('.d2l-dialog-content');
+			dialogScroll.scrollTo(0, dialogScroll.scrollHeight);
+		// }
 		}
 		const resp = await performSirenAction(this.token, action, fields, true);
 		this._actionCollectionEntity = new ActionCollectionEntity(this._collection, resp);


### PR DESCRIPTION
[DE37560](https://rally1.rallydev.com/#/detail/defect/363226148060?fdp=true)

Loading spinner was partially cut off when loading more activities for editing a learning path. Added a scroll that prevents this.