### PR TITLE
Visibility set to hidden when the last activity is removed

### DIFF
--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -501,7 +501,7 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 
 		const learningPathVisibilityToggle = this._handleFirstLoad(() => {
 			return html`
-				<d2l-activity-visibility-editor class="d2l-activity-collection-toggle-container" ?disabled="${!this._items.length}" .href="${this.href}" .token="${this.token}"></d2l-activity-visibility-editor>
+				<d2l-activity-visibility-editor class="d2l-activity-collection-toggle-container" .href="${this.href}" .token="${this.token}"></d2l-activity-visibility-editor>
 				<d2l-button-icon
 					class="d2l-activity-collection-toggle-container-button"
 					?disabled="${!this._canEditDraft || this.disabled}"

--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -101,6 +101,10 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 							collection.removeItem(item.self());
 							this._currentDeleteItemName = items[index].name();
 							this.shadowRoot.querySelector('#delete-succeeded-toast').open = true;
+							// if the result is an empty learning path, set to hidden
+							if (items.length - 1 === 0) {
+								this._setVisibility(true);
+							}
 						};
 						items[index].itemSelf = item.self();
 						if (typeof this._organizationImageChunk[item.self()] === 'undefined') {
@@ -501,7 +505,7 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 
 		const learningPathVisibilityToggle = this._handleFirstLoad(() => {
 			return html`
-				<d2l-activity-visibility-editor class="d2l-activity-collection-toggle-container" .href="${this.href}" .token="${this.token}"></d2l-activity-visibility-editor>
+				<d2l-activity-visibility-editor class="d2l-activity-collection-toggle-container" ?disabled="${!this._items.length}" .href="${this.href}" .token="${this.token}"></d2l-activity-visibility-editor>
 				<d2l-button-icon
 					class="d2l-activity-collection-toggle-container-button"
 					?disabled="${!this._canEditDraft || this.disabled}"


### PR DESCRIPTION
[DE37520](https://rally1.rallydev.com/#/detail/defect/362778356136?fdp=true)

This is a solution to the issue where deleting all activities from a learning path resulted in a locked visibility toggle, including when the LP was visible. This caused empty learning paths to be viewable by a learner, which is currently undefined behaviour.

The visibility will now always be set to hidden after all activities are deleted.