### PR TITLE
Integrate validation requests with mobx state 

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
@@ -44,46 +44,6 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeMixin
 		store.get(this.href).setEndDate(e.detail.toISOString());
 	}
 
-	_getStartDateErrorLangterm(errorType) {
-		if (!errorType) {
-			return null;
-		}
-
-		if (errorType.includes('end-due-start-date-error')) {
-			return this.localize('dueBetweenStartEndDate');
-		}
-
-		if (errorType.includes('start-after-end-date-error') || errorType.includes('start-after-due-date-error')) {
-			return this.localize('dueAfterStartDate');
-		}
-
-		if (errorType.includes('end-before-start-date-error')) {
-			return this.localize('startBeforeEndDate');
-		}
-
-		return null;
-	}
-
-	_getEndDateErrorLangterm(errorType) {
-		if (!errorType) {
-			return null;
-		}
-
-		if (errorType.includes('end-due-start-date-error')) {
-			return this.localize('dueBetweenStartEndDate');
-		}
-
-		if (errorType.includes('start-after-end-date-error')) {
-			return this.localize('startBeforeEndDate');
-		}
-
-		if (errorType.includes('end-before-start-date-error') || errorType.includes('end-before-due-date-error')) {
-			return this.localize('dueBeforeEndDate');
-		}
-
-		return null;
-	}
-
 	render() {
 		const activity = store.get(this.href);
 		let canEditDates, startDate, endDate, startDateErrorTerm, endDateErrorTerm;
@@ -98,8 +58,8 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeMixin
 			canEditDates = activity.canEditDates;
 			startDate = activity.startDate;
 			endDate = activity.endDate;
-			startDateErrorTerm = this._getStartDateErrorLangterm(activity.errorType);
-			endDateErrorTerm = this._getEndDateErrorLangterm(activity.errorType);
+			startDateErrorTerm = this.localize(activity.startDateErrorTerm);
+			endDateErrorTerm = this.localize(activity.endDateErrorTerm);
 		}
 
 		//TODO: Ugly hacked-in error tooltips can probably be removed when we have date pickers with proper error styling

--- a/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
@@ -44,20 +44,65 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeMixin
 		store.get(this.href).setEndDate(e.detail.toISOString());
 	}
 
