### PR TITLE
List items display only text content of description

### DIFF
--- a/components/d2l-activity-list-item/d2l-activity-list-item.js
+++ b/components/d2l-activity-list-item/d2l-activity-list-item.js
@@ -626,7 +626,7 @@ class D2lActivityListItem extends mixinBehaviors([
 
 		//Use a temporary div to strip html out of the content
 		if (description) {
-			var tempDiv = document.createElement('div');
+			const tempDiv = document.createElement('div');
 			tempDiv.innerHTML = description;
 			description = tempDiv.textContent || tempDiv.innerText;
 		}

--- a/components/d2l-activity-list-item/d2l-activity-list-item.js
+++ b/components/d2l-activity-list-item/d2l-activity-list-item.js
@@ -624,8 +624,9 @@ class D2lActivityListItem extends mixinBehaviors([
 	_handleOrganizationResponse(organization) {
 		let description = organization.properties && organization.properties.description;
 
-		//Use a temporary div to strip html out of the content
+		//Use a temporary div to strip html out of the content and display html entities.
 		if (description) {
+			description = description.replace(/<[^>]*>/g, '');
 			const tempDiv = document.createElement('div');
 			tempDiv.innerHTML = description;
 			description = tempDiv.textContent || tempDiv.innerText;

--- a/components/d2l-activity-list-item/d2l-activity-list-item.js
+++ b/components/d2l-activity-list-item/d2l-activity-list-item.js
@@ -623,8 +623,12 @@ class D2lActivityListItem extends mixinBehaviors([
 
 	_handleOrganizationResponse(organization) {
 		let description = organization.properties && organization.properties.description;
+
+		//Use a temporary div to strip html out of the content
 		if (description) {
-			description = description.replace(/<[^>]*>/g, '');
+			var tempDiv = document.createElement('div');
+			tempDiv.innerHTML = description;
+			description = tempDiv.textContent || tempDiv.innerText;
 		}
 		this._description = description;
 


### PR DESCRIPTION
### Changes
`d2l-activity-list-items` used a regex replace to parse the content from the description: `/<[^>]*>/g, ''`
This is insufficient to deal with a few other scenarios such as html entitites.`&nbsp;` would not be caught by this, nor would `&lt;`.

This has been resolved by using a temporary div to strip html out of the content, resulting in it being displayed with the entities properly parsed and all tags removed. 

Sample string:
`<p>Lorem <p>ipsum &nbsp; </br> dolor <b>sit</b> amet, con<>ectetur&lt; /test&gt; adipiscing </p> elit. Donec u<span>ltricies</span> ligula libero, eu dapibus`

Before:
![image](https://user-images.githubusercontent.com/55998273/74274644-6a6af080-4ce0-11ea-91a3-64874dc45ffb.png)

After:
![image](https://user-images.githubusercontent.com/55998273/74274636-67700000-4ce0-11ea-9ee9-df7696fac122.png)

Edit: Kept regex tag removal in addition to changes to prevent execution of javascript.