### PR TITLE
Implement save of attachments

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,9 +32,8 @@
             "disableOptimisticBPs": true,
             "args": [
                 "--runInBand",
-                "${relativeFile}",
+                "${fileBasename}",
                 "--env=jsdom",
-                "--watch"
             ],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
@@ -43,22 +42,49 @@
             },
             "cwd": "${workspaceRoot}/"
         },
+        // {
+        //     "type": "node",
+        //     "request": "launch",
+        //     "name": "Jest Current File",
+        //     "program": "${workspaceRoot}/node_modules/.bin/jest",
+        //     "disableOptimisticBPs": true,
+        //     "args": [
+        //         "--runInBand",
+        //         "${input:testName}", // Doesn't resolve input
+        //         "${relativeFile}", // Doesn't work on windows as uses back slash path separators which jest doesn't like
+        //         "--env=jsdom",
+        //     ],
+        //     "console": "integratedTerminal",
+        //     "internalConsoleOptions": "neverOpen",
+        //     "windows": {
+        //         "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+        //     },
+        //     "cwd": "${workspaceRoot}/"
+        // },
+        // {
+        //     "type": "node",
+        //     "request": "launch",
+        //     "name": "Jest Workspace File",
+        //     "program": "${workspaceRoot}/node_modules/.bin/jest",
+        //     "disableOptimisticBPs": true,
+        //     "args": [
+        //         "--runInBand",
+        //          "--env=jsdom"
+        //     ],
+        //     "console": "integratedTerminal",
+        //     "internalConsoleOptions": "neverOpen",
+        //     "windows": {
+        //         "program": "${workspaceRoot}/node_modules/jest/bin/jest"
+        //     },
+        //     "cwd": "${workspaceRoot}/"
+        // }
+    ],
+    "inputs": [
         {
-            "type": "node",
-            "request": "launch",
-            "name": "Jest Workspace File",
-            "program": "${workspaceRoot}/node_modules/.bin/jest",
-            "disableOptimisticBPs": true,
-            "args": [
-                "--runInBand",
-                 "--env=jsdom"
-            ],
-            "console": "integratedTerminal",
-            "internalConsoleOptions": "neverOpen",
-            "windows": {
-                "program": "${workspaceRoot}/node_modules/jest/bin/jest"
-            },
-            "cwd": "${workspaceRoot}/"
+            "type": "promptString",
+            "id": "testName",
+            "description": "The file or name you want to test",
+            "default": "echo ${fileBasename}"
         }
     ]
 }

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachment.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachment.js
@@ -18,7 +18,7 @@ class ActivityAttachment extends ActivityEditorMixin(MobxLitElement) {
 		super(store);
 	}
 
