### PR TITLE
US113175 Open availability dates accordion on error

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
@@ -115,7 +115,7 @@ class ActivityAssignmentAvailabilityEditor extends LocalizeMixin(ActivityEditorM
 	}
 
 	// Returns true if any error states relevant to this accordion are set
-	get _openOnError() {
+	get _errorInAccordion() {
 		const activity = store.get(this.href);
 		if (!activity) {
 			return false;

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
@@ -3,11 +3,14 @@ import '../d2l-activity-availability-dates-editor.js';
 import '../d2l-activity-release-conditions-editor.js';
 import '@brightspace-ui-labs/accordion/accordion-collapse.js';
 import { bodySmallStyles, heading4Styles } from '@brightspace-ui/core/components/typography/styles.js';
-import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { css, html } from 'lit-element/lit-element.js';
+import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { getLocalizeResources } from '../localization.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { MobxLitElement } from '@adobe/lit-mobx';
+import { shared as store } from '../state/activity-store.js';
 
-class ActivityAssignmentAvailabilityEditor extends LocalizeMixin(LitElement) {
+class ActivityAssignmentAvailabilityEditor extends LocalizeMixin(ActivityEditorMixin(MobxLitElement)) {
 
 	static get properties() {
 
@@ -111,10 +114,19 @@ class ActivityAssignmentAvailabilityEditor extends LocalizeMixin(LitElement) {
 		return html``;
 	}
 
-	render() {
+	// Returns true if any error states relevant to this accordion are set
+	get _openOnError() {
+		const activity = store.get(this.href);
+		if (!activity) {
+			return false;
+		}
 
+		return activity.dueDateErrorTerm || activity.startDateErrorTerm;
+	}
+
+	render() {
 		return html`
-			<d2l-labs-accordion-collapse flex header-border>
+			<d2l-labs-accordion-collapse flex header-border ?opened=${this._errorInAccordion}>
 				<h4 class="header" slot="header">
 					${this.localize('hdrAvailability')}
 				</h4>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
@@ -121,7 +121,7 @@ class ActivityAssignmentAvailabilityEditor extends LocalizeMixin(ActivityEditorM
 			return false;
 		}
 
-		return activity.dueDateErrorTerm || activity.startDateErrorTerm;
+		return activity.endDateErrorTerm || activity.startDateErrorTerm;
 	}
 
 	render() {


### PR DESCRIPTION
This wires the availability dates editor component with the accordion into the activity usage state, so that it can check if any errors that pertain to the accordion are set.
In this case it cares about the start and end dates, which are known to be in error state when the respective `*DateErrorTerm` property is truthy.