### PR TITLE
DE37770 US110507: fix langterm file formatting

### DIFF
--- a/components/d2l-quick-eval/build/lang/ar.js
+++ b/components/d2l-quick-eval/build/lang/ar.js
@@ -43,7 +43,7 @@ export const LangAr = {
 			'moreActions': 'مزيد من الإجراءات',
 			'multiCourseQuickEval': 'التقييم السريع لعدة مقررات تعليمية',
 			'newAttempts': 'محاولات جديدة',
-			'newAttemptsDetails': '{newNum, plural, =0 {{reAttemptNum, plural, =1 {إعادة محاولة واحدة} other ‏{{reAttemptNum} من إعادة المحاولات}}} other {{reAttemptNum, plural, =0 {{newNum} إعادة محاولة جديدة} =1{{newNum} إعادة محاولة واحدة جديدة} other {{newNum}{reAttemptNum} من إعادة المحاولات الجديدة}}}}',
+			'newAttemptsDetails': '{newNum, plural, =0 {{reAttemptNum, plural, =1 {إعادة محاولة واحدة} other {{reAttemptNum} من إعادة المحاولات}}} other {{reAttemptNum, plural, =0 {{newNum} إعادة محاولة جديدة} =1{{newNum} إعادة محاولة واحدة جديدة} other {{newNum}{reAttemptNum} من إعادة المحاولات الجديدة}}}}',
 			'newPostDetails': '{numInteractions, plural, =1 {ترابط أو رد واحد} other {{numInteractions} من الترابطات أو الردود}}',
 			'newPosts': 'منشورات جديدة',
 			'newSubmissionDetails': '{newNum, plural, =0 {{resub, plural, =1 {عملية إعادة إرسال واحدة} other {{resub} من عمليات إعادة الإرسال}}} other {{resub, plural, =0 {{newNum} إعادة محاولة جديدة} =1{{newNum} عملية إعادة إرسال واحدة جديدة} other {{newNum} {resub} من عمليات إعادة الإرسال الجديدة}}}}',

--- a/components/d2l-quick-eval/build/lang/sv.js
+++ b/components/d2l-quick-eval/build/lang/sv.js
@@ -46,7 +46,7 @@ export const LangSv = {
 			'newAttemptsDetails': '{newNum, plural, =0 {{reAttemptNum, plural, =1 {1 reattempt} other {{reAttemptNum} återförsök}}} other {{reAttemptNum, plural, =0 {{newNum} new} =1{{newNum} nytt, 1 återförsök} other {{newNum} new, {reAttemptNum} återförsök}}}}',
 			'newPostDetails': '{numInteractions, plural, =1 {1 tråd eller svar} other {{numInteractions} trådar eller svar}}',
 			'newPosts': 'Nya inlägg',
-			'newSubmissionDetails': '{new Num, plural, =0 {{resub, plural, =1 {1 återinlämning} other {{resub} återinlämningar}}} other {{resub, plural, =0 {{newNum} new} =1{{newNum} ny, 1 återinlämning} other {{newNum} new, {resub} återinlämningar}}}}',
+			'newSubmissionDetails': '{newNum, plural, =0 {{resub, plural, =1 {1 återinlämning} other {{resub} återinlämningar}}} other {{resub, plural, =0 {{newNum} new} =1{{newNum} ny, 1 återinlämning} other {{newNum} new, {resub} återinlämningar}}}}',
 			'newSubmissions': 'Nya inlämningar',
 			'nextSubmission': 'Nästa inlämning',
 			'no': 'Nej',

--- a/components/d2l-quick-eval/lang/ar.json
+++ b/components/d2l-quick-eval/lang/ar.json
@@ -43,7 +43,7 @@
    "moreActions" : "مزيد من الإجراءات",
    "multiCourseQuickEval" : "التقييم السريع لعدة مقررات تعليمية",
    "newAttempts" : "محاولات جديدة",
-   "newAttemptsDetails" : "{newNum, plural, =0 {{reAttemptNum, plural, =1 {إعادة محاولة واحدة} other ‏{{reAttemptNum} من إعادة المحاولات}}} other {{reAttemptNum, plural, =0 {{newNum} إعادة محاولة جديدة} =1{{newNum} إعادة محاولة واحدة جديدة} other {{newNum}{reAttemptNum} من إعادة المحاولات الجديدة}}}}",
+   "newAttemptsDetails" : "{newNum, plural, =0 {{reAttemptNum, plural, =1 {إعادة محاولة واحدة} other {{reAttemptNum} من إعادة المحاولات}}} other {{reAttemptNum, plural, =0 {{newNum} إعادة محاولة جديدة} =1{{newNum} إعادة محاولة واحدة جديدة} other {{newNum}{reAttemptNum} من إعادة المحاولات الجديدة}}}}",
    "newPostDetails" : "{numInteractions, plural, =1 {ترابط أو رد واحد} other {{numInteractions} من الترابطات أو الردود}}",
    "newPosts" : "منشورات جديدة",
    "newSubmissionDetails" : "{newNum, plural, =0 {{resub, plural, =1 {عملية إعادة إرسال واحدة} other {{resub} من عمليات إعادة الإرسال}}} other {{resub, plural, =0 {{newNum} إعادة محاولة جديدة} =1{{newNum} عملية إعادة إرسال واحدة جديدة} other {{newNum} {resub} من عمليات إعادة الإرسال الجديدة}}}}",

--- a/components/d2l-quick-eval/lang/sv.json
+++ b/components/d2l-quick-eval/lang/sv.json
@@ -46,7 +46,7 @@
    "newAttemptsDetails" : "{newNum, plural, =0 {{reAttemptNum, plural, =1 {1 reattempt} other {{reAttemptNum} återförsök}}} other {{reAttemptNum, plural, =0 {{newNum} new} =1{{newNum} nytt, 1 återförsök} other {{newNum} new, {reAttemptNum} återförsök}}}}",
    "newPostDetails" : "{numInteractions, plural, =1 {1 tråd eller svar} other {{numInteractions} trådar eller svar}}",
    "newPosts" : "Nya inlägg",
-   "newSubmissionDetails" : "{new Num, plural, =0 {{resub, plural, =1 {1 återinlämning} other {{resub} återinlämningar}}} other {{resub, plural, =0 {{newNum} new} =1{{newNum} ny, 1 återinlämning} other {{newNum} new, {resub} återinlämningar}}}}",
+   "newSubmissionDetails" : "{newNum, plural, =0 {{resub, plural, =1 {1 återinlämning} other {{resub} återinlämningar}}} other {{resub, plural, =0 {{newNum} new} =1{{newNum} ny, 1 återinlämning} other {{newNum} new, {resub} återinlämningar}}}}",
    "newSubmissions" : "Nya inlämningar",
    "nextSubmission" : "Nästa inlämning",
    "no" : "Nej",


### PR DESCRIPTION
This PR fixes both stories:
 * https://rally1.rallydev.com/#/42960320374d/detail/userstory/336778594020
* https://rally1.rallydev.com/#/42960320374d/detail/defect/367913252916

The problem with the `ar` file is there was an invisible character which threw off the parser. This was ungodly difficult to figure out. We really need automatic validation of these langterm files because no way a human was gonna catch it.

The problem with the `sv` file was simpler, the translator just mangled the variable name by adding a space.