-	_onAttachmentRemoved() {
+	_onToggleRemoved() {
 		const attachment = store.get(this.href);
 		attachment.markDeleted(!attachment.deleted);
 	}
@@ -45,8 +45,8 @@ class ActivityAttachment extends ActivityEditorMixin(MobxLitElement) {
 				?deleted="${deleted}"
 				?creating="${creating}"
 				?editing="${editing}"
-				@d2l-attachment-removed="${this._onAttachmentRemoved}"
-				@d2l-attachment-restored="${this._onAttachmentRemoved}"
+				@d2l-attachment-removed="${this._onToggleRemoved}"
+				@d2l-attachment-restored="${this._onToggleRemoved}"
 			>
 			</d2l-labs-attachment>
 		`;

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
@@ -52,5 +52,12 @@ class ActivityAttachmentsEditor extends ActivityEditorMixin(MobxLitElement) {
 			` :	html``}
 		`;
 	}
+
+	async save() {
+		const collection = store.get(this.href);
+		if (collection) {
+			await collection.save();
+		}
+	}
 }
 customElements.define('d2l-activity-attachments-editor', ActivityAttachmentsEditor);

--- a/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-collection.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-collection.js
@@ -135,5 +135,6 @@ decorate(AttachmentCollection, {
 	setCanRecordVideo: action,
 	setCanRecordAudio: action,
 	setAttachments: action,
-	addAttachment: action
+	addAttachment: action,
+	save: action
 });

--- a/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-collections-store.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-collections-store.js
@@ -1,10 +1,21 @@
 import { AttachmentCollection } from './attachment-collection.js';
+import { shared as attachmentStore } from './attachment-store.js';
 import { ObjectStore } from '../../state/object-store.js';
 
 export class AttachmentCollectionsStore extends ObjectStore {
 	constructor() {
 		super(AttachmentCollection);
 	}
+
+	getAttachmentStore() {
+		return this._attachmentStore;
+	}
+	setAttachmentStore(attachmentStore) {
+		this._attachmentStore = attachmentStore;
+	}
+
 }
 
 export const shared = new AttachmentCollectionsStore();
+
+shared.setAttachmentStore(attachmentStore);

--- a/components/d2l-activity-editor/d2l-activity-attachments/state/attachment.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/state/attachment.js
@@ -27,8 +27,6 @@ export class Attachment {
 		this._entity = entity;
 
 		this.editing = entity.canDeleteAttachment();
-		this.creating = false;
-		this.deleted = false;
 
 		this.attachment = {
 			id: entity.self(),
@@ -43,6 +41,12 @@ export class Attachment {
 
 	markDeleted(deleted) {
 		this.deleted = deleted;
+	}
+
+	async delete() {
+		if (this._entity) {
+			await this._entity.deleteAttachment();
+		}
 	}
 }
 
@@ -61,13 +65,16 @@ export class LinkAttachment extends Attachment {
 	initLink(name, url) {
 		this.editing = true;
 		this.creating = true;
-		this.deleted = false;
 
 		this.attachment = {
 			id: this.href,
 			name: name,
 			url: url
 		};
+	}
+
+	async save(entity) {
+		await entity.addLinkAttachment(this.attachment.name, this.attachment.url);
 	}
 }
 
@@ -77,16 +84,21 @@ decorate(LinkAttachment, {
 });
 
 export class GoogleDriveAttachment extends LinkAttachment {
+	async save(entity) {
+		await entity.addGoogleDriveLinkAttachment(this.attachment.name, this.attachment.url);
+	}
 }
 
 export class OneDriveAttachment extends LinkAttachment {
+	async save(entity) {
+		await entity.addOneDriveLinkAttachment(this.attachment.name, this.attachment.url);
+	}
 }
 
 export class FileAttachment extends Attachment {
 	initFile(name, fileSystemType, fileId) {
 		this.editing = true;
 		this.creating = true;
-		this.deleted = false;
 
 		this.fileSystemType = fileSystemType;
 		this.fileId = fileId;
@@ -99,6 +111,10 @@ export class FileAttachment extends Attachment {
 			type: 'Document'
 		};
 	}
+
+	async save(entity) {
+		await entity.addFileAttachment(this.fileSystemType, this.fileId);
+	}
 }
 
 decorate(FileAttachment, {
@@ -107,8 +123,14 @@ decorate(FileAttachment, {
 });
 
 export class VideoAttachment extends FileAttachment {
+	async save(entity) {
+		await entity.addVideoNoteAttachment(this.fileSystemType, this.fileId);
+	}
 }
 
 export class AudioAttachment extends FileAttachment {
+	async save(entity) {
+		await entity.addAudioNoteAttachment(this.fileSystemType, this.fileId);
+	}
 }
 

--- a/components/d2l-activity-editor/state/object-store.js
+++ b/components/d2l-activity-editor/state/object-store.js
@@ -10,7 +10,7 @@ export class ObjectStore {
 	async fetch(href, token) {
 		let promise = this._fetches.get(href);
 		if (!promise) {
-			const object = new this.Type(href, token);
+			const object = new this.Type(href, token, this);
 
 			promise = object.fetch();
 			this._fetches.set(href, promise);
@@ -32,6 +32,11 @@ export class ObjectStore {
 	put(href, object) {
 		this._objects.set(href, object);
 		this._fetches.set(href, Promise.resolve(object));
+	}
+
+	remove(href) {
+		this._objects.delete(href);
+		this._fetches.delete(href);
 	}
 
 	clear() {

--- a/components/d2l-activity-editor/state/object-store.js
+++ b/components/d2l-activity-editor/state/object-store.js
@@ -51,6 +51,7 @@ decorate(ObjectStore, {
 	// actions
 	fetch: action,
 	put: action,
-	clear: action
+	clear: action,
+	remove: action
 });
 

--- a/test/d2l-activity-editor/d2l-activity-attachments/state/attachment-collection.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-attachments/state/attachment-collection.spec.js
@@ -1,17 +1,23 @@
-import { Attachment } from '../../../../components/d2l-activity-editor/d2l-activity-attachments/state/attachment.js';
+import chai, { expect } from 'chai';
 import { AttachmentCollection } from '../../../../components/d2l-activity-editor/d2l-activity-attachments/state/attachment-collection.js';
 import { AttachmentCollectionEntity } from 'siren-sdk/src/activities/AttachmentCollectionEntity.js';
-import { expect } from 'chai';
+import { AttachmentCollectionsStore } from '../../../../components/d2l-activity-editor/d2l-activity-attachments/state/attachment-collections-store.js';
+import { AttachmentStore } from '../../../../components/d2l-activity-editor/d2l-activity-attachments/state/attachment-store.js';
+import chaiAsPromised from 'chai-as-promised';
 import { fetchEntity } from '../../../../components/d2l-activity-editor/state/fetch-entity.js';
 import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 import { when } from 'mobx';
+
+chai.use(chaiAsPromised);
+chai.use(sinonChai);
 
 jest.mock('siren-sdk/src/activities/AttachmentCollectionEntity.js');
 jest.mock('../../../../components/d2l-activity-editor/state/fetch-entity.js');
 
 describe('Attachment Collection', function() {
 
-	const defaultEntityMock = {
+	const defaultCollectionEntityMock = {
 		canAddAttachments: () => true,
 		canAddLinkAttachment: () => true,
 		canAddFileAttachment: () => true,
@@ -19,7 +25,7 @@ describe('Attachment Collection', function() {
 		canAddOneDriveLinkAttachment: () => true,
 		canAddVideoNoteAttachment: () => true,
 		canAddAudioNoteAttachment: () => false,
-		getAttachmentEntityHrefs: () => ['http://attachment/1', 'http://attachment/2']
+		getAttachmentEntityHrefs: () => []
 	};
 
 	afterEach(() => {
@@ -30,15 +36,20 @@ describe('Attachment Collection', function() {
 
 	let sirenEntity;
 
+	beforeEach(() => {
+		sirenEntity = sinon.stub();
+		fetchEntity.mockImplementation(() => Promise.resolve(sirenEntity));
+	});
+
 	describe('fetching', () => {
+
 		beforeEach(() => {
-			sirenEntity = sinon.stub();
-
 			AttachmentCollectionEntity.mockImplementation(() => {
-				return defaultEntityMock;
+				return {
+					...defaultCollectionEntityMock,
+					getAttachmentEntityHrefs: () => ['http://attachment/1', 'http://attachment/2']
+				};
 			});
-
-			fetchEntity.mockImplementation(() => Promise.resolve(sirenEntity));
 		});
 
 		it('fetches', async() => {
@@ -65,7 +76,9 @@ describe('Attachment Collection', function() {
 
 	describe('updating', () => {
 		it('reacts to new attachment', async(done) => {
-			const attachment = new Attachment('http://attachment/1', 'token');
+			const attachment = {
+				href: 'http://attachment/1'
+			};
 			const collection = new AttachmentCollection('http://collection/1', 'token');
 
 			when(
@@ -76,6 +89,89 @@ describe('Attachment Collection', function() {
 			);
 
 			collection.addAttachment(attachment);
+		});
+	});
+
+	describe('saving', () => {
+		let store, attachmentStore, collection;
+
+		beforeEach(async() => {
+			AttachmentCollectionEntity.mockImplementation(() => {
+				return defaultCollectionEntityMock;
+			});
+
+			store = new AttachmentCollectionsStore();
+			attachmentStore = new AttachmentStore();
+			store.setAttachmentStore(attachmentStore);
+
+			collection = new AttachmentCollection('http://collection/1', 'token', store);
+
+			await collection.fetch();
+		});
+
+		describe('errors', () => {
+			it('throws error if no attachment store configured', async() => {
+				expect(collection.save()).to.be.rejectedWith(Error);
+			});
+		});
+
+		describe('succeeds', () => {
+
+			function addToCollection(attachment) {
+				collection.addAttachment(attachment);
+				attachmentStore.put(attachment.href, attachment);
+			}
+
+			it('deletes existing attachments which were removed', async() => {
+				const mockDelete = sinon.stub();
+				const attachment = {
+					href: 'http://attachment/1',
+					deleted: true,
+					creating: false,
+					delete: mockDelete
+				};
+
+				addToCollection(attachment);
+				await collection.save();
+
+				expect(mockDelete).to.have.been.calledOnce;
+				expect(fetchEntity.mock.calls.length).to.equal(2);
+				expect(attachmentStore.get('http://attachment/1')).to.be.undefined;
+			});
+
+			it('ignores new attachments that were immediately removed', async() => {
+				const mockDelete = sinon.stub();
+				const attachment = {
+					href: 'http://attachment/1',
+					deleted: true,
+					creating: true,
+					delete: mockDelete
+				};
+
+				addToCollection(attachment);
+				await collection.save();
+
+				expect(mockDelete.callCount).to.equal(0);
+				expect(attachmentStore.get('http://attachment/1')).to.be.undefined;
+				expect(collection.attachments).to.be.empty;
+			});
+
+			it('saves new attachments', async() => {
+				const mockSave = sinon.stub();
+				const attachment = {
+					href: 'http://attachment/1',
+					deleted: false,
+					creating: true,
+					save: mockSave
+				};
+
+				addToCollection(attachment);
+				await collection.save();
+
+				expect(mockSave).to.have.been.calledWithExactly(AttachmentCollectionEntity.mock.results[0].value);
+				expect(fetchEntity.mock.calls.length).to.equal(2);
+				expect(attachmentStore.get('http://attachment/1')).to.be.undefined;
+			});
 		});
 	});
 });


### PR DESCRIPTION
This is the final PR for save/cancel of attachments. Once this is approved I will merge the 2 branches into the `mbayly/save-cancel-attachments-2` branch, and then request a final approval on that merged PR in order to push to master.

The bulk of this PR is adding the polymorphic save methods to each of the attachment types, and adding the attachment collection save method, which determines which attachments are new/deleted/discarded based on analyzing the `creating` and `deleted` flags. The attachment collection tells each changed attachment to either delete or save itself, passing in the current `AttachmentCollectionEntity` into the `save` method so the attachment can call the specific attachment save action (e.g. link, google, onedrive, file etc).

You'll see that I had to add a reference to the attachment store, to the attachment collection store and give each collection a reference to it's attachment collection store so that it can get access to the attachment store. This is needed during save to allow the attachment collection to get access to the actual attachments, as currently the collection only stores the hrefs of the associated attachments. With hindsight, I might have been able to avoid having to connect the stores in this way by storing the actual attachment references in the attachment collection as opposed to just the hrefs. Possibly a candidate for a future refactoring if we think that would be cleaner, but I'm happy enough with the implemented approach for now.

@emil-furniss I also renamed the delete attachment method and simplified the setting of the attachment status flags in this PR, based on your comments from the previous PR.