+	_getStartDateErrorLangterm(errorType) {
+		if (!errorType) {
+			return null;
+		}
+
+		if (errorType.includes('end-due-start-date-error')) {
+			return this.localize('dueBetweenStartEndDate');
+		}
+
+		if (errorType.includes('start-after-end-date-error') || errorType.includes('start-after-due-date-error')) {
+			return this.localize('dueAfterStartDate');
+		}
+
+		if (errorType.includes('end-before-start-date-error')) {
+			return this.localize('startBeforeEndDate');
+		}
+
+		return null;
+	}
+
+	_getEndDateErrorLangterm(errorType) {
+		if (!errorType) {
+			return null;
+		}
+
+		if (errorType.includes('end-due-start-date-error')) {
+			return this.localize('dueBetweenStartEndDate');
+		}
+
+		if (errorType.includes('start-after-end-date-error')) {
+			return this.localize('startBeforeEndDate');
+		}
+
+		if (errorType.includes('end-before-start-date-error') || errorType.includes('end-before-due-date-error')) {
+			return this.localize('dueBeforeEndDate');
+		}
+
+		return null;
+	}
+
 	render() {
 		const activity = store.get(this.href);
-		let canEditDates, startDate, endDate;
+		let canEditDates, startDate, endDate, startDateErrorTerm, endDateErrorTerm;
 
 		if (!activity) {
 			canEditDates = false;
 			startDate = null;
 			endDate = null;
+			startDateErrorTerm = null;
+			endDateErrorTerm = null;
 		} else {
 			canEditDates = activity.canEditDates;
 			startDate = activity.startDate;
 			endDate = activity.endDate;
+			startDateErrorTerm = this._getStartDateErrorLangterm(activity.errorType);
+			endDateErrorTerm = this._getEndDateErrorLangterm(activity.errorType);
 		}
 
+		//TODO: Ugly hacked-in error tooltips can probably be removed when we have date pickers with proper error styling
 		return html`
 			<label class="d2l-label-text" ?hidden=${!canEditDates}>${this.localize('startDate')}</label>
 			<div id="startdate-container" ?hidden=${!canEditDates}>
@@ -70,9 +115,19 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeMixin
 					datetime="${startDate}"
 					overrides="${this._overrides}"
 					placeholder="${this.localize('noStartDate')}"
+					aria-invalid="${startDateErrorTerm ? 'true' : 'false'}"
 					@d2l-datetime-picker-datetime-changed="${this._onStartDatetimePickerDatetimeChanged}"
 					@d2l-datetime-picker-datetime-cleared="${this._onStartDatetimePickerDatetimeCleared}">
 				</d2l-datetime-picker>
+				${startDateErrorTerm ? html`
+					<d2l-tooltip
+						id="score-tooltip"
+						for="startDate"
+						position="bottom"
+					>
+						${startDateErrorTerm}
+					</d2l-tooltip>
+				` : null}
 			</div>
 			<label class="d2l-label-text" ?hidden=${!canEditDates}>${this.localize('endDate')}</label>
 			<div id="enddate-container" ?hidden=${!canEditDates}>
@@ -85,9 +140,19 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeMixin
 					datetime="${endDate}"
 					overrides="${this._overrides}"
 					placeholder="${this.localize('noEndDate')}"
+					aria-invalid="${endDateErrorTerm ? 'true' : 'false'}"
 					@d2l-datetime-picker-datetime-changed="${this._onEndDatetimePickerDatetimeChanged}"
 					@d2l-datetime-picker-datetime-cleared="${this._onEndDatetimePickerDatetimeCleared}">
 				</d2l-datetime-picker>
+				${endDateErrorTerm ? html`
+					<d2l-tooltip
+						id="score-tooltip"
+						for="endDate"
+						position="bottom"
+					>
+						${endDateErrorTerm}
+					</d2l-tooltip>
+				` : null}
 			</div>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-due-date-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-due-date-editor.js
@@ -110,7 +110,7 @@ class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeMixin(MobxLitEle
 		if (!activity || this._isFirstLoad) {
 			dueDate = null;
 			canEditDates = false;
-			errorTerm = null
+			errorTerm = null;
 		} else {
 			dueDate = activity.dueDate;
 			canEditDates = activity.canEditDates;

--- a/components/d2l-activity-editor/d2l-activity-due-date-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-due-date-editor.js
@@ -75,26 +75,6 @@ class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeMixin(MobxLitEle
 		`;
 	}
 
