### PR TITLE
Remove usage completionTypeOptions method

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -23,29 +23,49 @@ export class Assignment {
 	_getValidCompletionTypes(currentSubmissionType) {
 		const selectedSubmissionType = String(currentSubmissionType);
 
-		return this.submissionTypeOptions.find(
+		const submissionType = this.submissionTypeOptions.find(
 			submissionType => submissionType.value.toString() === selectedSubmissionType
-		).completionTypes;
+		);
+
+		if (!submissionType) {
+			return [];
+		}
+
+		return submissionType.completionTypes;
 	}
 
 	_isCompletionTypeValid(completionTypeId, validCompletionTypes) {
 		const completionType = String(completionTypeId);
+
+		if (!validCompletionTypes) {
+			return false;
+		}
+
 		return validCompletionTypes.some(validCompletionType => validCompletionType.toString() === completionType);
+	}
+
+	_getCompletionTypeOptions(validCompletionTypes) {
+		let completionTypeOptions = [];
+
+		if (validCompletionTypes && validCompletionTypes.length > 0) {
+			completionTypeOptions = this.allCompletionTypeOptions.filter(
+				completionType => this._isCompletionTypeValid(completionType.value, validCompletionTypes)
+			);
+		}
+
+		return completionTypeOptions;
 	}
 
 	_setValidCompletionTypeForSubmissionType() {
 		const validCompletionTypes = this._getValidCompletionTypes(this.submissionType);
+		this.completionTypeOptions = this._getCompletionTypeOptions(validCompletionTypes);
 
-		if (validCompletionTypes && validCompletionTypes.length > 0) {
-			this.completionTypeOptions = this.allCompletionTypeOptions.filter(
-				completionType => this._isCompletionTypeValid(completionType.value, validCompletionTypes)
-			);
-
-			if (this.completionType === null || !this._isCompletionTypeValid(this.completionType, validCompletionTypes)) {
+		if (this.completionType === null || !this._isCompletionTypeValid(this.completionType, validCompletionTypes)) {
+			if (validCompletionTypes && validCompletionTypes.length > 0) {
 				this.completionType = String(validCompletionTypes[0]);
+			} else {
+				this.completionType = null;
 			}
-		} else {
-			this.completionTypeOptions = [];
 		}
 	}
 
@@ -75,7 +95,8 @@ export class Assignment {
 		this.isReadOnly = entity.isAssignmentTypeReadOnly();
 		this.selectedGroupCategoryName = entity.getAssignmentTypeSelectedGroupCategoryName();
 
-		this._setValidCompletionTypeForSubmissionType();
+		const validCompletionTypes = this._getValidCompletionTypes(this.submissionType);
+		this.completionTypeOptions = this._getCompletionTypeOptions(validCompletionTypes);
 
 		if (!this.isIndividualAssignmentType && this.groupCategories.length > 0) {
 			this.selectedGroupCategoryId = String(this.groupCategories[0].value);

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -64,7 +64,6 @@ export class Assignment {
 		this.annotationToolsAvailable = entity.getAvailableAnnotationTools();
 		this.activityUsageHref = entity.activityUsageHref();
 		this.submissionTypeOptions = entity.submissionTypeOptions();
-		this.completionTypeOptions = entity.completionTypeOptions();
 		this.allCompletionTypeOptions = entity.allCompletionTypeOptions();
 		this.canEditSubmissionType = entity.canEditSubmissionType();
 		this.canEditCompletionType = entity.canEditCompletionType();
@@ -75,6 +74,8 @@ export class Assignment {
 		this.groupCategories = entity.getAssignmentTypeGroupCategoryOptions();
 		this.isReadOnly = entity.isAssignmentTypeReadOnly();
 		this.selectedGroupCategoryName = entity.getAssignmentTypeSelectedGroupCategoryName();
+
+		this._setValidCompletionTypeForSubmissionType();
 
 		if (!this.isIndividualAssignmentType && this.groupCategories.length > 0) {
 			this.selectedGroupCategoryId = String(this.groupCategories[0].value);

--- a/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
@@ -37,8 +37,8 @@ describe('Assignment ', function() {
 				submissionTypeOptions: () => [
 					{title: 'File submission', value: 0, completionTypes: null, selected: false},
 					{title: 'Text submission', value: 1, completionTypes: null, selected: false},
-					{title: 'On paper submission', value: 2, completionTypes: [1, 2, 3], selected: true},
-					{title: 'Observed in person', value: 3, completionTypes: [1, 2, 3], selected: false}
+					{title: 'On paper submission', value: 2, completionTypes: [1, 2], selected: true},
+					{title: 'Observed in person', value: 3, completionTypes: [3], selected: false}
 				],
 				allCompletionTypeOptions: () => [
 					{
@@ -88,13 +88,12 @@ describe('Assignment ', function() {
 		expect(assignment.submissionTypeOptions).to.eql([
 			{title: 'File submission', value: 0, completionTypes: null, selected: false},
 			{title: 'Text submission', value: 1, completionTypes: null, selected: false},
-			{title: 'On paper submission', value: 2, completionTypes: [1, 2, 3], selected: true},
-			{title: 'Observed in person', value: 3, completionTypes: [1, 2, 3], selected: false}
+			{title: 'On paper submission', value: 2, completionTypes: [1, 2], selected: true},
+			{title: 'Observed in person', value: 3, completionTypes: [3], selected: false}
 		]);
 		expect(assignment.completionTypeOptions).to.eql([
 			{selected: false, title: 'Manually by learners', value: 1},
-			{selected: false, title: 'Automatically on evaluation', value: 2},
-			{selected: true, title: 'Automatically on due date', value: 3}
+			{selected: false, title: 'Automatically on evaluation', value: 2}
 		]);
 		expect(assignment.canEditSubmissionType).to.equal(true);
 		expect(assignment.canEditCompletionType).to.equal(true);
@@ -114,7 +113,7 @@ describe('Assignment ', function() {
 		assignment.setSubmissionType('3');
 
 		expect(assignment.submissionType).to.equal('3');
-		expect(assignment.completionType).to.equal('1');
+		expect(assignment.completionType).to.equal('3');
 		expect(assignment.canEditCompletionType).to.equal(true);
 	});
 
@@ -126,7 +125,7 @@ describe('Assignment ', function() {
 		assignment.setSubmissionType('1');
 
 		expect(assignment.submissionType).to.equal('1');
-		expect(assignment.completionType).to.equal('3');
+		expect(assignment.completionType).to.equal(null);
 		expect(assignment.canEditCompletionType).to.equal(true);
 	});
 
@@ -147,7 +146,7 @@ describe('Assignment ', function() {
 		assignment.setSubmissionType('0');
 
 		expect(assignment.submissionType).to.equal('0');
-		expect(assignment.completionType).to.equal('2');
+		expect(assignment.completionType).to.equal(null);
 		expect(assignment.canEditCompletionType).to.equal(true);
 	});
 });

--- a/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
@@ -37,35 +37,30 @@ describe('Assignment ', function() {
 				submissionTypeOptions: () => [
 					{title: 'File submission', value: 0, completionTypes: null, selected: false},
 					{title: 'Text submission', value: 1, completionTypes: null, selected: false},
-					{title: 'On paper submission', value: 2, completionTypes: [2, 3, 4], selected: true},
-					{title: 'Observed in person', value: 3, completionTypes: [1, 3, 4], selected: false}
+					{title: 'On paper submission', value: 2, completionTypes: [1, 2, 3], selected: true},
+					{title: 'Observed in person', value: 3, completionTypes: [1, 2, 3], selected: false}
 				],
 				allCompletionTypeOptions: () => [
 					{
 						'title': 'Automatically on submission',
 						'value': 0,
-						'selected': true
+						'selected': false
 					},
 					{
 						'title': 'Manually by learners',
-						'value': 2,
+						'value': 1,
 						'selected': false
 					},
 					{
 						'title': 'Automatically on evaluation',
-						'value': 3,
+						'value': 2,
 						'selected': false
 					},
 					{
 						'title': 'Automatically on due date',
-						'value': 1,
-						'selected': false
+						'value': 3,
+						'selected': true
 					}
-				],
-				completionTypeOptions: () => [
-					{title: 'Manually by learners', value: 2},
-					{title: 'Automatically on evaluation', value: 3},
-					{title: 'Automatically on due date', value: 4}
 				],
 				canEditSubmissionType: () => true,
 				canEditCompletionType: () => true,
@@ -93,13 +88,13 @@ describe('Assignment ', function() {
 		expect(assignment.submissionTypeOptions).to.eql([
 			{title: 'File submission', value: 0, completionTypes: null, selected: false},
 			{title: 'Text submission', value: 1, completionTypes: null, selected: false},
-			{title: 'On paper submission', value: 2, completionTypes: [2, 3, 4], selected: true},
-			{title: 'Observed in person', value: 3, completionTypes: [1, 3, 4], selected: false}
+			{title: 'On paper submission', value: 2, completionTypes: [1, 2, 3], selected: true},
+			{title: 'Observed in person', value: 3, completionTypes: [1, 2, 3], selected: false}
 		]);
 		expect(assignment.completionTypeOptions).to.eql([
-			{title: 'Manually by learners', value: 2},
-			{title: 'Automatically on evaluation', value: 3},
-			{title: 'Automatically on due date', value: 4}
+			{selected: false, title: 'Manually by learners', value: 1},
+			{selected: false, title: 'Automatically on evaluation', value: 2},
+			{selected: true, title: 'Automatically on due date', value: 3}
 		]);
 		expect(assignment.canEditSubmissionType).to.equal(true);
 		expect(assignment.canEditCompletionType).to.equal(true);
@@ -149,10 +144,10 @@ describe('Assignment ', function() {
 	it('setSubmissionType when current completion type is no longer valid', async() => {
 		const assignment = new Assignment('http://assignment/1', 'token');
 		await assignment.fetch();
-		assignment.setSubmissionType('3');
+		assignment.setSubmissionType('0');
 
-		expect(assignment.submissionType).to.equal('3');
-		expect(assignment.completionType).to.equal('1');
+		expect(assignment.submissionType).to.equal('0');
+		expect(assignment.completionType).to.equal('2');
 		expect(assignment.canEditCompletionType).to.equal(true);
 	});
 });


### PR DESCRIPTION
For https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/157 we need to remove these usages of the completionTypeOptions method.

The variable is used to hold the current visible completionTypeOptions in the UI. So we now populate it using the `_setValidCompletionTypeForSubmissionType` method.