### PR TITLE
Fix assignment editor datetime picker spacing

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -29,6 +29,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 		};
 	}
 
+	// The #score-and-duedate-container min-height and padding rules are a hack for the old datetime picker. Can hopefully be removed when the new picker is used.
 	static get styles() {
 		return [
 			labelStyles,
@@ -45,6 +46,8 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 				#score-and-duedate-container {
 					display: flex;
 					flex-wrap: wrap;
+					min-height: 90px;
+					padding-bottom: 0;
 				}
 				#score-container {
 					margin-right: 40px;

--- a/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
@@ -8,6 +8,7 @@ import { MobxLitElement } from '@adobe/lit-mobx';
 import { shared as store } from './state/activity-store.js';
 
 class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeMixin(MobxLitElement))) {
+	// The start/enddate-container rule is a hack for the old datetime picker. Can hopefully be removed when the new picker is used.
 	static get styles() {
 		return [labelStyles, css`
 			:host {
@@ -15,6 +16,10 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeMixin
 			}
 			:host([hidden]) {
 				display: none;
+			}
+			#startdate-container,
+			#enddate-container {
+				min-height: 62px;
 			}
 		`];
 	}


### PR DESCRIPTION
Problem:
On first render and after setting a date/time, the datetime picker has 20px extra bottom padding. After clearing the date/time, the picker has no bottom padding. This results in spacing being too much initially, and then not enough after clearing the date/time.

This fix forces the container elements of each datetime picker to compensate by simply setting the min-height to the height of the containing elements (either just the picker, or picker & label) + 20px (which is the desired spacing/padding).
Using min-height as opposed to height so the container can still expend for the timezone label which appears below the picker when a date is set.