### PR TITLE
Use combined dates action to check edit dates permissions in editors

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
@@ -46,23 +46,21 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeMixin
 
 	render() {
 		const activity = store.get(this.href);
-		let canEditStartDate, canEditEndDate, startDate, endDate;
+		let canEditDates, startDate, endDate;
 
 		if (!activity) {
-			canEditStartDate = false;
-			canEditEndDate = false;
+			canEditDates = false;
 			startDate = null;
 			endDate = null;
 		} else {
-			canEditStartDate = activity.canEditStartDate;
-			canEditEndDate = activity.canEditEndDate;
+			canEditDates = activity.canEditDates;
 			startDate = activity.startDate;
 			endDate = activity.endDate;
 		}
 
 		return html`
-			<label class="d2l-label-text" ?hidden=${!canEditStartDate}>${this.localize('startDate')}</label>
-			<div id="startdate-container" ?hidden=${!canEditStartDate}>
+			<label class="d2l-label-text" ?hidden=${!canEditDates}>${this.localize('startDate')}</label>
+			<div id="startdate-container" ?hidden=${!canEditDates}>
 				<d2l-datetime-picker
 					hide-label
 					name="startDate"
@@ -76,8 +74,8 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeMixin
 					@d2l-datetime-picker-datetime-cleared="${this._onStartDatetimePickerDatetimeCleared}">
 				</d2l-datetime-picker>
 			</div>
-			<label class="d2l-label-text" ?hidden=${!canEditEndDate}>${this.localize('endDate')}</label>
-			<div id="enddate-container" ?hidden=${!canEditEndDate}>
+			<label class="d2l-label-text" ?hidden=${!canEditDates}>${this.localize('endDate')}</label>
+			<div id="enddate-container" ?hidden=${!canEditDates}>
 				<d2l-datetime-picker
 					hide-label
 					name="endDate"

--- a/components/d2l-activity-editor/d2l-activity-due-date-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-due-date-editor.js
@@ -63,7 +63,7 @@ class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeMixin(MobxLitEle
 
 	render() {
 		const activity = store.get(this.href);
-		let dueDate, canEditDueDate;
+		let dueDate, canEditDates;
 
 		// We have to render with null values for dueDate initially due to issues with
 		// how the d2l-datetime-picker converts between the date & datetime attributes.
@@ -75,14 +75,14 @@ class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeMixin(MobxLitEle
 		// Will be able to fix when we have a new data time component.
 		if (!activity) {
 			dueDate = null;
-			canEditDueDate = false;
+			canEditDates = false;
 		} else {
 			dueDate = activity.dueDate;
-			canEditDueDate = activity.canEditDueDate;
+			canEditDates = activity.canEditDates;
 		}
 
 		return html`
-			${this.dateTemplate(dueDate, canEditDueDate)}
+			${this.dateTemplate(dueDate, canEditDates)}
 		`;
 	}
 

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -1,4 +1,4 @@
-import { action, configure as configureMobx, decorate, observable, runInAction } from 'mobx';
+import { action, configure as configureMobx, decorate, observable } from 'mobx';
 import { ActivityUsageEntity } from 'siren-sdk/src/activities/ActivityUsageEntity.js';
 import { fetchEntity } from '../state/fetch-entity.js';
 
@@ -22,21 +22,12 @@ export class ActivityUsage {
 
 	async load(entity) {
 		this._entity = entity;
-
-		const canEditDueDate = await entity.canEditDueDate();
-		const canEditStartDate = await entity.canEditStartDate();
-		const canEditEndDate = await entity.canEditEndDate();
-
-		runInAction(() => {
-			this.dueDate = entity.dueDate();
-			this.canEditDueDate = canEditDueDate;
-			this.startDate = entity.startDate();
-			this.canEditStartDate = canEditStartDate;
-			this.endDate = entity.endDate();
-			this.canEditEndDate = canEditEndDate;
-			this.isDraft = entity.isDraft();
-			this.canEditDraft = entity.canEditDraft();
-		});
+		this.dueDate = entity.dueDate();
+		this.startDate = entity.startDate();
+		this.endDate = entity.endDate();
+		this.canEditDates = entity.canEditDates();
+		this.isDraft = entity.isDraft();
+		this.canEditDraft = entity.canEditDraft();
 	}
 
 	setDueDate(date) {
@@ -59,12 +50,8 @@ export class ActivityUsage {
 		this.canEditDraft = value;
 	}
 
-	setCanEditStartDate(value) {
-		this.canEditStartDate = value;
-	}
-
-	setCanEditEndDate(value) {
-		this.canEditEndDate = value;
+	setCanEditDates(value) {
+		this.canEditDates = value;
 	}
 
 	async save() {
@@ -86,11 +73,9 @@ export class ActivityUsage {
 decorate(ActivityUsage, {
 	// props
 	dueDate: observable,
-	canEditDueDate: observable,
 	startDate: observable,
-	canEditStartDate: observable,
 	endDate: observable,
-	canEditEndDate: observable,
+	canEditDates: observable,
 	isDraft: observable,
 	canEditDraft: observable,
 	// actions
@@ -100,7 +85,6 @@ decorate(ActivityUsage, {
 	setEndDate: action,
 	setDraftStatus: action,
 	setCanEditDraft: action,
-	setCanEditStartDate: action,
-	setCanEditEndDate: action,
+	setCanEditDates: action,
 	save: action
 });

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -15,12 +15,12 @@ export class ActivityUsage {
 		const sirenEntity = await fetchEntity(this.href, this.token);
 		if (sirenEntity) {
 			const entity = new ActivityUsageEntity(sirenEntity, this.token, { remove: () => { } });
-			await this.load(entity);
+			this.load(entity);
 		}
 		return this;
 	}
 
-	async load(entity) {
+	load(entity) {
 		this._entity = entity;
 		this.dueDate = entity.dueDate();
 		this.startDate = entity.startDate();

--- a/test/d2l-activity-editor/d2l-activity-availability-dates-editor.js
+++ b/test/d2l-activity-editor/d2l-activity-availability-dates-editor.js
@@ -10,8 +10,7 @@ describe('d2l-activity-availability-dates-editor', function() {
 	beforeEach(async() => {
 		href = 'http://activity/1';
 		activity = new ActivityUsage(href, 'token');
-		activity.setCanEditStartDate(true);
-		activity.setCanEditEndDate(true);
+		activity.setCanEditDates(true);
 		activity.setStartDate('2020-02-24T04:59:00.000Z');
 		activity.setEndDate('2020-02-26T04:59:00.000Z');
 		store.put(href, activity);
@@ -54,8 +53,7 @@ describe('d2l-activity-availability-dates-editor', function() {
 
 	describe('hidden', function() {
 		beforeEach(async() => {
-			activity.setCanEditStartDate(false);
-			activity.setCanEditEndDate(false);
+			activity.setCanEditDates(false);
 			await elementUpdated(el);
 		});
 

--- a/test/d2l-activity-editor/state/activity-usage.spec.js
+++ b/test/d2l-activity-editor/state/activity-usage.spec.js
@@ -12,11 +12,9 @@ describe('Activity Usage', function() {
 
 	const defaultEntityMock = {
 		startDate: () => '2020-01-22T04:59:00.000Z',
-		canEditStartDate: () => Promise.resolve(true),
 		dueDate: () => '2020-01-23T04:59:00.000Z',
-		canEditDueDate: () => Promise.resolve(true),
 		endDate: () => '2020-01-24T04:59:00.000Z',
-		canEditEndDate: () => Promise.resolve(true),
+		canEditDates: () => Promise.resolve(true),
 		isDraft: () => true,
 		canEditDraft: () => true
 	};
@@ -44,14 +42,10 @@ describe('Activity Usage', function() {
 			const activity = new ActivityUsage('http://1', 'token');
 			await activity.fetch();
 
+			expect(activity.canEditDates).to.be.true;
 			expect(activity.startDate).to.equal('2020-01-22T04:59:00.000Z');
-			expect(activity.canEditStartDate).to.be.true;
-
 			expect(activity.dueDate).to.equal('2020-01-23T04:59:00.000Z');
-			expect(activity.canEditDueDate).to.be.true;
-
 			expect(activity.endDate).to.equal('2020-01-24T04:59:00.000Z');
-			expect(activity.canEditEndDate).to.be.true;
 
 			expect(activity.isDraft).to.be.true;
 			expect(activity.canEditDraft).to.be.true;


### PR DESCRIPTION
Replaces checking for `canEditStartDate`, `canEditDueDate`, and `canEditEndDate` with `canEditDates` based on the new aggregate save dates action.

Depends on a new helper methon in the siren-sdk: https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/132