### PR TITLE
US111888 Availability Dates are progressively disclosed in the right panel

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
@@ -1,0 +1,138 @@
+import '../d2l-activity-availability-dates-summary.js';
+import '../d2l-activity-availability-dates-editor.js';
+import '../d2l-activity-release-conditions-editor.js';
+import '@brightspace-ui-labs/accordion/accordion-collapse.js';
+import { bodySmallStyles, heading4Styles } from '@brightspace-ui/core/components/typography/styles.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { getLocalizeResources } from '../localization.js';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+
+class ActivityAssignmentAvailabilityEditor extends LocalizeMixin(LitElement) {
+
+	static get properties() {
+
+		return {
+			href: { type: String },
+			token: { type: Object }
+		};
+	}
+
+	static get styles() {
+
+		return [
+			bodySmallStyles,
+			heading4Styles,
+			css`
+				:host {
+					display: block;
+				}
+
+				:host([hidden]) {
+					display: none;
+				}
+
+				.editor {
+					margin: 1rem 0;
+				}
+
+				.d2l-heading-4 {
+					margin: 0 0 0.6rem 0;
+				}
+
+				.d2l-body-small {
+					margin: 0 0 0.3rem 0;
+				}
+
+				.summary {
+					list-style: none;
+					padding-left: 0.2rem;
+					color: var(--d2l-color-galena);
+				}
+			`
+		];
+	}
+
+	static async getLocalizeResources(langs) {
+		return getLocalizeResources(langs, import.meta.url);
+	}
+
+	_renderAvailabilityDatesSummary() {
+
+		return html`
+			<d2l-activity-availability-dates-summary
+				href="${this.href}"
+				.token="${this.token}">
+			</d2l-activity-availability-dates-summary>
+		`;
+	}
+
+	_renderAvailabilityDatesEditor() {
+
+		return html`
+			<div class="editor">
+				<d2l-activity-availability-dates-editor
+					href="${this.href}"
+					.token="${this.token}">
+				</d2l-activity-availability-dates-editor>
+			</div>
+		`;
+	}
+
+	_renderReleaseConditionSummary() {
+
+		return html``;
+	}
+
+	_renderReleaseConditionEditor() {
+
+		return html`
+			<div class="editor">
+				<h3 class="d2l-heading-4">
+					${this.localize('hdrReleaseConditions')}
+				</h3>
+				<p class="d2l-body-small">
+					${this.localize('hlpReleaseConditions')}
+				</p>
+				<d2l-activity-release-conditions-editor
+					href="${this.href}"
+					.token="${this.token}">
+				</d2l-activity-release-conditions-editor>
+			</div>
+		`;
+	}
+
+	_renderSpecialAccessSummary() {
+
+		return html``;
+	}
+
+	_renderSpecialAccessEditor() {
+
+		return html``;
+	}
+
+	render() {
+
+		return html`
+			<d2l-labs-accordion-collapse flex header-border>
+				<h4 class="header" slot="header">
+					${this.localize('hdrAvailability')}
+				</h4>
+				<ul class="summary" slot="summary">
+					${this._renderAvailabilityDatesSummary()}
+					${this._renderReleaseConditionSummary()}
+					${this._renderSpecialAccessSummary()}
+				</ul>
+				${this._renderAvailabilityDatesEditor()}
+				${this._renderReleaseConditionEditor()}
+				${this._renderSpecialAccessEditor()}
+			</d2l-labs-accordion-collapse>
+		`;
+	}
+
+}
+
+customElements.define(
+	'd2l-activity-assignment-availability-editor',
+	ActivityAssignmentAvailabilityEditor
+);

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-secondary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-secondary.js
@@ -1,7 +1,6 @@
-import './d2l-assignment-turnitin-editor';
-import '../d2l-activity-availability-dates-editor.js';
-import '../d2l-activity-release-conditions-editor.js';
+import './d2l-activity-assignment-availability-editor.js';
 import './d2l-activity-assignment-type-editor.js';
+import './d2l-assignment-turnitin-editor';
 import 'd2l-inputs/d2l-input-checkbox.js';
 import 'd2l-inputs/d2l-input-checkbox-spacer.js';
 import '@brightspace-ui-labs/accordion/accordion-collapse.js';
