### PR TITLE
Update secondary panel w/ styled summarizer + background color

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/activity-summarizer-styles.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/activity-summarizer-styles.js
@@ -1,0 +1,18 @@
+import { css } from 'lit-element/lit-element.js';
+
+export const summarizerHeaderStyles = css`
+	.activity-summarizer-header {
+		margin-top: 3px;
+		margin-bottom: 3px;
+	}
+`;
+
+export const summarizerSummaryStyles = css`
+	.activity-summarizer-summary {
+		list-style: none;
+		padding: 0;
+		margin-top: 5px;
+		min-height: 20px;
+		color: var(--d2l-color-galena);
+	}
+`;

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
@@ -4,6 +4,8 @@ import '../d2l-activity-release-conditions-editor.js';
 import '@brightspace-ui-labs/accordion/accordion-collapse.js';
 import { bodySmallStyles, heading4Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html } from 'lit-element/lit-element.js';
+import { summarizerHeaderStyles, summarizerSummaryStyles } from './activity-summarizer-styles.js';
+
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { getLocalizeResources } from '../localization.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
@@ -45,13 +47,9 @@ class ActivityAssignmentAvailabilityEditor extends LocalizeMixin(ActivityEditorM
 				.d2l-body-small {
 					margin: 0 0 0.3rem 0;
 				}
-
-				.summary {
-					list-style: none;
-					padding-left: 0.2rem;
-					color: var(--d2l-color-galena);
-				}
-			`
+			`,
+			summarizerHeaderStyles,
+			summarizerSummaryStyles,
 		];
 	}
 
