### PR TITLE
Call to Associate New Grade

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-grades-dialog.js
+++ b/components/d2l-activity-editor/d2l-activity-grades-dialog.js
@@ -18,7 +18,6 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mo
 
 	static get properties() {
 		return {
-			activityName: { type: String },
 			_createNewRadioChecked: { type: Boolean }
 		};
 	}
@@ -76,7 +75,7 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mo
 		}
 
 		if (this._createNewRadioChecked) {
-			// Not yet implemented
+			scoreAndGrade.linkToNewGrade();
 		} else {
 			scoreAndGrade.linkToExistingGrade(prevSelectedHref);
 		}
@@ -103,18 +102,21 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mo
 		const {
 			scoreOutOf,
 			scoreOutOfError,
-			gradeCandidateCollection
+			gradeCandidateCollection,
+			newGradeName
 		} = activity.scoreAndGrade;
 
 		const hasGradeCandidates = gradeCandidateCollection && gradeCandidateCollection.gradeCandidates.length > 0;
+		const canLinkNewGrade = gradeCandidateCollection && !!gradeCandidateCollection.associateNewGradeAction;
 
 		return html`
 			<d2l-dialog title-text="${this.localize('chooseFromGrades')}">
-				<label class="d2l-input-radio-label">
+				<label class="d2l-input-radio-label ${!canLinkNewGrade ? 'd2l-input-radio-label-disabled' : ''}">
 					<input
 						type="radio"
 						name="chooseFromGrades"
 						value="createNew"
+						?disabled="${!canLinkNewGrade}"
 						.checked="${this._createNewRadioChecked}"
 						@change="${this._dialogRadioChanged}">
 					${this.localize('createAndLinkToNewGradeItem')}
@@ -123,7 +125,7 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mo
 					<div class="d2l-activity-grades-dialog-create-new-container">
 						<div class="d2l-activity-grades-dialog-create-new-icon"><d2l-icon icon="tier1:grade"></d2l-icon></div>
 						<div>
-							<div class="d2l-activity-grades-dialog-create-new-activity-name">${this.activityName}</div>
+							<div class="d2l-activity-grades-dialog-create-new-activity-name">${newGradeName}</div>
 							<div class="d2l-body-small">${scoreOutOf && !scoreOutOfError ? html`
 								${this.localize('points', { points: formatNumber(scoreOutOf, { maximumFractionDigits: 2 })})}
 							` : null }

--- a/components/d2l-activity-editor/d2l-activity-grades/state/grade-candidate-collection.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/state/grade-candidate-collection.js
@@ -32,6 +32,7 @@ export class GradeCandidateCollection {
 
 	async load(entity) {
 		this._entity = entity;
+		this.associateNewGradeAction = entity.getAssociateNewGradeAction();
 		const gradeCandidatePromises = entity.getGradeCandidates().map(gc => {
 			const gradeCandidateEntity = new GradeCandidateEntity(gc, this.token, { remove: () => { }});
 			return this.fetchGradeCandidate(gradeCandidateEntity);
@@ -87,6 +88,7 @@ decorate(GradeCandidateCollection, {
 	// props
 	gradeCandidates: observable,
 	selected: observable,
+	associateNewGradeAction: observable,
 	// actions
 	load: action,
 	setSelected: action

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -163,6 +163,8 @@ class ActivityScoreEditor extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mob
 					this.shadowRoot.querySelector('#ungraded') :
 					this.shadowRoot.querySelector('#score-out-of');
 				toFocus.focus();
+			} else if (propName === 'activityName') {
+				store.get(this.href).scoreAndGrade.setNewGradeName(this.activityName);
 			}
 		});
 	}
@@ -294,8 +296,7 @@ class ActivityScoreEditor extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mob
 						</d2l-dropdown>
 						<d2l-activity-grades-dialog
 							href="${this.href}"
-							.token="${this.token}"
-							.activityName="${this.activityName}"></d2l-activity-grades-dialog>
+							.token="${this.token}"></d2l-activity-grades-dialog>
 					</div>
 				` : null}
 			</div>

