### PR TITLE
Remove linked grade didn't change check.

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-grades-dialog.js
+++ b/components/d2l-activity-editor/d2l-activity-grades-dialog.js
@@ -91,7 +91,7 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mo
 		if (this._createNewRadioChecked) {
 			scoreAndGrade.linkToNewGrade();
 		} else if (!this._createNewRadioChecked && this._hasGradeCandidates) {
-			scoreAndGrade.linkToExistingGrade(prevSelectedHref);
+			scoreAndGrade.linkToExistingGrade();
 		}
 	}
 

--- a/components/d2l-activity-editor/state/activity-score-grade.js
+++ b/components/d2l-activity-editor/state/activity-score-grade.js
@@ -78,7 +78,7 @@ export class ActivityScoreGrade {
 		return !this.scoreOutOfError;
 	}
 
-	linkToExistingGrade(prevHref) {
+	linkToExistingGrade() {
 		if (!this.gradeCandidateCollection) {
 			return;
 		}
@@ -87,8 +87,7 @@ export class ActivityScoreGrade {
 		this.setGraded();
 
 		const gradeCandidate = this.gradeCandidateCollection.selected;
-		const setScoreOutOf = !this.scoreOutOf || (gradeCandidate && prevHref !== gradeCandidate.href);
-		if (setScoreOutOf && gradeCandidate.maxPoints !== undefined) {
+		if (gradeCandidate.maxPoints !== undefined) {
 			this.setScoreOutOf(gradeCandidate.maxPoints.toString());
 		}
 	}

--- a/test/d2l-activity-editor/state/activity-score-grade.spec.js
+++ b/test/d2l-activity-editor/state/activity-score-grade.spec.js
@@ -185,7 +185,7 @@ describe('Activity Score Grade', function() {
 				fetchEntity.mockImplementation(() => Promise.resolve({}));
 			});
 
-			it('sets scoreOutOf because it is empty (but linked grade has not changed)', async(done) => {
+			it('sets scoreOutOf when scoreOutOf is empty', async(done) => {
 				defaultEntityMock.scoreOutOf = () => '';
 				const activity = new ActivityScoreGrade(defaultEntityMock, 'token');
 				await activity.fetchGradeCandidates();
@@ -195,7 +195,7 @@ describe('Activity Score Grade', function() {
 					done
 				);
 
-				activity.linkToExistingGrade(gradeCandidate.href);
+				activity.linkToExistingGrade();
 			});
 
 			it('links and sets scoreOutOf when coming from ungraded with create new and link selected', async(done) => {
@@ -215,7 +215,7 @@ describe('Activity Score Grade', function() {
 					})
 				);
 
-				activity.linkToExistingGrade('');
+				activity.linkToExistingGrade();
 			});
 
 			it('links and sets scoreOutOf', async(done) => {
@@ -232,7 +232,7 @@ describe('Activity Score Grade', function() {
 					})
 				);
 
-				activity.linkToExistingGrade('http://test');
+				activity.linkToExistingGrade();
 			});
 		});
 	});


### PR DESCRIPTION
The code being removed checked if the linked grade didn't change when we clicked 'OK' in the dialog, and if it didn't change, we would not change the assignment `out of` value in the input. We are removing this check so that if the user doesn't change the `link to existing grade` and click 'OK', we will still override whatever assignment `outOf` value the user has entered.