@@ -127,13 +125,13 @@ class ActivityAssignmentAvailabilityEditor extends LocalizeMixin(ActivityEditorM
 	render() {
 		return html`
 			<d2l-labs-accordion-collapse flex header-border ?opened=${this._errorInAccordion}>
-				<h4 class="header" slot="header">
+				<h4 class="d2l-heading-4 activity-summarizer-header" slot="header">
 					${this.localize('hdrAvailability')}
 				</h4>
-				<ul class="summary" slot="summary">
-					${this._renderAvailabilityDatesSummary()}
-					${this._renderReleaseConditionSummary()}
-					${this._renderSpecialAccessSummary()}
+				<ul class="d2l-body-small activity-summarizer-summary" slot="summary">
+					<li>${this._renderAvailabilityDatesSummary()}</li>
+					<li>${this._renderReleaseConditionSummary()}</li>
+					<li>${this._renderSpecialAccessSummary()}</li>
 				</ul>
 				${this._renderAvailabilityDatesEditor()}
 				${this._renderReleaseConditionEditor()}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-secondary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-secondary.js
@@ -1,6 +1,7 @@
 import './d2l-activity-assignment-availability-editor.js';
 import './d2l-activity-assignment-evaluation-editor.js';
 import './d2l-activity-assignment-editor-submission-and-completion.js';
+import '@brightspace-ui/core/components/colors/colors.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { AssignmentEntity } from 'siren-sdk/src/activities/assignments/AssignmentEntity.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
@@ -24,14 +25,16 @@ class AssignmentEditorSecondary extends SaveStatusMixin(RtlMixin(EntityMixinLit(
 			css`
 				:host {
 					display: block;
+					background: var(--d2l-color-gypsum);
 				}
 				:host([hidden]) {
 					display: none;
 				}
-				:host > div {
-					padding-bottom: 20px;
-				}
-
+				:host > * {
+					background: var(--d2l-color-white);
+					margin-bottom: 10px;
+					border-radius: 8px;
+					padding: 20px;
 				}
 			`
 		];

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -1,7 +1,8 @@
 import '@brightspace-ui-labs/accordion/accordion-collapse.js';
 import './d2l-activity-assignment-type-editor.js';
+import { bodySmallStyles, heading4Styles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html } from 'lit-element/lit-element.js';
-import { heading4Styles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
+import { summarizerHeaderStyles, summarizerSummaryStyles } from './activity-summarizer-styles.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { getLocalizeResources } from '../localization.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
@@ -12,10 +13,15 @@ import { shared as store } from './state/assignment-store.js';
 class AssignmentEditorSubmissionAndCompletion extends ActivityEditorMixin(LocalizeMixin(MobxLitElement)) {
 	static get styles() {
 		return [
+			bodySmallStyles,
 			heading4Styles,
 			labelStyles,
 			selectStyles,
 			css`
+				:host {
+					display: block;
+				}
+
 				.block-select {
 					width: 100%;
 					max-width: 300px;
@@ -25,17 +31,12 @@ class AssignmentEditorSubmissionAndCompletion extends ActivityEditorMixin(Locali
 				.d2l-heading-4 {
 					margin: 0 0 0.6rem 0;
 				}
-
-				.summary {
-					list-style: none;
-					padding-left: 0.2rem;
-					color: var(--d2l-color-galena);
-				}
-
 				.assignment-type-heading {
 					margin: 0 0 0.5rem 0;
 				}
-			`
+			`,
+			summarizerHeaderStyles,
+			summarizerSummaryStyles
 		];
 	}
 
@@ -138,13 +139,13 @@ class AssignmentEditorSubmissionAndCompletion extends ActivityEditorMixin(Locali
 		const assignment = store.getAssignment(this.href);
 		return html`
             <d2l-labs-accordion-collapse class="accordion" flex header-border>
-				<h4 class="accordion-header" slot="header">
+				<h4 class="d2l-heading-4 activity-summarizer-header" slot="header">
 					${this.localize('submissionCompletionAndCategorization')}
 				</h4>
-				<ul class="summary" slot="summary">
-					${this._renderAssignmentTypeSummary()}
-					${this._renderAssignmentSubmissionTypeSummary()}
-					${this._renderAssignmentCompletionTypeSummary()}
+				<ul class="d2l-body-small activity-summarizer-summary" slot="summary">
+					<li>${this._renderAssignmentTypeSummary()}</li>
+					<li>${this._renderAssignmentSubmissionTypeSummary()}</li>
+					<li>${this._renderAssignmentCompletionTypeSummary()}</li>
 				</ul>
 				${this._renderAssignmentType()}
 				${this._renderAssignmentSubmissionType(assignment)}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -4,6 +4,8 @@ import './d2l-activity-assignment-editor-secondary.js';
 import './d2l-activity-assignment-editor-footer.js';
 import '@brightspace-ui/core/templates/primary-secondary/primary-secondary.js';
 import 'd2l-save-status/d2l-save-status.js';
+import '@brightspace-ui/core/components/colors/colors.js';
+
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorContainerMixin } from '../mixins/d2l-activity-editor-container-mixin.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
@@ -37,11 +39,18 @@ class AssignmentEditor extends ActivityEditorContainerMixin(ActivityEditorMixin(
 			:host([hidden]) {
 				display: none;
 			}
-			.d2l-activity-assignment-editor-detail-panel, .d2l-activity-assignment-editor-secondary-panel {
+			.d2l-activity-assignment-editor-detail-panel {
 				padding: 20px;
+			}
+			.d2l-activity-assignment-editor-secondary-panel {
+				padding: 10px;
 			}
 			d2l-save-status {
 				display: inline-block;
+			}
+			div[slot="secondary"] {
+				height: 100%;
+				background: var(--d2l-color-gypsum);
 			}
 		`;
 	}
@@ -133,12 +142,13 @@ class AssignmentEditor extends ActivityEditorContainerMixin(ActivityEditorMixin(
 					slot="primary"
 					class="d2l-activity-assignment-editor-detail-panel">
 				</d2l-activity-assignment-editor-detail>
-				<d2l-activity-assignment-editor-secondary
-					href="${assignmentHref}"
-					.token="${this.token}"
-					slot="secondary"
-					class="d2l-activity-assignment-editor-secondary-panel">
-				</d2l-activity-assignment-editor-secondary>
+				<div slot="secondary">
+					<d2l-activity-assignment-editor-secondary
+						href="${assignmentHref}"
+						.token="${this.token}"
+						class="d2l-activity-assignment-editor-secondary-panel">
+					</d2l-activity-assignment-editor-secondary>
+				</div>
 				<d2l-activity-assignment-editor-footer
 					href="${assignmentHref}"
 					.token="${this.token}"

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
@@ -4,7 +4,11 @@ import './d2l-activity-assignment-anonymous-marking-editor.js';
 import './d2l-activity-assignment-anonymous-marking-summary.js';
 import '../d2l-activity-rubrics/d2l-activity-rubrics-list-container.js';
 import './d2l-assignment-turnitin-editor.js';
+
+import { bodySmallStyles, heading4Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { summarizerHeaderStyles, summarizerSummaryStyles } from './activity-summarizer-styles.js';
+
 import { getLocalizeResources } from '../localization.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 
@@ -21,25 +25,24 @@ class ActivityAssignmentEvaluationEditor extends LocalizeMixin(LitElement) {
 
 	static get styles() {
 
-		return css`
-			:host {
-				display: block;
-			}
+		return [
+			bodySmallStyles,
+			heading4Styles,
+			css`
+				:host {
+					display: block;
+				}
 
-			:host([hidden]) {
-				display: none;
-			}
+				:host([hidden]) {
+					display: none;
+				}
 
-			.editor {
-				margin: 1rem 0;
-			}
-
-			.summary {
-				list-style: none;
-				padding-left: 0.2rem;
-				color: var(--d2l-color-galena);
-			}
-		`;
+				.editor {
+					margin: 1rem 0;
+				}
+			`,
+			summarizerHeaderStyles,
+			summarizerSummaryStyles];
 	}
 
 	static async getLocalizeResources(langs) {
@@ -117,13 +120,13 @@ class ActivityAssignmentEvaluationEditor extends LocalizeMixin(LitElement) {
 
 		return html`
 			<d2l-labs-accordion-collapse flex header-border>
-				<h4 class="header" slot="header">
+				<h4 class="d2l-heading-4 activity-summarizer-header" slot="header">
 					${this.localize('evaluationAndFeedback')}
 				</h4>
-				<ul class="summary" slot="summary">
-					${this._renderAnonymousMarkingSummary()}
-					${this._renderAnnotationsSummary()}
-					${this._renderTurnitinSummary()}
+				<ul class="d2l-body-small activity-summarizer-summary" slot="summary">
+					<li>${this._renderAnonymousMarkingSummary()}</li>
+					<li>${this._renderAnnotationsSummary()}</li>
+					<li>${this._renderTurnitinSummary()}</li>
 				</ul>
 				${this._renderRubricsCollectionEditor()}
 				${this._renderAnnotationsEditor()}


### PR DESCRIPTION
Screenshot: https://user-images.githubusercontent.com/3785788/75496655-ae175880-5976-11ea-85e6-ac82ccf155eb.png

@pureooze: note the header and summary classes are used in summarizers (d2l-activity-assignment-availability-editor.js , d2l-activity-assignment-editor-submission-and-completion.js, and d2l-activity-assignment-evaluation-editor.js). 