@@ -184,6 +183,12 @@ class AssignmentEditorSecondary extends SaveStatusMixin(RtlMixin(EntityMixinLit(
 
 	render() {
 		return html`
+
+			<d2l-activity-assignment-availability-editor
+				href="${this._activityUsageHref}"
+				.token="${this.token}">
+			</d2l-activity-assignment-availability-editor>
+
 			<div id="assignment-type-container">
 				<h3 class="assignment-type-heading d2l-heading-4">${this.localize('txtAssignmentType')}</h3>
 				<d2l-activity-assignment-type-editor
@@ -214,22 +219,6 @@ class AssignmentEditorSecondary extends SaveStatusMixin(RtlMixin(EntityMixinLit(
 
 					${this._getCompletionTypeOptions()}
 				</select>
-			</div>
-
-			<div id="availability-dates-container">
-				<d2l-activity-availability-dates-editor
-					href="${this._activityUsageHref}"
-					.token="${this.token}">
-				</d2l-activity-availability-dates-editor>
-			</div>
-
-			<div id="assignment-release-conditions-container">
-				<h3 class="d2l-heading-4">${this.localize('hdrReleaseConditions')}</h3>
-				<p class="d2l-body-small">${this.localize('hlpReleaseConditions')}</p>
-				<d2l-activity-release-conditions-editor
-					href="${this._activityUsageHref}"
-					.token="${this.token}">
-				</d2l-activity-release-conditions-editor>
 			</div>
 
 			<d2l-labs-accordion-collapse class="accordion" flex header-border>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
@@ -13,6 +13,7 @@ export default {
 	"hlpTurnitin": "The Turnitin® Integration allows you to use Originality Check® to assess student work for academic integrity and to use the GradeMark® external evaluation tool for assessment.", // turnitin help
 	"btnEditTurnitin": "Manage Turnitin® Integration", // edit turnitin button
 	"btnCloseDialog": "Close this Dialog", // close dialog button
+	"hdrAvailability": "Availability Dates & Conditions", // availability header
 	"name": "Name", // Label for the name field when creating/editing an activity
 	"submissionType": "Submission Type", // Label for the submission type field when creating/editing an assignment
 	"annotationTools": "Annotation Tools", // Label for enabling/disabling Annotation Tools when creating/editing an assignment

--- a/components/d2l-activity-editor/d2l-activity-availability-dates-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-summary.js
@@ -35,7 +35,7 @@ class ActivityAvailabilityDatesSummary
 	render() {
 
 		const activity = store.get(this.href);
-		if (activity == null) {
+		if (!activity) {
 			return html``;
 		}
 
@@ -44,11 +44,11 @@ class ActivityAvailabilityDatesSummary
 
 		let text;
 
-		if (startDate != null && endDate != null) {
+		if (startDate && endDate) {
 			text = this.localize('txtAvailabilityStartAndEnd', { startDate, endDate });
-		} else if (startDate != null) {
+		} else if (startDate) {
 			text = this.localize('txtAvailabilityStartOnly', { startDate });
-		} else if (endDate != null) {
+		} else if (endDate) {
 			text = this.localize('txtAvailabilityEndOnly', { endDate });
 		} else {
 			text = this.localize('txtAvailabilityNeither');
@@ -59,7 +59,7 @@ class ActivityAvailabilityDatesSummary
 
 	_formatDate(suspiciousString) {
 
-		if (suspiciousString == null) {
+		if (!suspiciousString) {
 			return null;
 		}
 

--- a/components/d2l-activity-editor/d2l-activity-availability-dates-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-summary.js
@@ -1,0 +1,78 @@
+import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
+import { formatDate } from '@brightspace-ui/intl/lib/dateTime.js';
+import { getLocalizeResources } from './localization';
+import { html } from 'lit-element/lit-element';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { MobxLitElement } from '@adobe/lit-mobx';
+import { shared as store } from './state/activity-store.js';
+
+class ActivityAvailabilityDatesSummary
+	extends ActivityEditorMixin(LocalizeMixin(MobxLitElement)) {
+
+	static async getLocalizeResources(langs) {
+		return getLocalizeResources(langs, import.meta.url);
+	}
+
+	constructor() {
+		super();
+		this._overrides = document.documentElement.dataset.intlOverrides || '{}';
+	}
+
+	updated(changedProperties) {
+
+		super.updated(changedProperties);
+
+		const didHrefTokenChange =
+			changedProperties.has('href') ||
+			changedProperties.has('token');
+
+		if (didHrefTokenChange && this.href && this.token) {
+
+			super._fetch(() => store.fetch(this.href, this.token));
+		}
+	}
+
+	render() {
+
+		const activity = store.get(this.href);
+		if (activity == null) {
+			return html``;
+		}
+
+		const startDate = this._formatDate(activity.startDate);
+		const endDate = this._formatDate(activity.endDate);
+
+		let text;
+
+		if (startDate != null && endDate != null) {
+			text = this.localize('txtAvailabilityStartAndEnd', { startDate, endDate });
+		} else if (startDate != null) {
+			text = this.localize('txtAvailabilityStartOnly', { startDate });
+		} else if (endDate != null) {
+			text = this.localize('txtAvailabilityEndOnly', { endDate });
+		} else {
+			text = this.localize('txtAvailabilityNeither');
+		}
+
+		return html`${text}`;
+	}
+
+	_formatDate(suspiciousString) {
+
+		if (suspiciousString == null) {
+			return null;
+		}
+
+		const date = new Date(suspiciousString);
+
+		if (isNaN(date.getTime())) {
+			return null;
+		}
+
+		return formatDate(date);
+	}
+}
+customElements.define(
+	'd2l-activity-availability-dates-summary',
+	ActivityAvailabilityDatesSummary
+);

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -17,6 +17,10 @@ export default {
 	"noStartDate": "No start date", // Placeholder text for due date field when no due date is set
 	"visible": "Visible", // Label displayed with the visibility switch when visible
 	"ariaVisible": "Visible to students", // Aria Label for the visibility switch when visible
+	"txtAvailabilityStartAndEnd": "Availability starts {startDate} and ends {endDate}", // start/end text
+	"txtAvailabilityStartOnly": "Availability starts {startDate}", // start only text
+	"txtAvailabilityEndOnly": "Availability ends {endDate}", // end only text
+	"txtAvailabilityNeither": "Always available", // always available text
 	"ungraded": "Ungraded", // State of score field when there is no score and no grade item, when creating/editing an activity
 	"inGrades": "In Grades", // State of the grades field when there is a score, and an associated grade item
 	"notInGrades": "Not in Grades", // State of the grades field when there is a score, but no associated grade item


### PR DESCRIPTION
[US111888](https://rally1.rallydev.com/#/detail/userstory/350128946056?fdp=true)

This PR moves the availability dates and release conditions into the accordion from the design. I yanked them from the editor secondary guy into a new element because it's more readable this way. I stubbed out the summary for release conditions, and the summary and editor for special access, neither of which can be implemented yet.

Screenshots:

- [closed](https://user-images.githubusercontent.com/30184468/74379900-96f13c00-4db6-11ea-812b-17dde8b5b809.png)
- [open](https://user-images.githubusercontent.com/30184468/74379901-96f13c00-4db6-11ea-9ddc-f8ab06e85496.png)

