### PR TITLE
Initial attachment collection MobX store. 

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-collection.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-collection.js
@@ -14,12 +14,12 @@ export class AttachmentCollection {
 		const sirenEntity = await fetchEntity(this.href, this.token);
 		if (sirenEntity) {
 			const entity = new AttachmentCollectionEntity(sirenEntity, this.token, { remove: () => { } });
-			await this.load(entity);
+			this.load(entity);
 		}
 		return this;
 	}
 
-	async load(entity) {
+	load(entity) {
 		this._entity = entity;
 
 		this.canAddAttachments = entity.canAddAttachments();

--- a/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-collection.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-collection.js
@@ -1,0 +1,49 @@
+import { action, configure as configureMobx, decorate, observable } from 'mobx';
+import { AttachmentCollectionEntity } from 'siren-sdk/src/activities/AttachmentCollectionEntity.js';
+import { fetchEntity } from '../../state/fetch-entity.js';
+
+configureMobx({ enforceActions: 'observed' });
+
+export class AttachmentCollection {
+	constructor(href, token) {
+		this.href = href;
+		this.token = token;
+	}
+
+	async fetch() {
+		const sirenEntity = await fetchEntity(this.href, this.token);
+		if (sirenEntity) {
+			const entity = new AttachmentCollectionEntity(sirenEntity, this.token, { remove: () => { } });
+			await this.load(entity);
+		}
+		return this;
+	}
+
+	async load(entity) {
+		this._entity = entity;
+
+		this.canAddAttachments = entity.canAddAttachments();
+		this.canAddLink = entity.canAddLinkAttachment();
+		this.canAddFile = entity.canAddFileAttachment();
+		this.canAddGoogleDriveLink = entity.canAddGoogleDriveLinkAttachment();
+		this.canAddOneDriveLink = entity.canAddOneDriveLinkAttachment();
+		this.canRecordVideo = entity.canAddVideoNoteAttachment();
+		this.canRecordAudio = entity.canAddAudioNoteAttachment();
+
+		this.attachments = entity.getAttachmentEntityHrefs();
+	}
+}
+
+decorate(AttachmentCollection, {
+	// props
+	canAddAttachments: observable,
+	canAddLink: observable,
+	canAddFile: observable,
+	canAddGoogleDriveLink: observable,
+	canAddOneDriveLink: observable,
+	canRecordVideo: observable,
+	canRecordAudio: observable,
+	attachments: observable,
+	// actions
+	load: action
+});

--- a/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-collections-store.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-collections-store.js
@@ -8,20 +8,20 @@ export class AttachmentCollectionsStore {
 		this._attachments = new ObjectStore(Attachment);
 	}
 
-	fetchAttachment(href, token) {
-		return this._assignments.fetch(href, token);
-	}
-
-	getAttachment(href) {
-		return this._attachments.get(href);
-	}
-
 	fetchCollection(href, token) {
 		return this._collections.fetch(href, token);
 	}
 
 	getCollection(href) {
 		return this._collections.get(href);
+	}
+
+	fetchAttachment(href, token) {
+		return this._attachments.fetch(href, token);
+	}
+
+	getAttachment(href) {
+		return this._attachments.get(href);
 	}
 }
 

--- a/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-collections-store.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-collections-store.js
@@ -1,0 +1,28 @@
+import { Attachment } from './attachment.js';
+import { AttachmentCollection } from './attachment-collection.js';
+import { ObjectStore } from '../../state/object-store.js';
+
+export class AttachmentCollectionsStore {
+	constructor() {
+		this._collections = new ObjectStore(AttachmentCollection);
+		this._attachments = new ObjectStore(Attachment);
+	}
+
+	fetchAttachment(href, token) {
+		return this._assignments.fetch(href, token);
+	}
+
+	getAttachment(href) {
+		return this._attachments.get(href);
+	}
+
+	fetchCollection(href, token) {
+		return this._collections.fetch(href, token);
+	}
+
+	getCollection(href) {
+		return this._collections.get(href);
+	}
+}
+
+export const shared = new AttachmentCollectionsStore();

--- a/components/d2l-activity-editor/d2l-activity-attachments/state/attachment.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/state/attachment.js
@@ -14,12 +14,12 @@ export class Attachment {
 		const sirenEntity = await fetchEntity(this.href, this.token);
 		if (sirenEntity) {
 			const entity = new AttachmentEntity(sirenEntity, this.token, { remove: () => { } });
-			await this.load(entity);
+			this.load(entity);
 		}
 		return this;
 	}
 
-	async load(entity) {
+	load(entity) {
 		this._entity = entity;
 
 		this.editing = entity.canDeleteAttachment();

--- a/components/d2l-activity-editor/d2l-activity-attachments/state/attachment.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/state/attachment.js
@@ -1,0 +1,45 @@
+import { action, configure as configureMobx, decorate, observable } from 'mobx';
+import { AttachmentEntity } from 'siren-sdk/src/activities/AttachmentEntity.js';
+import { fetchEntity } from '../../state/fetch-entity.js';
+
+configureMobx({ enforceActions: 'observed' });
+
+export class Attachment {
+	constructor(href, token) {
+		this.href = href;
+		this.token = token;
+	}
+
+	async fetch() {
+		const sirenEntity = await fetchEntity(this.href, this.token);
+		if (sirenEntity) {
+			const entity = new AttachmentEntity(sirenEntity, this.token, { remove: () => { } });
+			await this.load(entity);
+		}
+		return this;
+	}
+
+	async load(entity) {
+		this._entity = entity;
+
+		this.editing = entity.canDeleteAttachment();
+		this.creating = false;
+		this.deleted = false;
+
+		this.attachment = {
+			id: entity.self(),
+			name: entity.name(),
+			url: entity.href()
+		};
+	}
+}
+
+decorate(Attachment, {
+	// props
+	editing: observable,
+	creating: observable,
+	deleted: observable,
+	attachment: observable,
+	// actions
+	load: action
+});

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:polymer:local": "polymer test --skip-plugin sauce",
     "test:polymer:sauce": "polymer test --skip-plugin local",
     "test:js": "jest",
+    "test:js:watch": "jest --watch",
     "test": "npm run lint && npm run test:polymer:local && npm run test:js",
     "serve": "polymer serve"
   },

--- a/test/d2l-activity-editor/d2l-activity-attachments/state/attachment-collection.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-attachments/state/attachment-collection.spec.js
@@ -1,0 +1,63 @@
+import { AttachmentCollection } from '../../../../components/d2l-activity-editor/d2l-activity-attachments/state/attachment-collection.js';
+import { AttachmentCollectionEntity } from 'siren-sdk/src/activities/AttachmentCollectionEntity.js';
+import { expect } from 'chai';
+import { fetchEntity } from '../../../../components/d2l-activity-editor/state/fetch-entity.js';
+import sinon from 'sinon';
+
+jest.mock('siren-sdk/src/activities/AttachmentCollectionEntity.js');
+jest.mock('../../../../components/d2l-activity-editor/state/fetch-entity.js');
+
+describe('Attachment Collection', function() {
+
+	const defaultEntityMock = {
+		canAddAttachments: () => true,
+		canAddLinkAttachment: () => true,
+		canAddFileAttachment: () => true,
+		canAddGoogleDriveLinkAttachment: () => false,
+		canAddOneDriveLinkAttachment: () => true,
+		canAddVideoNoteAttachment: () => true,
+		canAddAudioNoteAttachment: () => false,
+		getAttachmentEntityHrefs: () => ['http://attachment/1', 'http://attachment/2']
+	};
+
+	afterEach(() => {
+		sinon.restore();
+		AttachmentCollectionEntity.mockClear();
+		fetchEntity.mockClear();
+	});
+
+	let sirenEntity;
+
+	describe('fetching', () => {
+		beforeEach(() => {
+			sirenEntity = sinon.stub();
+
+			AttachmentCollectionEntity.mockImplementation(() => {
+				return defaultEntityMock;
+			});
+
+			fetchEntity.mockImplementation(() => Promise.resolve(sirenEntity));
+		});
+
+		it('fetches', async() => {
+			const collection = new AttachmentCollection('http://1', 'token');
+			await collection.fetch();
+
+			expect(collection.canAddAttachments).to.be.true;
+			expect(collection.canAddLink).to.be.true;
+			expect(collection.canAddFile).to.be.true;
+			expect(collection.canAddGoogleDriveLink).to.be.false;
+			expect(collection.canAddOneDriveLink).to.be.true;
+			expect(collection.canRecordVideo).to.be.true;
+			expect(collection.canRecordAudio).to.be.false;
+
+			expect(collection.attachments.length).to.equal(2);
+			expect(collection.attachments[0]).to.equal('http://attachment/1');
+			expect(collection.attachments[1]).to.equal('http://attachment/2');
+
+			expect(fetchEntity.mock.calls.length).to.equal(1);
+			expect(AttachmentCollectionEntity.mock.calls[0][0]).to.equal(sirenEntity);
+			expect(AttachmentCollectionEntity.mock.calls[0][1]).to.equal('token');
+		});
+	});
+});

--- a/test/d2l-activity-editor/d2l-activity-attachments/state/attachment.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-attachments/state/attachment.spec.js
@@ -1,0 +1,54 @@
+import { Attachment } from '../../../../components/d2l-activity-editor/d2l-activity-attachments/state/attachment.js';
+import { AttachmentEntity } from 'siren-sdk/src/activities/AttachmentEntity.js';
+import { expect } from 'chai';
+import { fetchEntity } from '../../../../components/d2l-activity-editor/state/fetch-entity.js';
+import sinon from 'sinon';
+
+jest.mock('siren-sdk/src/activities/AttachmentEntity.js');
+jest.mock('../../../../components/d2l-activity-editor/state/fetch-entity.js');
+
+describe('Attachment', function() {
+
+	const defaultEntityMock = {
+		canDeleteAttachment: () => true,
+		name: () => 'Google Canada',
+		href: () => 'http://google.ca',
+		self: () => 'http://attachment/1'
+	};
+
+	afterEach(() => {
+		sinon.restore();
+		AttachmentEntity.mockClear();
+		fetchEntity.mockClear();
+	});
+
+	let sirenEntity;
+
+	describe('fetching', () => {
+		beforeEach(() => {
+			sirenEntity = sinon.stub();
+
+			AttachmentEntity.mockImplementation(() => {
+				return defaultEntityMock;
+			});
+
+			fetchEntity.mockImplementation(() => Promise.resolve(sirenEntity));
+		});
+
+		it('fetches', async() => {
+			const attachment = new Attachment('http://1', 'token');
+			await attachment.fetch();
+
+			expect(attachment.editing).to.be.true;
+			expect(attachment.creating).to.be.false;
+			expect(attachment.deleted).to.be.false;
+			expect(attachment.attachment.id).to.equal('http://attachment/1');
+			expect(attachment.attachment.name).to.equal('Google Canada');
+			expect(attachment.attachment.url).to.equal('http://google.ca');
+
+			expect(fetchEntity.mock.calls.length).to.equal(1);
+			expect(AttachmentEntity.mock.calls[0][0]).to.equal(sirenEntity);
+			expect(AttachmentEntity.mock.calls[0][1]).to.equal('token');
+		});
+	});
+});


### PR DESCRIPTION
Just supports loading collections and attachments for now.
Integration with web components will follow in later PR.

The store supports caching both collections and attachments so that resource based web components for the attachment list and attachments can each reference their associated entities.

The collection object contains observable properties for:
* the list of entity hrefs (not to be confused with attachment target urls), for each attachment in the collection.
* permissions for each attachment type that will be used to determine what buttons are enabled in the picker.

The attachment object contains observable properties for:
* the status (editing, creating, deleted) - used to determine whether we have a remove button/undo button etc
* the name/url of the attachment used to determine how the attachment will render.

This PR depends on a new `siren-sdk` method in this PR:
https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/131