### PR TITLE
Call `associate-new-grade`

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-grades-dialog.js
+++ b/components/d2l-activity-editor/d2l-activity-grades-dialog.js
@@ -19,7 +19,6 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mo
 
 	static get properties() {
 		return {
-			activityName: { type: String },
 			_createNewRadioChecked: { type: Boolean }
 		};
 	}
@@ -72,10 +71,10 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mo
 			return;
 		}
 
+		const gradeCandidateCollection = gradeCandidateCollectionStore.get(scoreAndGrade.gradeCandidatesHref);
 		if (this._createNewRadioChecked) {
-			// Not yet implemented
+			scoreAndGrade.replaceGradeItem(gradeCandidateCollection.associateNewGradeAction);
 		} else {
-			const gradeCandidateCollection = gradeCandidateCollectionStore.get(scoreAndGrade.gradeCandidatesHref);
 			scoreAndGrade.setAssociatedGrade(gradeCandidateCollection.selected);
 		}
 	}
@@ -101,7 +100,8 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mo
 		const {
 			scoreOutOf,
 			scoreOutOfError,
-			gradeCandidatesHref
+			gradeCandidatesHref,
+			newGradeName
 		} = activity.scoreAndGrade;
 
 		return html`
@@ -119,7 +119,7 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mo
 					<div class="d2l-activity-grades-dialog-create-new-container">
 						<div class="d2l-activity-grades-dialog-create-new-icon"><d2l-icon icon="tier1:grade"></d2l-icon></div>
 						<div>
-							<div class="d2l-activity-grades-dialog-create-new-activity-name">${this.activityName}</div>
+							<div class="d2l-activity-grades-dialog-create-new-activity-name">${newGradeName}</div>
 							<div class="d2l-body-small">${scoreOutOf && !scoreOutOfError ? html`
 								${this.localize('points', { points: formatNumber(scoreOutOf, { maximumFractionDigits: 2 })})}
 							` : null }

--- a/components/d2l-activity-editor/d2l-activity-grades/state/grade-candidate-collection.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/state/grade-candidate-collection.js
@@ -30,6 +30,8 @@ export class GradeCandidateCollection {
 
 	async load(entity) {
 		this._entity = entity;
+		this.associateNewGradeAction = entity.getAssociateNewGradeAction();
+
 		const gradeCandidatePromises = entity.getGradeCandidates().map(gc => {
 			const gradeCandidateEntity = new GradeCandidateEntity(gc, this.token, { remove: () => { }});
 			return this.fetchGradeCandidate(gradeCandidateEntity);
@@ -79,6 +81,7 @@ export class GradeCandidateCollection {
 decorate(GradeCandidateCollection, {
 	// props
 	gradeCandidates: observable,
+	associateNewGradeAction: observable,
 	selected: observable,
 	// actions
 	load: action,

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -163,6 +163,8 @@ class ActivityScoreEditor extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mob
 					this.shadowRoot.querySelector('#ungraded') :
 					this.shadowRoot.querySelector('#score-out-of');
 				toFocus.focus();
+			} else if (propName === 'activityName') {
+				store.get(this.href).scoreAndGrade.setNewGradeName(this.activityName);
 			}
 		});
 	}
@@ -294,8 +296,7 @@ class ActivityScoreEditor extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mob
 						</d2l-dropdown>
 						<d2l-activity-grades-dialog
 							href="${this.href}"
-							.token="${this.token}"
-							.activityName="${this.activityName}"></d2l-activity-grades-dialog>
+							.token="${this.token}"></d2l-activity-grades-dialog>
 					</div>
 				` : null}
 			</div>

--- a/components/d2l-activity-editor/state/activity-score-grade.js
+++ b/components/d2l-activity-editor/state/activity-score-grade.js
@@ -17,6 +17,7 @@ export class ActivityScoreGrade {
 		this.associatedGrade = null;
 		this.gradeHref = entity.gradeHref();
 		this.gradeCandidatesHref = entity.gradeCandidatesHref();
+		this.associateNewGradeAction = null;
 	}
 
 	setScoreOutOf(value) {
@@ -77,6 +78,17 @@ export class ActivityScoreGrade {
 			this.setScoreOutOf(gradeCandidate.maxPoints.toString());
 		}
 	}
+
+	replaceGradeItem(associateNewGradeAction) {
+		this.associateNewGradeAction = associateNewGradeAction;
+		this.associatedGrade = null;
+		this.gradeHref = '';
+		this.inGrades = true;
+	}
+
+	setNewGradeName(name) {
+		this.newGradeName = name;
+	}
 }
 
 decorate(ActivityScoreGrade, {
@@ -92,6 +104,8 @@ decorate(ActivityScoreGrade, {
 	gradeCandidatesHref: observable,
 	gradeHref: observable,
 	associatedGrade: observable,
+	associateNewGradeAction: observable,
+	newGradeName: observable,
 	// actions
 	setScoreOutOf: action,
 	setUngraded: action,
@@ -99,5 +113,7 @@ decorate(ActivityScoreGrade, {
 	removeFromGrades: action,
 	addToGrades: action,
 	validate: action,
-	setAssociatedGrade: action
+	setAssociatedGrade: action,
+	replaceGradeItem: action,
+	setNewGradeName: action
 });

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -97,7 +97,9 @@ export class ActivityUsage {
 			scoreAndGrade: {
 				scoreOutOf: this.scoreAndGrade.scoreOutOf,
 				inGrades: this.scoreAndGrade.inGrades,
-				associatedGrade: (this.scoreAndGrade.associatedGrade || {}).gradeCandidateEntity
+				associatedGrade: (this.scoreAndGrade.associatedGrade || {}).gradeCandidateEntity,
+				associateNewGradeAction: this.scoreAndGrade.associateNewGradeAction,
+				newGradeName: this.scoreAndGrade.newGradeName
 			}
 		};
 	}


### PR DESCRIPTION
This processes and passes the correct info to the activity-usage save to `associate-new-grade`. There is some gross stuff like having to store the assignment `name` in the activity score out of MobX object, but it is required because the name needs to be known by the activity in order to create a new grade with that name.  The `associate-new-grade` action is in the grade-candidates response. The `score-out-of` does not have access to the grade candidates, so the `associateNewGradeAction` variable is being set when the grades dialog is opened and the "Create and link new grade object" is selected. If the dialog isn't opened, such as if we're adding an activity to grades for the first time, it will default to using the `score-out-of` in the `siren-sdk`

This is not all that great and am open to hearing if anyone has any better ideas...

will add tests if this code is fine.