### PR TITLE
fix assignment activity not loading in edge

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -49,10 +49,9 @@ class ActivityEditor extends PendingContainerMixin(LocalizeMixin(LitElement)) {
 		this.loading = false;
 	}
 	render() {
-		return this.loading ? html`
-			<div class="d2l-activity-editor-loading">${this.localize('loading')}</div>
-		` : html`
-			<div>
+		return html`
+			<div ?hidden="${!this.loading}" class="d2l-activity-editor-loading">${this.localize('loading')}</div>
+			<div ?hidden="${this.loading}">
 				<slot name="editor"></slot>
 			</div>
 		`;


### PR DESCRIPTION
Fixes https://trello.com/c/54WLoPqc/89-edge-only-face-page-doesnt-load
Turns out the problem was that when `this.loading` was true, the editor slot wasn't rendered, so in edge that meant it also wasn't receiving / handling any events. Using `hidden` instead ensures the elements are present in the dom and able to handle events, even when not visible.