### PR TITLE
Added background fill to skeletons to fix Edge

### DIFF
--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -407,6 +407,7 @@ class CollectionEditor extends LocalizeMixin(EntityMixinLit(LitElement)) {
 
 			.d2l-activity-collection-skeleton-rect {
 				animation: loadingPulse 1.8s linear infinite;
+				fill: var(--d2l-color-sylvite);
 			}
 
 			.d2l-activity-collection-no-activity {


### PR DESCRIPTION
This PR will resolve the loading black boxes in Edge, setting them to animate and pulse like in other browsers.

In Edge pre-Credge, if: 
- A css animation contains a css var, and 
- the animation is played in an SVG shape like a rect, 
Then there must also be a `fill:` css property applied to the SVG rect, and the fill colour must be assigned by a css variable, though the chosen variable doesn't seem to matter.

Using a basic color will block the animation, but using no fill property at all will render as a black box.