### PR TITLE
Fix availability dates editor accordion closing on error clear

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
@@ -63,16 +63,6 @@ class ActivityAssignmentAvailabilityEditor extends LocalizeMixin(ActivityEditorM
 		this._opened = false;
 	}
 
-	connectedCallback() {
-		super.connectedCallback();
-		this.addEventListener('d2l-labs-accordion-collapse-state-changed', this._onAccordionStateChange);
-	}
-
-	disconnectedCallback() {
-		super.disconnectedCallback();
-		this.removeEventListener('d2l-labs-accordion-collapse-state-changed', this._onAccordionStateChange);
-	}
-
 	_onAccordionStateChange(e) {
 		this._opened = e.detail.opened;
 	}
@@ -148,7 +138,11 @@ class ActivityAssignmentAvailabilityEditor extends LocalizeMixin(ActivityEditorM
 
 	render() {
 		return html`
-			<d2l-labs-accordion-collapse flex header-border ?opened=${this._isOpened()}>
+			<d2l-labs-accordion-collapse
+				flex
+				header-border
+				?opened=${this._isOpened()}
+				@d2l-labs-accordion-collapse-state-changed=${this._onAccordionStateChange}>
 				<h4 class="d2l-heading-4 activity-summarizer-header" slot="header">
 					${this.localize('hdrAvailability')}
 				</h4>


### PR DESCRIPTION
Previously the accordion would open on error, but then close when the error is cleared. Now it will leave it open when the error is cleared.

To do this we need to know if the accordion is currently open: Either track the open state in a prop via the accordion state change events, or check the dom via `this.shadowRoot.querySelector('d2l-labs-accordion-collapse').opened`. I went for the former, using `this._opened`.