### PR TITLE
Extract activity dates mobx state from activity-usage

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
@@ -121,7 +121,7 @@ class ActivityAssignmentAvailabilityEditor extends LocalizeMixin(ActivityEditorM
 			return false;
 		}
 
-		return activity.endDateErrorTerm || activity.startDateErrorTerm;
+		return activity.dates.endDateErrorTerm || activity.dates.startDateErrorTerm;
 	}
 
 	render() {

--- a/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
@@ -29,37 +29,37 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeMixin
 	}
 
 	_onStartDatetimePickerDatetimeCleared() {
-		store.get(this.href).setStartDate('');
+		store.get(this.href).dates.setStartDate('');
 	}
 
 	_onStartDatetimePickerDatetimeChanged(e) {
-		store.get(this.href).setStartDate(e.detail.toISOString());
+		store.get(this.href).dates.setStartDate(e.detail.toISOString());
 	}
 
 	_onEndDatetimePickerDatetimeCleared() {
-		store.get(this.href).setEndDate('');
+		store.get(this.href).dates.setEndDate('');
 	}
 
 	_onEndDatetimePickerDatetimeChanged(e) {
-		store.get(this.href).setEndDate(e.detail.toISOString());
+		store.get(this.href).dates.setEndDate(e.detail.toISOString());
 	}
 
 	render() {
-		const activity = store.get(this.href);
+		const dates = store.get(this.href) ? store.get(this.href).dates : null;
 		let canEditDates, startDate, endDate, startDateErrorTerm, endDateErrorTerm;
 
-		if (!activity) {
+		if (!dates) {
 			canEditDates = false;
 			startDate = null;
 			endDate = null;
 			startDateErrorTerm = null;
 			endDateErrorTerm = null;
 		} else {
-			canEditDates = activity.canEditDates;
-			startDate = activity.startDate;
-			endDate = activity.endDate;
-			startDateErrorTerm = this.localize(activity.startDateErrorTerm);
-			endDateErrorTerm = this.localize(activity.endDateErrorTerm);
+			canEditDates = dates.canEditDates;
+			startDate = dates.startDate;
+			endDate = dates.endDate;
+			startDateErrorTerm = this.localize(dates.startDateErrorTerm);
+			endDateErrorTerm = this.localize(dates.endDateErrorTerm);
 		}
 
 		return html`

--- a/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
@@ -45,7 +45,8 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeMixin
 	}
 
 	render() {
-		const dates = store.get(this.href) ? store.get(this.href).dates : null;
+		const entity = store.get(this.href);
+		const dates = entity ? entity.dates : null;
 		let canEditDates, startDate, endDate, startDateErrorTerm, endDateErrorTerm;
 
 		if (!dates) {

--- a/components/d2l-activity-editor/d2l-activity-availability-dates-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-summary.js
@@ -39,8 +39,8 @@ class ActivityAvailabilityDatesSummary
 			return html``;
 		}
 
-		const startDate = this._formatDate(activity.startDate);
-		const endDate = this._formatDate(activity.endDate);
+		const startDate = this._formatDate(activity.dates.startDate);
+		const endDate = this._formatDate(activity.dates.endDate);
 
 		let text;
 

--- a/components/d2l-activity-editor/d2l-activity-due-date-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-due-date-editor.js
@@ -68,7 +68,8 @@ class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeMixin(MobxLitEle
 	}
 
 	render() {
-		const dates = store.get(this.href) ? store.get(this.href).dates : null;
+		const entity = store.get(this.href);
+		const dates = entity ? entity.dates : null;
 		let dueDate, canEditDates, errorTerm;
 
 		// We have to render with null values for dueDate initially due to issues with

--- a/components/d2l-activity-editor/d2l-activity-due-date-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-due-date-editor.js
@@ -37,11 +37,11 @@ class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeMixin(MobxLitEle
 	}
 
 	_onDatetimePickerDatetimeCleared() {
-		store.get(this.href).setDueDate('');
+		store.get(this.href).dates.setDueDate('');
 	}
 
 	_onDatetimePickerDatetimeChanged(e) {
-		store.get(this.href).setDueDate(e.detail.toISOString());
+		store.get(this.href).dates.setDueDate(e.detail.toISOString());
 	}
 
 	dateTemplate(date, canEdit, errorTerm) {
@@ -68,7 +68,7 @@ class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeMixin(MobxLitEle
 	}
 
 	render() {
-		const activity = store.get(this.href);
+		const dates = store.get(this.href) ? store.get(this.href).dates : null;
 		let dueDate, canEditDates, errorTerm;
 
 		// We have to render with null values for dueDate initially due to issues with
@@ -79,14 +79,14 @@ class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeMixin(MobxLitEle
 		// Tried passing an invalid date attribute to force it to use our datetime attribute
 		// but the 2-way data binding with the vaadin date picker always overrides it
 		// Will be able to fix when we have a new data time component.
-		if (!activity || this._isFirstLoad) {
+		if (!dates || this._isFirstLoad) {
 			dueDate = null;
 			canEditDates = false;
 			errorTerm = null;
 		} else {
-			dueDate = activity.dueDate;
-			canEditDates = activity.canEditDates;
-			errorTerm = this.localize(activity.dueDateErrorTerm);
+			dueDate = dates.dueDate;
+			canEditDates = dates.canEditDates;
+			errorTerm = this.localize(dates.dueDateErrorTerm);
 		}
 
 		return html`

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
@@ -1,3 +1,5 @@
+import { getFirstFocusableDescendant } from '@brightspace-ui/core/helpers/focus.js';
+
 export const ActivityEditorContainerMixin = superclass => class extends superclass {
 
 	constructor() {
@@ -25,6 +27,18 @@ export const ActivityEditorContainerMixin = superclass => class extends supercla
 		});
 	}
 
+	_focusOnInvalid() {
+		const isAriaInvalid = node => node.getAttribute('aria-invalid') === 'true';
+		for (const editor of this._editors) {
+			const el = getFirstFocusableDescendant(editor, true, isAriaInvalid);
+			if (el) {
+				el.focus();
+				return true;
+			}
+		}
+		return false;
+	}
+
 	async _save() {
 		const validations = [];
 		for (const editor of this._editors) {
@@ -34,7 +48,11 @@ export const ActivityEditorContainerMixin = superclass => class extends supercla
 		try {
 			await Promise.all(validations);
 		} catch (e) {
-			// Skip save on vaidation error
+			// Server-side validation error
+		}
+
+		// Catch both client- and server-side validation errors
+		if (this._focusOnInvalid()) {
 			return;
 		}
 

--- a/components/d2l-activity-editor/state/activity-dates.js
+++ b/components/d2l-activity-editor/state/activity-dates.js
@@ -1,0 +1,90 @@
+import { action, configure as configureMobx, decorate, observable } from 'mobx';
+
+configureMobx({ enforceActions: 'observed' });
+
+export class ActivityDates {
+
+	constructor(entity) {
+		this.dueDate = entity.dueDate();
+		this.startDate = entity.startDate();
+		this.endDate = entity.endDate();
+		this.canEditDates = entity.canEditDates();
+		this.dueDateErrorTerm = null;
+		this.startDateErrorTerm = null;
+		this.endDateErrorTerm = null;
+	}
+
+	setDueDate(date) {
+		this.dueDate = date;
+	}
+
+	setStartDate(date) {
+		this.startDate = date;
+	}
+
+	setEndDate(date) {
+		this.endDate = date;
+	}
+
+	setCanEditDates(value) {
+		this.canEditDates = value;
+	}
+
+	setErrorLangTerms(errorType) {
+		if (errorType && errorType.includes('end-due-start-date-error')) {
+			this.dueDateErrorTerm = 'dueBetweenStartEndDate';
+			this.startDateErrorTerm = 'dueBetweenStartEndDate';
+			this.endDateErrorTerm = 'dueBetweenStartEndDate';
+			return;
+		}
+
+		if (errorType && errorType.includes('start-after-end-date-error')) {
+			this.dueDateErrorTerm = 'dueAfterStartDate';
+			this.startDateErrorTerm = 'dueAfterStartDate';
+			this.endDateErrorTerm = 'startBeforeEndDate';
+			return;
+		}
+
+		if (errorType && errorType.includes('start-after-due-date-error')) {
+			this.dueDateErrorTerm = 'dueAfterStartDate';
+			this.startDateErrorTerm = 'dueAfterStartDate';
+			this.endDateErrorTerm = null;
+			return;
+		}
+
+		if (errorType && errorType.includes('end-before-start-date-error')) {
+			this.dueDateErrorTerm = 'dueBeforeEndDate';
+			this.startDateErrorTerm = 'startBeforeEndDate';
+			this.endDateErrorTerm = 'dueBeforeEndDate';
+			return;
+		}
+
+		if (errorType && errorType.includes('end-before-due-date-error')) {
+			this.dueDateErrorTerm = 'dueBeforeEndDate';
+			this.startDateErrorTerm = null;
+			this.endDateErrorTerm = 'dueBeforeEndDate';
+			return;
+		}
+
+		this.dueDateErrorTerm = null;
+		this.startDateErrorTerm = null;
+		this.endDateErrorTerm = null;
+	}
+}
+
+decorate(ActivityDates, {
+	// props
+	dueDate: observable,
+	startDate: observable,
+	endDate: observable,
+	canEditDates: observable,
+	dueDateErrorTerm: observable,
+	startDateErrorTerm: observable,
+	endDateErrorTerm: observable,
+	// actions
+	setDueDate: action,
+	setStartDate: action,
+	setEndDate: action,
+	setCanEditDates: action,
+	setErrorLangTerms: action
+});

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -27,7 +27,6 @@ export class ActivityUsage {
 		this.isDraft = entity.isDraft();
 		this.canEditDraft = entity.canEditDraft();
 		this.isError = false;
-		this.errorType = null;
 		this.dates = new ActivityDates(entity);
 		this.scoreAndGrade = new ActivityScoreGrade(entity);
 	}
@@ -62,7 +61,6 @@ export class ActivityUsage {
 		}
 
 		this.isError = false;
-		this.errorType = null;
 		this.setErrorLangTerms();
 
 		if (!this.scoreAndGrade.validate()) {
@@ -78,8 +76,7 @@ export class ActivityUsage {
 		}).catch(e => runInAction(() => {
 			this.isError = true;
 			if (e.json && e.json.properties && e.json.properties.type) {
-				this.errorType = e.json.properties.type;
-				this.setErrorLangTerms(this.errorType);
+				this.setErrorLangTerms(e.json.properties.type);
 			}
 		}));
 
@@ -116,7 +113,6 @@ decorate(ActivityUsage, {
 	isDraft: observable,
 	canEditDraft: observable,
 	isError: observable,
-	errorType: observable,
 	scoreAndGrade: observable,
 	dates: observable,
 	// actions

--- a/test/d2l-activity-editor/d2l-activity-availability-dates-editor.js
+++ b/test/d2l-activity-editor/d2l-activity-availability-dates-editor.js
@@ -1,18 +1,24 @@
 import '../../components/d2l-activity-editor/d2l-activity-availability-dates-editor';
 import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
+import { ActivityDates } from '../../components/d2l-activity-editor/state/activity-dates';
 import { ActivityUsage } from '../../components/d2l-activity-editor/state/activity-usage.js';
 import { shared as store } from '../../components/d2l-activity-editor/state/activity-store.js';
 
 describe('d2l-activity-availability-dates-editor', function() {
 
-	let el, href, activity, startDatePicker, startDatePickerContainer, endDatePicker, endDatePickerContainer, labels;
+	let el, href, activity, dates, startDatePicker, startDatePickerContainer, endDatePicker, endDatePickerContainer, labels;
 
 	beforeEach(async() => {
+		dates = new ActivityDates({
+			canEditDates: () => true,
+			startDate: () => '2020-02-24T04:59:00.000Z',
+			dueDate: () => '2020-02-25T04:59:00.000Z',
+			endDate: () => '2020-02-26T04:59:00.000Z'
+		});
+
 		href = 'http://activity/1';
 		activity = new ActivityUsage(href, 'token');
-		activity.setCanEditDates(true);
-		activity.setStartDate('2020-02-24T04:59:00.000Z');
-		activity.setEndDate('2020-02-26T04:59:00.000Z');
+		activity.setDates(dates);
 		store.put(href, activity);
 
 		el = await fixture(html`
@@ -53,7 +59,7 @@ describe('d2l-activity-availability-dates-editor', function() {
 
 	describe('hidden', function() {
 		beforeEach(async() => {
-			activity.setCanEditDates(false);
+			dates.setCanEditDates(false);
 			await elementUpdated(el);
 		});
 
@@ -76,8 +82,8 @@ describe('d2l-activity-availability-dates-editor', function() {
 		});
 
 		it('displays updated dates on change', async() => {
-			activity.setStartDate('2020-02-25T04:59:00.000Z');
-			activity.setEndDate('2020-02-27T04:59:00.000Z');
+			dates.setStartDate('2020-02-25T04:59:00.000Z');
+			dates.setEndDate('2020-02-27T04:59:00.000Z');
 			await elementUpdated(el);
 
 			expect(startDatePicker).to.have.attr('datetime', '2020-02-25T04:59:00.000Z');

--- a/test/d2l-activity-editor/state/activity-dates.spec.js
+++ b/test/d2l-activity-editor/state/activity-dates.spec.js
@@ -1,5 +1,4 @@
 import { ActivityDates } from '../../../components/d2l-activity-editor/state/activity-dates.js';
-import { ActivityUsage} from '../../../components/d2l-activity-editor/state/activity-usage.js';
 import { ActivityUsageEntity } from 'siren-sdk/src/activities/ActivityUsageEntity.js';
 import { expect } from 'chai';
 import { fetchEntity } from '../../../components/d2l-activity-editor/state/fetch-entity.js';
@@ -12,12 +11,10 @@ jest.mock('../../../components/d2l-activity-editor/state/fetch-entity.js');
 describe('Activity Usage', function() {
 
 	const defaultEntityMock = {
-		dates: {
-			startDate: () => '2020-01-22T04:59:00.000Z',
-			dueDate: () => '2020-01-23T04:59:00.000Z',
-			endDate: () => '2020-01-24T04:59:00.000Z',
-			canEditDates: () => true
-		}
+		startDate: () => '2020-01-22T04:59:00.000Z',
+		dueDate: () => '2020-01-23T04:59:00.000Z',
+		endDate: () => '2020-01-24T04:59:00.000Z',
+		canEditDates: () => true
 	};
 
 	afterEach(() => {
@@ -51,36 +48,33 @@ describe('Activity Usage', function() {
 		});
 
 		it('reacts to start date', async(done) => {
-			const activity = new ActivityUsage('http://1', 'token');
-			await activity.fetch();
+			const activity = new ActivityDates(defaultEntityMock);
 
 			when(
-				() => activity.dates.startDate === '2020-02-21T04:59:00.000Z',
+				() => activity.startDate === '2020-02-21T04:59:00.000Z',
 				() => {
 					done();
 				}
 			);
 
-			activity.dates.setStartDate('2020-02-21T04:59:00.000Z');
+			activity.setStartDate('2020-02-21T04:59:00.000Z');
 		});
 
 		it('reacts to due date', async(done) => {
-			const activity = new ActivityUsage('http://1', 'token');
-			await activity.fetch();
+			const activity = new ActivityDates(defaultEntityMock);
 
 			when(
-				() => activity.dates.dueDate === '2020-02-23T04:59:00.000Z',
+				() => activity.dueDate === '2020-02-23T04:59:00.000Z',
 				() => {
 					done();
 				}
 			);
 
-			activity.dates.setDueDate('2020-02-23T04:59:00.000Z');
+			activity.setDueDate('2020-02-23T04:59:00.000Z');
 		});
 
 		it('reacts to end date', async(done) => {
-			const activity = new ActivityUsage('http://1', 'token');
-			await activity.fetch();
+			const activity = new ActivityDates(defaultEntityMock);
 
 			when(
 				() => activity.endDate === '2020-02-25T04:59:00.000Z',
@@ -89,7 +83,7 @@ describe('Activity Usage', function() {
 				}
 			);
 
-			activity.dates.setEndDate('2020-02-25T04:59:00.000Z');
+			activity.setEndDate('2020-02-25T04:59:00.000Z');
 		});
 	});
 });

--- a/test/d2l-activity-editor/state/activity-dates.spec.js
+++ b/test/d2l-activity-editor/state/activity-dates.spec.js
@@ -1,0 +1,95 @@
+import { ActivityDates } from '../../../components/d2l-activity-editor/state/activity-dates.js';
+import { ActivityUsage} from '../../../components/d2l-activity-editor/state/activity-usage.js';
+import { ActivityUsageEntity } from 'siren-sdk/src/activities/ActivityUsageEntity.js';
+import { expect } from 'chai';
+import { fetchEntity } from '../../../components/d2l-activity-editor/state/fetch-entity.js';
+import sinon from 'sinon';
+import { when } from 'mobx';
+
+jest.mock('siren-sdk/src/activities/ActivityUsageEntity.js');
+jest.mock('../../../components/d2l-activity-editor/state/fetch-entity.js');
+
+describe('Activity Usage', function() {
+
+	const defaultEntityMock = {
+		dates: {
+			startDate: () => '2020-01-22T04:59:00.000Z',
+			dueDate: () => '2020-01-23T04:59:00.000Z',
+			endDate: () => '2020-01-24T04:59:00.000Z',
+			canEditDates: () => true
+		}
+	};
+
+	afterEach(() => {
+		sinon.restore();
+		ActivityUsageEntity.mockClear();
+		fetchEntity.mockClear();
+	});
+
+	let sirenEntity;
+
+	describe('fetching', () => {
+		it('initializes with dates', async() => {
+			const activity = new ActivityDates(defaultEntityMock);
+
+			expect(activity.canEditDates).to.be.true;
+			expect(activity.startDate).to.equal('2020-01-22T04:59:00.000Z');
+			expect(activity.dueDate).to.equal('2020-01-23T04:59:00.000Z');
+			expect(activity.endDate).to.equal('2020-01-24T04:59:00.000Z');
+		});
+	});
+
+	describe('updating', () => {
+		beforeEach(() => {
+			sirenEntity = sinon.stub();
+
+			ActivityUsageEntity.mockImplementation(() => {
+				return defaultEntityMock;
+			});
+
+			fetchEntity.mockImplementation(() => sirenEntity);
+		});
+
+		it('reacts to start date', async(done) => {
+			const activity = new ActivityUsage('http://1', 'token');
+			await activity.fetch();
+
+			when(
+				() => activity.dates.startDate === '2020-02-21T04:59:00.000Z',
+				() => {
+					done();
+				}
+			);
+
+			activity.dates.setStartDate('2020-02-21T04:59:00.000Z');
+		});
+
+		it('reacts to due date', async(done) => {
+			const activity = new ActivityUsage('http://1', 'token');
+			await activity.fetch();
+
+			when(
+				() => activity.dates.dueDate === '2020-02-23T04:59:00.000Z',
+				() => {
+					done();
+				}
+			);
+
+			activity.dates.setDueDate('2020-02-23T04:59:00.000Z');
+		});
+
+		it('reacts to end date', async(done) => {
+			const activity = new ActivityUsage('http://1', 'token');
+			await activity.fetch();
+
+			when(
+				() => activity.endDate === '2020-02-25T04:59:00.000Z',
+				() => {
+					done();
+				}
+			);
+
+			activity.dates.setEndDate('2020-02-25T04:59:00.000Z');
+		});
+	});
+});

--- a/test/d2l-activity-editor/state/activity-usage.spec.js
+++ b/test/d2l-activity-editor/state/activity-usage.spec.js
@@ -11,12 +11,10 @@ jest.mock('../../../components/d2l-activity-editor/state/fetch-entity.js');
 describe('Activity Usage', function() {
 
 	const defaultEntityMock = {
-		dates: {
-			startDate: () => '2020-01-22T04:59:00.000Z',
-			dueDate: () => '2020-01-23T04:59:00.000Z',
-			endDate: () => '2020-01-24T04:59:00.000Z',
-			canEditDates: () => true
-		},
+		startDate: () => '2020-01-22T04:59:00.000Z',
+		dueDate: () => '2020-01-23T04:59:00.000Z',
+		endDate: () => '2020-01-24T04:59:00.000Z',
+		canEditDates: () => true,
 		isDraft: () => true,
 		canEditDraft: () => true,
 		scoreOutOf: () => 10,

--- a/test/d2l-activity-editor/state/activity-usage.spec.js
+++ b/test/d2l-activity-editor/state/activity-usage.spec.js
@@ -11,10 +11,12 @@ jest.mock('../../../components/d2l-activity-editor/state/fetch-entity.js');
 describe('Activity Usage', function() {
 
 	const defaultEntityMock = {
-		startDate: () => '2020-01-22T04:59:00.000Z',
-		dueDate: () => '2020-01-23T04:59:00.000Z',
-		endDate: () => '2020-01-24T04:59:00.000Z',
-		canEditDates: () => true,
+		dates: {
+			startDate: () => '2020-01-22T04:59:00.000Z',
+			dueDate: () => '2020-01-23T04:59:00.000Z',
+			endDate: () => '2020-01-24T04:59:00.000Z',
+			canEditDates: () => true
+		},
 		isDraft: () => true,
 		canEditDraft: () => true,
 		scoreOutOf: () => 10,
@@ -48,11 +50,6 @@ describe('Activity Usage', function() {
 			const activity = new ActivityUsage('http://1', 'token');
 			await activity.fetch();
 
-			expect(activity.canEditDates).to.be.true;
-			expect(activity.startDate).to.equal('2020-01-22T04:59:00.000Z');
-			expect(activity.dueDate).to.equal('2020-01-23T04:59:00.000Z');
-			expect(activity.endDate).to.equal('2020-01-24T04:59:00.000Z');
-
 			expect(activity.isDraft).to.be.true;
 			expect(activity.canEditDraft).to.be.true;
 
@@ -71,48 +68,6 @@ describe('Activity Usage', function() {
 			});
 
 			fetchEntity.mockImplementation(() => sirenEntity);
-		});
-
-		it('reacts to start date', async(done) => {
-			const activity = new ActivityUsage('http://1', 'token');
-			await activity.fetch();
-
-			when(
-				() => activity.startDate === '2020-02-21T04:59:00.000Z',
-				() => {
-					done();
-				}
-			);
-
-			activity.setStartDate('2020-02-21T04:59:00.000Z');
-		});
-
-		it('reacts to due date', async(done) => {
-			const activity = new ActivityUsage('http://1', 'token');
-			await activity.fetch();
-
-			when(
-				() => activity.dueDate === '2020-02-23T04:59:00.000Z',
-				() => {
-					done();
-				}
-			);
-
-			activity.setDueDate('2020-02-23T04:59:00.000Z');
-		});
-
-		it('reacts to end date', async(done) => {
-			const activity = new ActivityUsage('http://1', 'token');
-			await activity.fetch();
-
-			when(
-				() => activity.endDate === '2020-02-25T04:59:00.000Z',
-				() => {
-					done();
-				}
-			);
-
-			activity.setEndDate('2020-02-25T04:59:00.000Z');
 		});
 
 		it('reacts to is draft', async(done) => {
@@ -147,19 +102,21 @@ describe('Activity Usage', function() {
 			const activity = new ActivityUsage('http://1', 'token');
 			await activity.fetch();
 
-			activity.setStartDate('2020-02-22T04:59:00.000Z');
-			activity.setDueDate('2020-02-23T04:59:00.000Z');
-			activity.setEndDate('2020-02-24T04:59:00.000Z');
+			activity.dates.setStartDate('2020-02-22T04:59:00.000Z');
+			activity.dates.setDueDate('2020-02-23T04:59:00.000Z');
+			activity.dates.setEndDate('2020-02-24T04:59:00.000Z');
 			activity.setDraftStatus(false);
 
 			await activity.save();
 
 			expect(save.mock.calls.length).to.equal(1);
 			expect(save.mock.calls[0][0]).to.eql({
-				startDate: '2020-02-22T04:59:00.000Z',
-				dueDate: '2020-02-23T04:59:00.000Z',
-				endDate: '2020-02-24T04:59:00.000Z',
 				isDraft: false,
+				dates: {
+					startDate: '2020-02-22T04:59:00.000Z',
+					dueDate: '2020-02-23T04:59:00.000Z',
+					endDate: '2020-02-24T04:59:00.000Z'
+				},
 				scoreAndGrade: {
 					scoreOutOf: '10',
 					inGrades: true


### PR DESCRIPTION
Adds a new `ActivityDates` class that encapsulates most of the dates-related functions and properties.

Relies on https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/141

Also implements focusing on first element in error after a validation error.