### PR TITLE
Part 2: Activity Score/In Grades - Refactor validation to support Save/Cancel

### DIFF
--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -115,6 +115,10 @@ export class ActivityUsage {
 		this.errorType = null;
 		this.setErrorLangTerms();
 
+		if (!this.scoreAndGrade.validate()) {
+			this.isError = true;
+		}
+
 		await this._entity.validate({
 			dueDate: this.dueDate,
 			startDate: this.startDate,
@@ -125,8 +129,11 @@ export class ActivityUsage {
 				this.errorType = e.json.properties.type;
 				this.setErrorLangTerms(this.errorType);
 			}
-			throw e;
 		}));
+
+		if (this.isError) {
+			throw new Error('Activity Usage validation failed');
+		}
 	}
 
 	async save() {


### PR DESCRIPTION
[US113166](https://rally1.rallydev.com/#/29180338367d/detail/userstory/362987616496)

This builds on 
https://github.com/BrightspaceHypermediaComponents/activities/pull/716

It moves the validation from the web component to the MobX state class so that it can also be called when the Save button is clicked. Some of the validation is still done immediately when the state of the score out of field changes. e.g. if someone enters in a non-numeric value, or if someone clears the score out of field when 'In Grades' is selected. But we also need to do the validation when Save is clicked in case they have not resolved the errors, or for the scenario where they select 'Graded' but never actually enter a score out of.

The MobX state class actions for setting the score out of and the various grade states now set/clear a validation error observable to the appropriate lang term, and the `d2l-activity-score-editor` UI component's render method observes that error property, and includes the tooltip when necessary.

There is also a new `ActivityScoreGrade.validate` method that runs the validation on demand, eg. when Save is clicked. This hooks into the existing validation that had been added for the dates.
It's slightly different to the dates validation in that currently the validation is implemented only in the MobX state class `ActivityScoreGrade` and the `ActivityUsage` state class calls `ActivityScoreGrade.validate()` as part of it's own `validate` implementation.

If the score/grade validation fails, it sets the `ActivityUsage.isError` property that was previously only being used for dates. As discussed yesterday with @emil-furniss , at some point we may need to work out how to integrate Assignments error handling with this Activity error handling.

The existing `ActivityUsage` validation delegates to the siren-sdk `ActivityUsageEntity` to do it's validation because it needs to make an API call.

So I find it a little bit inconsistent that the validation for score/grade is handled by the `ActivityScoreGrade` state class, but when it comes to saving, we delegate the save of the activity score and grade to the siren-sdk `ActivityUsageEntity` too.

As mentioned in the PR, the validation was originally done in the UI component which is why I've moved it to the MobX state class, but it might have been better to have been put into the `ActivityUsageEntity`, so that we could call `ActivityUsageEntity.validate` for both dates and score/grade making it more consistent with how save is implemented. But that would have required us to come up with some way to return all the validation errors and then work out how to map those back to the individual error observables required by the different state classes. `ActivityScoreGrade` needs to track error state for its fields independently of the error state fields being used to manage the date errors. So having it all handled by the state class makes that easier.

I suggest we stick with this for now and monitor going forward.

@emil-furniss As you mentioned, it's nice having the `ActivityUsage` state broken up between different classes and it would be nice at some point to consider refactoring the date stuff into a helper class and that might give us some more insight into how to manage the aggregate save/validation behavior.