### PR TITLE
Make HTML editor initialization more deterministic

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -150,6 +150,10 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 	}
 
 	render() {
+		if (!this._activityUsageHref) {
+			return html``;
+		}
+
 		return html`
 			<div id="assignment-name-container">
 				<label class="d2l-label-text" for="assignment-name">${this.localize('name')}*</label>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -150,10 +150,6 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 	}
 
 	render() {
-		if (!this._activityUsageHref) {
-			return html``;
-		}
-
 		return html`
 			<div id="assignment-name-container">
 				<label class="d2l-label-text" for="assignment-name">${this.localize('name')}*</label>
@@ -191,7 +187,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 			<div id="assignment-instructions-container">
 				<label class="d2l-label-text">${this.localize('instructions')}</label>
 				<d2l-activity-text-editor
-					value="${this._instructions}"
+					.value="${this._instructions}"
 					.richtextEditorConfig="${this._instructionsRichTextEditorConfig}"
 					@d2l-activity-text-editor-change="${this._saveInstructionsOnChange}"
 					ariaLabel="${this.localize('instructions')}"

--- a/components/d2l-activity-editor/d2l-activity-html-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-editor.js
@@ -168,8 +168,8 @@ class ActivityHtmlEditor extends LocalizeMixin(LitElement) {
 			</d2l-html-editor>`;
 	}
 
-	firstUpdated(changedProperties) {
-		super.firstUpdated(changedProperties);
+	updated(changedProperties) {
+		super.updated(changedProperties);
 		// This is acknowledged to be non-idiomatic (manipulating DOM outside render), but this
 		// is unforunately a necessary evil of using the tinymce/HTML editor.
 		// NB: Using first updated relies on the properties being set on first render
@@ -181,7 +181,7 @@ class ActivityHtmlEditor extends LocalizeMixin(LitElement) {
 			}
 		}
 
-		if (changedProperties.has('value')) {
+		if (changedProperties.has('value') && typeof changedProperties.get('value') === 'undefined') {
 			const editorContainer = this.shadowRoot.querySelector('d2l-html-editor > .d2l-html-editor-container');
 			if (editorContainer) {
 				editorContainer.innerHTML = this.value;

--- a/components/d2l-activity-editor/d2l-activity-html-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-editor.js
@@ -172,8 +172,6 @@ class ActivityHtmlEditor extends LocalizeMixin(LitElement) {
 		super.updated(changedProperties);
 		// This is acknowledged to be non-idiomatic (manipulating DOM outside render), but this
 		// is unforunately a necessary evil of using the tinymce/HTML editor.
-		// NB: Using first updated relies on the properties being set on first render
-		// and so clients should avoid rendering this component with undefined properties
 		if (changedProperties.has('richtextEditorConfig')) {
 			const editor = this.shadowRoot.querySelector('d2l-html-editor');
 			if (editor) {

--- a/components/d2l-activity-editor/d2l-activity-html-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-editor.js
@@ -13,8 +13,7 @@ class ActivityHtmlEditor extends LocalizeMixin(LitElement) {
 			value: { type: String },
 			ariaLabel: { type: String },
 			disabled: { type: Boolean },
-			_htmlEditorUniqueId: { type: String },
-			_valueSet: { type: Boolean }
+			_htmlEditorUniqueId: { type: String }
 		};
 	}
 
@@ -124,33 +123,6 @@ class ActivityHtmlEditor extends LocalizeMixin(LitElement) {
 	constructor() {
 		super();
 		this._htmlEditorUniqueId = `htmleditor-${getUniqueId()}`;
-		this._valueSet = false;
-	}
-
-	set value(newValue) {
-		const oldValue = this.value;
-
-		if (!this._valueSet) {
-			const editorContainer = this.shadowRoot.querySelector('d2l-html-editor > .d2l-html-editor-container');
-			if (editorContainer) {
-				this._valueSet = true;
-				editorContainer.innerHTML = newValue;
-			}
-		}
-
-		this.requestUpdate('value', oldValue);
-	}
-
-	set richtextEditorConfig(newValue) {
-		const oldValue = this.richtextEditorConfig;
-
-		const editorConfig = newValue || {};
-		const editor = this.shadowRoot.querySelector('d2l-html-editor');
-		if (editor) {
-			editor.d2lPluginSettings = editorConfig.properties || {};
-		}
-
-		this.requestUpdate('richtextEditorConfig', oldValue);
 	}
 
 	_resolveUrl() {
@@ -194,6 +166,27 @@ class ActivityHtmlEditor extends LocalizeMixin(LitElement) {
 					prevent-submit>
 				</div>
 			</d2l-html-editor>`;
+	}
+
+	firstUpdated(changedProperties) {
+		super.firstUpdated(changedProperties);
+		// This is acknowledged to be non-idiomatic (manipulating DOM outside render), but this
+		// is unforunately a necessary evil of using the tinymce/HTML editor.
+		// NB: Using first updated relies on the properties being set on first render
+		// and so clients should avoid rendering this component with undefined properties
+		if (changedProperties.has('richtextEditorConfig')) {
+			const editor = this.shadowRoot.querySelector('d2l-html-editor');
+			if (editor) {
+				editor.d2lPluginSettings = this.richtextEditorConfig.properties || {};
+			}
+		}
+
+		if (changedProperties.has('value')) {
+			const editorContainer = this.shadowRoot.querySelector('d2l-html-editor > .d2l-html-editor-container');
+			if (editorContainer) {
+				editorContainer.innerHTML = this.value;
+			}
+		}
 	}
 }
 

