### PR TITLE
US113175 Display alert on validation error

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -4,6 +4,7 @@ import '../d2l-activity-due-date-editor.js';
 import '../d2l-activity-score-editor.js';
 import '../d2l-activity-text-editor.js';
 import '../d2l-activity-attachments/d2l-activity-attachments-editor.js';
+import '../d2l-activity-editor-alert.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { AssignmentEntity } from 'siren-sdk/src/activities/assignments/AssignmentEntity.js';
@@ -156,6 +157,12 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 		} = assignment;
 
 		return html`
+			<d2l-activity-editor-alert
+				href="${activityUsageHref}"
+				.token="${this.token}"
+				text="${this.localize('assignmentSaveError')}">
+			</d2l-activity-editor-alert>
+
 			<div id="assignment-name-container">
 				<label class="d2l-label-text" for="assignment-name">${this.localize('name')}*</label>
 				<d2l-input-text

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
@@ -27,5 +27,6 @@ export default {
 	"txtGroup": "Group Assignment", // Label for group assignment type,
 	"txtGroupCategoryWithName": "Group Category: {groupCategory}", //Label for the group category {groupCategory} is the name of the group category
 	"txtGroupCategory": "Group Category", // Label for group category
-	"submissionCompletionAndCategorization": "Submission, Completion & Categorization" // Label for the availability and dates summarizer
+	"submissionCompletionAndCategorization": "Submission, Completion & Categorization", // Label for the availability and dates summarizer
+	"assignmentSaveError": "Your assignment wasn't saved. Please correct the field(s) outlined in red." // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
 };

--- a/components/d2l-activity-editor/d2l-activity-editor-alert.js
+++ b/components/d2l-activity-editor/d2l-activity-editor-alert.js
@@ -1,0 +1,43 @@
+import 'd2l-alert';
+import { css, html } from 'lit-element/lit-element.js';
+import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
+import { MobxLitElement } from '@adobe/lit-mobx';
+import { shared as store } from './state/activity-store.js';
+
+class ActivityEditorAlert extends ActivityEditorMixin(MobxLitElement) {
+
+	static get properties() {
+		return {
+			/**
+			 * Text to be displayed in the alert
+			 */
+			text: { type: String }
+		};
+	}
+
+	static get styles() {
+		return css`
+			.alert-container {
+				padding-bottom: 10px;
+			}
+		`;
+	}
+
+	render() {
+		const activity = store.get(this.href);
+		if (!activity || !this.text) {
+			return html``;
+		}
+
+		if (!activity.isError) {
+			return html``;
+		}
+
+		return html`
+			<div class="alert-container">
+				<d2l-alert type="error">${this.text}</d2l-alert>
+			</div>
+		`;
+	}
+}
+customElements.define('d2l-activity-editor-alert', ActivityEditorAlert);

--- a/components/d2l-activity-editor/d2l-activity-editor-alert.js
+++ b/components/d2l-activity-editor/d2l-activity-editor-alert.js
@@ -25,11 +25,8 @@ class ActivityEditorAlert extends ActivityEditorMixin(MobxLitElement) {
 
 	render() {
 		const activity = store.get(this.href);
-		if (!activity || !this.text) {
-			return html``;
-		}
-
-		if (!activity.isError) {
+		const showAlert = this.text && activity && activity.isError;
+		if (!showAlert) {
 			return html``;
 		}
 

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -59,6 +59,10 @@ export class ActivityUsage {
 		this.canEditDates = value;
 	}
 
+	setIsError(value) {
+		this.isError = value;
+	}
+
 	setErrorLangTerms(errorType) {
 		if (errorType && errorType.includes('end-due-start-date-error')) {
 			this.dueDateErrorTerm = 'dueBetweenStartEndDate';
@@ -162,5 +166,6 @@ decorate(ActivityUsage, {
 	setCanEditDates: action,
 	save: action,
 	validate: action,
-	setErrorLangTerms: action
+	setErrorLangTerms: action,
+	setIsError: action
 });

--- a/test/d2l-activity-editor/d2l-activity-editor-alert.html
+++ b/test/d2l-activity-editor/d2l-activity-editor-alert.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-activity-editor-buttons tests</title>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/axe-core/axe.min.js"></script>
+	</head>
+	<body>
+		<script type="module" src="./d2l-activity-editor-alert.js"></script>
+	</body>
+</html>

--- a/test/d2l-activity-editor/d2l-activity-editor-alert.js
+++ b/test/d2l-activity-editor/d2l-activity-editor-alert.js
@@ -1,0 +1,52 @@
+import '../../components/d2l-activity-editor/d2l-activity-editor-alert.js';
+import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { ActivityUsage } from '../../components/d2l-activity-editor/state/activity-usage.js';
+import { shared as store } from '../../components/d2l-activity-editor/state/activity-store.js';
+
+describe('d2l-activity-visibility-editor', function() {
+
+	let el, href, activity, alert;
+
+	beforeEach(async() => {
+		href = 'http://activity/1';
+		activity = new ActivityUsage(href, 'token');
+		activity.setIsError(true);
+		store.put(href, activity);
+
+		el = await fixture(html`
+			<d2l-activity-editor-alert href=${href} token="token" text="This is an alert"></d2l-activity-editor-alert>
+		`);
+
+		alert = el.shadowRoot.querySelector('d2l-alert');
+	});
+
+	afterEach(() => {
+		store.clear();
+	});
+
+	it('passes accessibility test', async() => {
+		await expect(el).to.be.accessible();
+	});
+
+	it('is visible if activity is in error', async() => {
+		expect(alert).to.have.attr('type', 'error');
+		expect(alert).to.have.text('This is an alert');
+	});
+
+	it('is not visible if activity is in error but text is not set', async() => {
+		el = await fixture(html`
+			<d2l-activity-editor-alert href=${href} token="token"></d2l-activity-editor-alert>
+		`);
+
+		alert = el.shadowRoot.querySelector('d2l-alert');
+		expect(alert).to.be.null;
+	});
+
+	it('is not visible if activity is not in error', async() => {
+		activity.setIsError(false);
+		await elementUpdated(el);
+
+		alert = el.shadowRoot.querySelector('d2l-alert');
+		expect(alert).to.be.null;
+	});
+});

--- a/test/d2l-activity-editor/index.html
+++ b/test/d2l-activity-editor/index.html
@@ -16,6 +16,7 @@
 		// Load and run all tests (.html, .js):
 		WCT.loadSuites([
 			'd2l-activity-editor.html',
+			'd2l-activity-editor-alert.html',
 			'd2l-activity-editor-buttons.html',
 			'd2l-activity-visibility-editor.html',
 			'd2l-activity-availability-dates-editor.html',


### PR DESCRIPTION
Adds a new generic `d2l-activity-editor-alert` component, which is toggled by `ActivityUsage.isError`.
When instantiated by `AssignmentEditorDetail`, we also give it the assignment-specific langterm.