### PR TITLE
Fix submission and completion types saving

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -53,7 +53,7 @@ class AssignmentEditorSubmissionAndCompletion extends ActivityEditorMixin(Locali
 		}
 
 		return html`
-			${assignment.submissionTypeOptions.map(option => html`<option value=${option.value} ?selected=${option.value === assignment.submissionType}>${option.title}</option>`)}
+			${assignment.submissionTypeOptions.map(option => html`<option value=${option.value} ?selected=${String(option.value) === assignment.submissionType}>${option.title}</option>`)}
 		`;
 	}
 
@@ -66,7 +66,7 @@ class AssignmentEditorSubmissionAndCompletion extends ActivityEditorMixin(Locali
 		const completionType = assignment ? assignment.completionType : '0';
 
 		return html`
-			${completionTypeOptions.map(option => html`<option value=${option.value} ?selected=${option.value === completionType}>${option.title}</option>`)}
+			${completionTypeOptions.map(option => html`<option value=${option.value} ?selected=${String(option.value) === completionType}>${option.title}</option>`)}
 		`;
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -90,7 +90,9 @@ export class Assignment {
 
 		await this._entity.save({
 			name: this.name,
-			instructions: this.instructions
+			instructions: this.instructions,
+			submissionType: this.submissionType,
+			completionType: this.completionTypeOptions.length === 0 ? 0 : this.completionType
 		});
 		await this.fetch();
 	}


### PR DESCRIPTION
Fixes a bug where the submission and completion types were not being saved correctly

Depends on https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/140