### PR TITLE
Improve Visual Diff Tests Stability

### DIFF
--- a/test/d2l-quick-eval/perceptual/d2l-quick-eval-action-dismiss-dialog.visual-diff.js
+++ b/test/d2l-quick-eval/perceptual/d2l-quick-eval-action-dismiss-dialog.visual-diff.js
@@ -29,6 +29,7 @@ describe('d2l-quick-eval-action-dismiss-dialog', function() {
 				el.open();
 			});
 		}, element);
+		await new Promise(resolve => setTimeout(resolve, 100));
 	}
 
 	async function waitForClose(element) {
@@ -59,6 +60,7 @@ describe('d2l-quick-eval-action-dismiss-dialog', function() {
 			const forever = dialog.shadowRoot.querySelector('#dismiss-action-dialog-radio-input-forever');
 			forever.click();
 		});
+		await new Promise(resolve => setTimeout(resolve, 100));
 		const rect = await visualDiff.getRect(page, '#default');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		await waitForClose('#default d2l-quick-eval-action-dismiss-dialog');
@@ -71,6 +73,7 @@ describe('d2l-quick-eval-action-dismiss-dialog', function() {
 			const specDate = dialog.shadowRoot.querySelector('#dismiss-action-dialog-radio-input-specificDate');
 			specDate.click();
 		});
+		await new Promise(resolve => setTimeout(resolve, 100));
 		const rect = await visualDiff.getRect(page, '#default');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		await waitForClose('#default d2l-quick-eval-action-dismiss-dialog');
@@ -83,6 +86,7 @@ describe('d2l-quick-eval-action-dismiss-dialog', function() {
 			const nextSub = dialog.shadowRoot.querySelector('#dismiss-action-dialog-radio-input-nextSubmission');
 			nextSub.click();
 		});
+		await new Promise(resolve => setTimeout(resolve, 100));
 		const rect = await visualDiff.getRect(page, '#default');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		await waitForClose('#default d2l-quick-eval-action-dismiss-dialog');

--- a/test/d2l-quick-eval/perceptual/d2l-quick-eval-ellipsis-dismiss-dialog.visual-diff.js
+++ b/test/d2l-quick-eval/perceptual/d2l-quick-eval-ellipsis-dismiss-dialog.visual-diff.js
@@ -35,6 +35,7 @@ describe('d2l-quick-eval-ellipsis-dialog', function() {
 				el.opened = true;
 			});
 		}, element);
+		await new Promise(resolve => setTimeout(resolve, 100));
 	}
 
 	async function waitForClose(element) {
@@ -77,6 +78,7 @@ describe('d2l-quick-eval-ellipsis-dialog', function() {
 			const item = list.shadowRoot.querySelectorAll('d2l-list-item')[1];
 			item.shadowRoot.querySelector('label').click();
 		});
+		await new Promise(resolve => setTimeout(resolve, 100));
 		const rect = await visualDiff.getRect(page, '#default');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 		await waitForClose('#default d2l-quick-eval-ellipsis-dialog');

--- a/test/d2l-quick-eval/perceptual/d2l-quick-eval-view-toggle-button.visual-diff.js
+++ b/test/d2l-quick-eval/perceptual/d2l-quick-eval-view-toggle-button.visual-diff.js
@@ -33,6 +33,7 @@ describe('d2l-quick-eval-view-toggle-button', function() {
 							await page.click(selector);
 							break;
 					}
+					await new Promise(resolve => setTimeout(resolve, 100));
 					const rect = await visualDiff.getRect(page, `#${name}`);
 					await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 				});

--- a/test/d2l-quick-eval/perceptual/utils.js
+++ b/test/d2l-quick-eval/perceptual/utils.js
@@ -1,0 +1,5 @@
+function sleep(ms) {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+module.exports = sleep;

--- a/test/d2l-quick-eval/perceptual/utils.js
+++ b/test/d2l-quick-eval/perceptual/utils.js
@@ -1,5 +1,0 @@
-function sleep(ms) {
-	return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-module.exports = sleep;


### PR DESCRIPTION
I added periods of sleep to each of the visual difference tests that were frequently failing. The reason for doing this is because the screenshots were being taken before the CSS animations were finishing, which caused the tests to frequently fail as this introduced a race condition. I am hoping this PR will allow these tests to become more stable.

Unfortunately, the `HTMLElement` API that we are using for things like `click`, `focus`, `hover` etc. does not return an obvious `Promise` that resolves when the CSS animations are complete. The next best solution was to just give a small amount of time for the CSS animations to complete before taking the screenshot.

Let me know if there are any other possible solutions to this problem to explore.