-	_getErrorLangterm(errorType) {
-		if (!errorType) {
-			return null;
-		}
-
-		if (errorType.includes('end-due-start-date-error')) {
-			return this.localize('dueBetweenStartEndDate');
-		}
-
-		if (errorType.includes('start-after-end-date-error') || errorType.includes('start-after-due-date-error')) {
-			return this.localize('dueAfterStartDate');
-		}
-
-		if (errorType.includes('end-before-start-date-error') || errorType.includes('end-before-due-date-error')) {
-			return this.localize('dueBeforeEndDate');
-		}
-
-		return null;
-	}
-
 	render() {
 		const activity = store.get(this.href);
 		let dueDate, canEditDates, errorTerm;
@@ -114,7 +94,7 @@ class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeMixin(MobxLitEle
 		} else {
 			dueDate = activity.dueDate;
 			canEditDates = activity.canEditDates;
-			errorTerm = this._getErrorLangterm(activity.errorType);
+			errorTerm = this.localize(activity.dueDateErrorTerm);
 		}
 
 		return html`

--- a/components/d2l-activity-editor/d2l-activity-due-date-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-due-date-editor.js
@@ -1,4 +1,5 @@
 import 'd2l-datetime-picker/d2l-datetime-picker';
+import 'd2l-tooltip/d2l-tooltip';
 import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
 import { getLocalizeResources } from './localization';
@@ -44,7 +45,8 @@ class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeMixin(MobxLitEle
 		store.get(this.href).setDueDate(e.detail.toISOString());
 	}
 
-	dateTemplate(date, canEdit) {
+	dateTemplate(date, canEdit, errorTerm) {
+		//TODO: Ugly hacked-in error tooltips can probably be removed when we have date pickers with proper error styling
 		return html`
 			<div id="datetime-picker-container" ?hidden="${!canEdit}">
 				<d2l-datetime-picker
@@ -56,16 +58,46 @@ class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeMixin(MobxLitEle
 					datetime="${date}"
 					overrides="${this._overrides}"
 					placeholder="${this.localize('noDueDate')}"
+					aria-invalid="${errorTerm ? 'true' : 'false'}"
 					@d2l-datetime-picker-datetime-changed="${this._onDatetimePickerDatetimeChanged}"
 					@d2l-datetime-picker-datetime-cleared="${this._onDatetimePickerDatetimeCleared}">
 				</d2l-datetime-picker>
+				${errorTerm ? html`
+					<d2l-tooltip
+						id="score-tooltip"
+						for="date"
+						position="bottom"
+					>
+						${errorTerm}
+					</d2l-tooltip>
+				` : null}
 			</div>
 		`;
 	}
 
+	_getErrorLangterm(errorType) {
+		if (!errorType) {
+			return null;
+		}
+
+		if (errorType.includes('end-due-start-date-error')) {
+			return this.localize('dueBetweenStartEndDate');
+		}
+
+		if (errorType.includes('start-after-end-date-error') || errorType.includes('start-after-due-date-error')) {
+			return this.localize('dueAfterStartDate');
+		}
+
+		if (errorType.includes('end-before-start-date-error') || errorType.includes('end-before-due-date-error')) {
+			return this.localize('dueBeforeEndDate');
+		}
+
+		return null;
+	}
+
 	render() {
 		const activity = store.get(this.href);
-		let dueDate, canEditDates;
+		let dueDate, canEditDates, errorTerm;
 
 		// We have to render with null values for dueDate initially due to issues with
 		// how the d2l-datetime-picker converts between the date & datetime attributes.
@@ -78,13 +110,15 @@ class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeMixin(MobxLitEle
 		if (!activity || this._isFirstLoad) {
 			dueDate = null;
 			canEditDates = false;
+			errorTerm = null
 		} else {
 			dueDate = activity.dueDate;
 			canEditDates = activity.canEditDates;
+			errorTerm = this._getErrorLangterm(activity.errorType);
 		}
 
 		return html`
-			${this.dateTemplate(dueDate, canEditDates)}
+			${this.dateTemplate(dueDate, canEditDates, errorTerm)}
 		`;
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -51,6 +51,13 @@ class ActivityEditor extends PendingContainerMixin(ActivityEditorMixin(LocalizeM
 		this.loading = false;
 	}
 
+	async validate() {
+		const activity = store.get(this.href);
+		if (activity) {
+			await activity.validate();
+		}
+	}
+
 	async save() {
 		const activity = store.get(this.href);
 		if (activity) {

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -35,5 +35,9 @@ export default {
 	"cancel": "Cancel", // Text of dialog button to cancel action
 	"ariaToolbarShortcutInstructions": "Press ALT-F10 for toolbar, and press ESC to exit toolbar once inside.", // Instructions for screenreader users on how to enter and exit the html editor toolbar
 	"editGradesLink": "Edit Grades Link", // Link text and dialog title for the edit grades dialog,
-	"hdrRubrics": "Rubrics" //Header for the rubrics section
+	"hdrRubrics": "Rubrics", //Header for the rubrics section
+	"startBeforeEndDate": "Start Date must be before End Date",
+	"dueBetweenStartEndDate": "Due Date must be after Start Date and before or equal to End Date",
+	"dueAfterStartDate": "Due Date must be after Start Date",
+	"dueBeforeEndDate": "Due Date must be before or equal to End Date",
 };

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
@@ -23,13 +23,18 @@ export const ActivityEditorContainerMixin = superclass => class extends supercla
 			validations.push(editor.validate());
 		}
 
-		await Promise.all(validations).then(async() => {
-			for (const editor of this._editors) {
-				// TODO - Once we decide how we want to handle errors we may want to add error handling logic
-				// to the save
-				await editor.save();
-			}
-		});
+		try {
+			await Promise.all(validations);
+		} catch (e) {
+			// Skip save on vaidation error
+			return;
+		}
+
+		for (const editor of this._editors) {
+			// TODO - Once we decide how we want to handle errors we may want to add error handling logic
+			// to the save
+			await editor.save();
+		}
 	}
 
 };

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
@@ -19,7 +19,7 @@ export const ActivityEditorContainerMixin = superclass => class extends supercla
 
 	async _save() {
 		try {
-			let validations = [];
+			const validations = [];
 			for (const editor of this._editors) {
 				validations.push(editor.validate());
 			}
@@ -31,7 +31,9 @@ export const ActivityEditorContainerMixin = superclass => class extends supercla
 				// to the save
 				await editor.save();
 			}
-		} catch (e) {}
+		} catch (e) {
+			return;
+		}
 	}
 
 };

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
@@ -18,11 +18,20 @@ export const ActivityEditorContainerMixin = superclass => class extends supercla
 	}
 
 	async _save() {
-		for (const editor of this._editors) {
-			// TODO - Once we decide how we want to handle errors we may want to add error handling logic
-			// to the save
-			await editor.save();
-		}
+		try {
+			let validations = [];
+			for (const editor of this._editors) {
+				validations.push(editor.validate());
+			}
+
+			await Promise.all(validations);
+
+			for (const editor of this._editors) {
+				// TODO - Once we decide how we want to handle errors we may want to add error handling logic
+				// to the save
+				await editor.save();
+			}
+		} catch (e) {}
 	}
 
 };

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
@@ -18,22 +18,18 @@ export const ActivityEditorContainerMixin = superclass => class extends supercla
 	}
 
 	async _save() {
-		try {
-			const validations = [];
-			for (const editor of this._editors) {
-				validations.push(editor.validate());
-			}
+		const validations = [];
+		for (const editor of this._editors) {
+			validations.push(editor.validate());
+		}
 
-			await Promise.all(validations);
-
+		await Promise.all(validations).then(async() => {
 			for (const editor of this._editors) {
 				// TODO - Once we decide how we want to handle errors we may want to add error handling logic
 				// to the save
 				await editor.save();
 			}
-		} catch (e) {
-			return;
-		}
+		});
 	}
 
 };

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
@@ -22,6 +22,8 @@ export const ActivityEditorMixin = superclass => class extends superclass {
 		this.store = store;
 	}
 
+	async validate() {}
+
 	async save() {}
 
 	_dispatchActivityEditorEvent() {

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -61,6 +61,9 @@ export class ActivityUsage {
 			return;
 		}
 
+		this.isError = false;
+		this.errorType = null;
+
 		await this._entity.validate({
 			dueDate: this.dueDate,
 			startDate: this.startDate,
@@ -72,11 +75,6 @@ export class ActivityUsage {
 			}
 			throw e;
 		}));
-
-		runInAction(() => {
-			this.isError = false;
-			this.errorType = null;
-		});
 	}
 
 	async save() {

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -66,13 +66,12 @@ export class ActivityUsage {
 			startDate: this.startDate,
 			endDate: this.endDate
 		}).catch(e => runInAction(() => {
-				this.isError = true;
-				if (e.json && e.json.properties && e.json.properties.type) {
-					this.errorType = e.json.properties.type;
-				}
-				throw e;
-			})
-		);
+			this.isError = true;
+			if (e.json && e.json.properties && e.json.properties.type) {
+				this.errorType = e.json.properties.type;
+			}
+			throw e;
+		}));
 
 		runInAction(() => {
 			this.isError = false;

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -30,6 +30,9 @@ export class ActivityUsage {
 		this.canEditDraft = entity.canEditDraft();
 		this.isError = false;
 		this.errorType = null;
+		this.dueDateErrorTerm = null;
+		this.startDateErrorTerm = null;
+		this.endDateErrorTerm = null;
 	}
 
 	setDueDate(date) {
@@ -56,6 +59,47 @@ export class ActivityUsage {
 		this.canEditDates = value;
 	}
 
+	setErrorLangTerms(errorType) {
+		if (errorType && errorType.includes('end-due-start-date-error')) {
+			this.dueDateErrorTerm = 'dueBetweenStartEndDate';
+			this.startDateErrorTerm = 'dueBetweenStartEndDate';
+			this.endDateErrorTerm = 'dueBetweenStartEndDate';
+			return;
+		}
+
+		if (errorType && errorType.includes('start-after-end-date-error')) {
+			this.dueDateErrorTerm = 'dueAfterStartDate';
+			this.startDateErrorTerm = 'dueAfterStartDate';
+			this.endDateErrorTerm = 'startBeforeEndDate';
+			return;
+		}
+
+		if (errorType && errorType.includes('start-after-due-date-error')) {
+			this.dueDateErrorTerm = 'dueAfterStartDate';
+			this.startDateErrorTerm = 'dueAfterStartDate';
+			this.endDateErrorTerm = null;
+			return;
+		}
+
+		if (errorType && errorType.includes('end-before-start-date-error')) {
+			this.dueDateErrorTerm = 'dueBeforeEndDate';
+			this.startDateErrorTerm = 'startBeforeEndDate';
+			this.endDateErrorTerm = 'dueBeforeEndDate';
+			return;
+		}
+
+		if (errorType && errorType.includes('end-before-due-date-error')) {
+			this.dueDateErrorTerm = 'dueBeforeEndDate';
+			this.startDateErrorTerm = null;
+			this.endDateErrorTerm = 'dueBeforeEndDate';
+			return;
+		}
+
+		this.dueDateErrorTerm = null;
+		this.startDateErrorTerm = null;
+		this.endDateErrorTerm = null;
+	}
+
 	async validate() {
 		if (!this._entity) {
 			return;
@@ -63,6 +107,7 @@ export class ActivityUsage {
 
 		this.isError = false;
 		this.errorType = null;
+		this.setErrorLangTerms();
 
 		await this._entity.validate({
 			dueDate: this.dueDate,
@@ -72,6 +117,7 @@ export class ActivityUsage {
 			this.isError = true;
 			if (e.json && e.json.properties && e.json.properties.type) {
 				this.errorType = e.json.properties.type;
+				this.setErrorLangTerms(this.errorType);
 			}
 			throw e;
 		}));
@@ -103,6 +149,9 @@ decorate(ActivityUsage, {
 	canEditDraft: observable,
 	isError: observable,
 	errorType: observable,
+	dueDateErrorTerm: observable,
+	startDateErrorTerm: observable,
+	endDateErrorTerm: observable,
 	// actions
 	load: action,
 	setDueDate: action,
@@ -112,5 +161,6 @@ decorate(ActivityUsage, {
 	setCanEditDraft: action,
 	setCanEditDates: action,
 	save: action,
-	validate: action
+	validate: action,
+	setErrorLangTerms: action
 });

--- a/test/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
+++ b/test/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
@@ -1,4 +1,4 @@
-import { defineCE, expect, fixture } from '@open-wc/testing';
+import { defineCE, expect, fixture, nextFrame } from '@open-wc/testing';
 import { ActivityEditorContainerMixin} from '../../../components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js';
 
 const container = defineCE(
@@ -10,6 +10,23 @@ const editor = defineCE(
 	class extends HTMLElement {
 		save() {
 			this.saveCalled = true;
+		}
+
+		validate() {
+			this.validateCalled = true;
+		}
+	}
+);
+
+const editorValidationFail = defineCE(
+	class extends HTMLElement {
+		save() {
+			this.saveCalled = true;
+		}
+
+		validate() {
+			this.validateCalled = true;
+			throw new Error('Validation error');
 		}
 	}
 );
@@ -39,6 +56,23 @@ describe('d2l-activity-editor-container-mixin', function() {
 		childEditor.dispatchEvent(connectedEvent(childEditor));
 		childEditor.dispatchEvent(saveEvent);
 
-		expect(childEditor.saveCalled).to.be.true;
+		await nextFrame();
+
+		expect(childEditor.validateCalled, 'validateCalled with successful validation').to.be.true;
+		expect(childEditor.saveCalled, 'saveCalled after successful validation').to.be.true;
+	});
+
+	it('does not save on validation fail', async() => {
+		const el = await fixture(`<${container}><${editorValidationFail}></${editorValidationFail}></${container}`);
+
+		const childEditor = el.firstElementChild;
+
+		childEditor.dispatchEvent(connectedEvent(childEditor));
+		childEditor.dispatchEvent(saveEvent);
+
+		await nextFrame();
+
+		expect(childEditor.validateCalled, 'validateCalled with unsuccessful validation').to.be.true;
+		expect(childEditor.saveCalled, 'saveCalled after unsuccessful validation').to.be.undefined;
 	});
 });


### PR DESCRIPTION
When saving, it will first run the new `validate` method on all editors that implement it. If any validations fail, the LMS will return a 400 with details on the type of error. The error props can be used by components to determine if the error is relevant to them, and which lang term to use for the error tooltip.

Depends on https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/134

The datetime pickers are in flux right now, so I just added some pretty ugly tooltips for now, just to demonstrate that the errors and langterms are working. They should ultimately be replaced by the incoming new datetime input component.