### PR TITLE
US114762 Fix rc dialog width/height to account for dialog chrome

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-conditions-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-conditions-editor.js
@@ -255,8 +255,8 @@ class ActivityConditionsEditor
 			/*          srcCallback: */ 'AttachConditions',
 			/*       resizeCallback: */ '',
 			/*      responseDataKey: */ 'conditions',
-			/*                width: */ 638,
-			/*               height: */ 588,
+			/*                width: */ 700,
+			/*               height: */ 650,
 			/*            closeText: */ attachExistingCloseText,
 			/*              buttons: */ buttons,
 			/* forceTriggerOnCancel: */ false
@@ -306,8 +306,8 @@ class ActivityConditionsEditor
 			/*          srcCallback: */ 'CreateCondition',
 			/*       resizeCallback: */ '',
 			/*      responseDataKey: */ 'condition',
-			/*                width: */ 638,
-			/*               height: */ 683,
+			/*                width: */ 700,
+			/*               height: */ 745,
 			/*            closeText: */ createNewCloseText,
 			/*              buttons: */ buttons,
 			/* forceTriggerOnCancel: */ false


### PR DESCRIPTION
[US114762](https://rally1.rallydev.com/#/detail/userstory/376876593184?fdp=true)

This PR tweaks the rc dialog width/height to account for an API difference between legacy and mvc: in legacy, the width/height is for the content frame, in mvc it is the entire dialog chrome.