### PR TITLE
Set aria-live to off for activity-collection-editor

### DIFF
--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -45,7 +45,7 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 		this._candidateLoad = new Promise(() => null);
 		this._candidateFirstLoad = false;
 		this.ariaBusy = 'true';
-		this.ariaLive = 'polite';
+		this.role = 'main';
 		this._currentDeleteItemName = '';
 		this._dialogOpen = false;
 		this._isLoadingMore = false;
@@ -238,7 +238,8 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 			_candidateItemsLoading: {type: Boolean},
 			_isLoadingMore: {type: Boolean},
 			ariaBusy: { type: String, reflect: true, attribute: 'aria-busy' },
-			ariaLive: { type: String, reflect: true, attribute: 'aria-live' }
+			ariaLive: { type: String, reflect: true, attribute: 'aria-live' },
+			role: { type: String, reflect: true, attribute: 'role' }
 		};
 	}
 


### PR DESCRIPTION
[DE37493](https://rally1.rallydev.com/#/detail/defect/362514237868?fdp=true)

Visiting the edit learning path page while using a screen reader resulted in the entire page contents being read. This was due to the aria-live="polite" set on the main web component. This attribute will read the contents to the user once aria-busy is false, which in VoiceOver's case, means _all_ of the contained content.

Setting the aria-live to off prevents this.