--- a/components/d2l-activity-editor/d2l-activity-text-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-text-editor.js
@@ -48,7 +48,7 @@ class ActivityTextEditor extends LitElement {
 			return html`
 				<d2l-activity-html-editor
 					ariaLabel="${this.ariaLabel}"
-					value="${this.value}"
+					.value="${this.value}"
 					?disabled="${this.disabled}"
 					@d2l-activity-html-editor-change="${this._onRichtextChange}"
 					.richtextEditorConfig="${this.richtextEditorConfig}">


### PR DESCRIPTION
During work on the Save/Cancel changes, I was experimenting with skipping rendering of components when things like the the assignment and activity properties were not yet initialized.

Currently we always just render which means we are rendering with lots of properties with undefined values. Whilst this isn't necessarily bad (and sometimes it can even improve eventual perceived render performance) it requires all components to handle the `undefined` values correctly and it was making it clunky to destructure the MobX properties.

So I tried skipping rendering until the activity was loaded, but this bizarrely broke the HTML editor. It turned out that the HTML editor initialization basically depends upon initially being called with an `undefined` `value` property. If you call it initially with an actual `value` property then it doesn't correctly initialize.

So these changes are intended to make the initialization more deterministic. Unfortunately it does mean we have to pass the value as a prop `.value` (notice the period), because the HTML editor does not set the tinymce inner text after it's first received a valid string. And if you pass an attribute like

`value="${this.value}"` 

and `this.value` is undefined, it get's coerced into the string "undefined" and that's what ends up in the tinymce editor. By always passing the `value` as a property we ensure we can detect when it changes from `undefined` to a valid string.

The reason why it was sort of working before (but depended on an "undefined" value being set initially) was because the initialization code that queries the shadow dom in order to set up the tinymce stuff was not finding anything the very first time that `set value(value)` was called with the value "undefined" because the very first time those setters are invoked, the component has not yet rendered so the component's local DOM doesn't yet exist.  When the component was rendered again with a valid string value, now the code to manipulate the tinymce DOM in the setter would find the DOM elements so it worked.

But if you try and render the component with the actual string value on the first render, tinymce would not initalize because the light DOM children didn't exist when the setter was first called.

I'm not that keen on requiring users of these components to have to pass the value attribute as a property either. If people use an attribute and they happen to cause the component to be initialized with an "undefined" value, then that is what will be set in the editor. But it seems more straight forward to require people to use a property than to require them to always initialize the editor with an undefined value first.

If people don't want to use a property and want to use an attribute they just need to make sure they never set the attribute to `undefined`.