--- a/components/d2l-activity-editor/state/activity-score-grade.js
+++ b/components/d2l-activity-editor/state/activity-score-grade.js
@@ -57,7 +57,7 @@ export class ActivityScoreGrade {
 		this.inGrades = true;
 	}
 
-	getAssociatedGrade() {
+	getAssociatedGradeEntity() {
 		if (this.gradeCandidateCollection && this.gradeCandidateCollection.selected) {
 			return this.gradeCandidateCollection.selected.gradeCandidateEntity;
 		}
@@ -116,6 +116,7 @@ decorate(ActivityScoreGrade, {
 	gradeCandidatesHref: observable,
 	gradeCandidateCollection: observable,
 	newGradeName: observable,
+	createNewGrade: observable,
 	// actions
 	setScoreOutOf: action,
 	setUngraded: action,

--- a/components/d2l-activity-editor/state/activity-score-grade.js
+++ b/components/d2l-activity-editor/state/activity-score-grade.js
@@ -94,6 +94,15 @@ export class ActivityScoreGrade {
 			this.setScoreOutOf(gradeCandidate.maxPoints.toString());
 		}
 	}
+
+	linkToNewGrade() {
+		this.createNewGrade = true;
+		this.setGraded();
+	}
+
+	setNewGradeName(name) {
+		this.newGradeName = name;
+	}
 }
 
 decorate(ActivityScoreGrade, {
@@ -108,6 +117,7 @@ decorate(ActivityScoreGrade, {
 	canEditGrades: observable,
 	gradeCandidatesHref: observable,
 	gradeCandidateCollection: observable,
+	newGradeName: observable,
 	// actions
 	setScoreOutOf: action,
 	setUngraded: action,
@@ -116,5 +126,7 @@ decorate(ActivityScoreGrade, {
 	addToGrades: action,
 	validate: action,
 	linkToExistingGrade: action,
-	fetchGradeCandidates: action
+	fetchGradeCandidates: action,
+	linkToNewGrade: action,
+	setNewGradeName: action
 });

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -97,7 +97,9 @@ export class ActivityUsage {
 			scoreAndGrade: {
 				scoreOutOf: this.scoreAndGrade.scoreOutOf,
 				inGrades: this.scoreAndGrade.inGrades,
-				associatedGrade: this.scoreAndGrade.getAssociatedGrade()
+				associatedGrade: this.scoreAndGrade.createNewGrade ? null : this.scoreAndGrade.getAssociatedGrade(),
+				associateNewGradeAction: (this.scoreAndGrade.gradeCandidateCollection || {}).associateNewGradeAction,
+				newGradeName: this.scoreAndGrade.newGradeName
 			}
 		};
 	}

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -97,7 +97,7 @@ export class ActivityUsage {
 			scoreAndGrade: {
 				scoreOutOf: this.scoreAndGrade.scoreOutOf,
 				inGrades: this.scoreAndGrade.inGrades,
-				associatedGrade: this.scoreAndGrade.createNewGrade ? null : this.scoreAndGrade.getAssociatedGrade(),
+				associatedGrade: this.scoreAndGrade.createNewGrade ? null : this.scoreAndGrade.getAssociatedGradeEntity(),
 				associateNewGradeAction: (this.scoreAndGrade.gradeCandidateCollection || {}).associateNewGradeAction,
 				newGradeName: this.scoreAndGrade.newGradeName
 			}

--- a/test/d2l-activity-editor/d2l-activity-grades/state/grade-candidate-collection.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-grades/state/grade-candidate-collection.spec.js
@@ -26,7 +26,8 @@ describe('Grade Candidate Collection', function() {
 			getGradeCandidates: () => [
 				{'test': 1},
 				{'test': 2}
-			]
+			],
+			getAssociateNewGradeAction: () => {}
 		};
 
 		GradeCandidateCollectionEntity.mockImplementation(() => {

--- a/test/d2l-activity-editor/state/activity-score-grade.spec.js
+++ b/test/d2l-activity-editor/state/activity-score-grade.spec.js
@@ -65,6 +65,12 @@ describe('Activity Score Grade', function() {
 
 			expect(activity.isUngraded).to.be.true;
 		});
+
+		it('initializes with correct createNewGrade', async() => {
+			const activity = new ActivityScoreGrade(defaultEntityMock);
+
+			expect(activity.createNewGrade).to.be.false;
+		});
 	});
 
 	describe('updating', () => {
@@ -122,47 +128,112 @@ describe('Activity Score Grade', function() {
 			activity.setScoreOutOf('99');
 		});
 
-		it('reacts to link to existing grade', async(done) => {
-			const gradeEntityMock = {
-				name: () => '',
-				baseWeight: () => '',
-				maxPoints: () => 50
-			};
-			GradeEntity.mockImplementation(() => gradeEntityMock);
-
-			const gradeCandidateEntityMock = {
-				isCategory: () => false,
-				isCurrentAssociation: () => false,
-				href: () => 'http://grade-candidate-href',
-				getGradeCandidates: () => []
-			};
-
-			const gradeCandidate = new GradeCandidate(gradeCandidateEntityMock, 'token');
-			await gradeCandidate.fetch();
-
-			const gradeCandidateCollectionEntityMock = {
-				href: () => 'http://grade-candidate-collection-href',
-				getGradeCandidates: () => [gradeCandidate],
-				selected: () => gradeCandidate,
-				getAssociateNewGradeAction: () => {}
-			};
-			GradeCandidateCollectionEntity.mockImplementation(() => gradeCandidateCollectionEntityMock);
-			GradeCandidateEntity.mockImplementation(() => gradeCandidateEntityMock);
-			fetchEntity.mockImplementation(() => Promise.resolve({}));
-
-			const activity = new ActivityScoreGrade(defaultEntityMock, 'token');
-
-			await activity.fetchGradeCandidates();
-			activity.linkToExistingGrade(gradeCandidate.href);
+		it('reacts to set new grade name', async(done) => {
+			const activity = new ActivityScoreGrade(defaultEntityMock);
 
 			when(
-				() => !activity.createNewGrade,
+				() => activity.newGradeName === 'a new grade name',
+				done
+			);
+
+			activity.setNewGradeName('a new grade name');
+		});
+
+		it('reacts to link to new grade', async(done) => {
+			const activity = new ActivityScoreGrade(defaultEntityMock);
+
+			when(
+				() => activity.createNewGrade,
 				catchErrors(done, () => {
-					expect(activity.inGrades).to.be.true;
+					expect(activity.createNewGrade).to.be.true;
 					expect(activity.isUngraded).to.be.false;
-					expect(activity.scoreOutOf).to.equal('50');
 				})
 			);
+
+			activity.linkToNewGrade();
+		});
+
+		describe('reacts to link to existing grade', () => {
+			let gradeCandidate;
+
+			beforeEach(async() => {
+				const gradeEntityMock = {
+					name: () => '',
+					baseWeight: () => '',
+					maxPoints: () => 50
+				};
+				GradeEntity.mockImplementation(() => gradeEntityMock);
+
+				const gradeCandidateEntityMock = {
+					isCategory: () => false,
+					isCurrentAssociation: () => false,
+					href: () => 'http://grade-candidate-href',
+					getGradeCandidates: () => []
+				};
+
+				gradeCandidate = new GradeCandidate(gradeCandidateEntityMock, 'token');
+				await gradeCandidate.fetch();
+
+				const gradeCandidateCollectionEntityMock = {
+					href: () => 'http://grade-candidate-collection-href',
+					getGradeCandidates: () => [gradeCandidate],
+					selected: () => gradeCandidate,
+					getAssociateNewGradeAction: () => {}
+				};
+				GradeCandidateCollectionEntity.mockImplementation(() => gradeCandidateCollectionEntityMock);
+				GradeCandidateEntity.mockImplementation(() => gradeCandidateEntityMock);
+				fetchEntity.mockImplementation(() => Promise.resolve({}));
+			});
+
+			it('sets scoreOutOf because it is empty (but linked grade has not changed)', async(done) => {
+				defaultEntityMock.scoreOutOf = () => '';
+				const activity = new ActivityScoreGrade(defaultEntityMock, 'token');
+				await activity.fetchGradeCandidates();
+
+				when(
+					() => activity.scoreOutOf === '50',
+					done
+				);
+
+				activity.linkToExistingGrade(gradeCandidate.href);
+			});
+
+			it('links and sets scoreOutOf when coming from ungraded with create new and link selected', async(done) => {
+
+				const activity = new ActivityScoreGrade(defaultEntityMock, 'token');
+				activity.linkToNewGrade();
+				activity.setUngraded();
+
+				await activity.fetchGradeCandidates();
+
+				when(
+					() => !activity.createNewGrade,
+					catchErrors(done, () => {
+						expect(activity.inGrades).to.be.true;
+						expect(activity.isUngraded).to.be.false;
+						expect(activity.scoreOutOf).to.equal('50');
+					})
+				);
+
+				activity.linkToExistingGrade('');
+			});
+
+			it('links and sets scoreOutOf', async(done) => {
+				const activity = new ActivityScoreGrade(defaultEntityMock, 'token');
+
+				await activity.fetchGradeCandidates();
+
+				when(
+					() => activity.scoreOutOf === '50',
+					catchErrors(done, () => {
+						expect(activity.createNewGrade).to.be.false;
+						expect(activity.inGrades).to.be.true;
+						expect(activity.isUngraded).to.be.false;
+					})
+				);
+
+				activity.linkToExistingGrade('http://test');
+			});
 		});
 	});
 

--- a/test/d2l-activity-editor/state/activity-score-grade.spec.js
+++ b/test/d2l-activity-editor/state/activity-score-grade.spec.js
@@ -143,7 +143,8 @@ describe('Activity Score Grade', function() {
 			const gradeCandidateCollectionEntityMock = {
 				href: () => 'http://grade-candidate-collection-href',
 				getGradeCandidates: () => [gradeCandidate],
-				selected: () => gradeCandidate
+				selected: () => gradeCandidate,
+				getAssociateNewGradeAction: () => {}
 			};
 			GradeCandidateCollectionEntity.mockImplementation(() => gradeCandidateCollectionEntityMock);
 			GradeCandidateEntity.mockImplementation(() => gradeCandidateEntityMock);

--- a/test/d2l-activity-editor/state/activity-usage.spec.js
+++ b/test/d2l-activity-editor/state/activity-usage.spec.js
@@ -108,7 +108,7 @@ describe('Activity Usage', function() {
 			activity.dates.setDueDate('2020-02-23T04:59:00.000Z');
 			activity.dates.setEndDate('2020-02-24T04:59:00.000Z');
 			activity.setDraftStatus(false);
-
+			activity.scoreAndGrade.setNewGradeName('a new grade');
 			await activity.save();
 
 			expect(save.mock.calls.length).to.equal(1);
@@ -120,9 +120,11 @@ describe('Activity Usage', function() {
 					endDate: '2020-02-24T04:59:00.000Z'
 				},
 				scoreAndGrade: {
-					associatedGrade: undefined,
+					associateNewGradeAction: undefined,
+					associatedGrade: null,
 					scoreOutOf: '10',
-					inGrades: true
+					inGrades: true,
+					newGradeName: 'a new grade'
 				}
 			});
 		});


### PR DESCRIPTION
When the `Create and link to new grade item` radio button is selected, the appropriate data will be included so that when the `activity-usage` `siren-sdk` save is called, it will be able to call the `associate-new-grade` action extracted from the `scoreAndGrade.gradeCandidateCollection` entity.

The `activity-usage` save will now include sending the `associate-new-grade` action and `gradeName` of the assignment activity as data to the `siren-sdk` `activity-usage` save method.
