### PR TITLE
Fix assignment editor file attachments rendering

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachment.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachment.js
@@ -36,6 +36,9 @@ class ActivityAttachment extends EntityMixinLit(LitElement) {
 				url: entity.href(),
 				name: entity.name()
 			};
+			if (entity.hasClass('file')) {
+				this._attachment.type = 'Document';
+			}
 			this._editing = entity.canDeleteAttachment();
 			this.creating = entity.canDeleteAttachment();
 		}


### PR DESCRIPTION
https://trello.com/c/N6eVNFLU/98-face-lms-file-attachment-should-not-be-unfurled

Flag 'file' attachments as 'Document', so they are rendered as intended by attachments-ui.