### PR TITLE
Remove unnecessary usages of boundary due to improved d2l-tooltip

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -74,11 +74,6 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeMixin(RtlMix
 	constructor() {
 		super(store);
 
-		this._tooltipBoundary = {
-			left: 20 + 12, // padding-left applied to d2l-activity-attachments-picker + padding-left of d2l-button-icon
-			right: 0
-		};
-
 		D2L.ActivityEditor = D2L.ActivityEditor || {};
 		// Referenced by the server-side ActivitiesView renderer
 		D2L.ActivityEditor.FileUploadDialogCallback = (files) => {
@@ -217,8 +212,7 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeMixin(RtlMix
 				<d2l-tooltip
 					for="add-file-button"
 					aria-hidden="true"
-					disable-focus-lock
-					.boundary="${this._tooltipBoundary}">${this.localize('addFile')}</d2l-tooltip>
+					disable-focus-lock>${this.localize('addFile')}</d2l-tooltip>
 					<!-- Important: keep tooltip content inline, otherwise screenreader gets confused -->
 				<d2l-button-icon
 					id="add-quicklink-button"
@@ -230,8 +224,7 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeMixin(RtlMix
 				<d2l-tooltip
 					for="add-quicklink-button"
 					aria-hidden="true"
-					disable-focus-lock
-					.boundary="${this._tooltipBoundary}">${this.localize('addQuicklink')}</d2l-tooltip>
+					disable-focus-lock>${this.localize('addQuicklink')}</d2l-tooltip>
 
 				<d2l-button-icon
 					id="add-link-button"
@@ -243,8 +236,7 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeMixin(RtlMix
 				<d2l-tooltip
 					for="add-link-button"
 					aria-hidden="true"
-					disable-focus-lock
-					.boundary="${this._tooltipBoundary}">${this.localize('addLink')}</d2l-tooltip>
+					disable-focus-lock>${this.localize('addLink')}</d2l-tooltip>
 
 				<d2l-button-icon
 					id="add-google-drive-link-button"
@@ -256,8 +248,7 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeMixin(RtlMix
 				<d2l-tooltip
 					for="add-google-drive-link-button"
 					aria-hidden="true"
-					disable-focus-lock
-					.boundary="${this._tooltipBoundary}">${this.localize('addGoogleDriveLink')}</d2l-tooltip>
+					disable-focus-lock>${this.localize('addGoogleDriveLink')}</d2l-tooltip>
 
 				<d2l-button-icon
 					id="add-onedrive-link-button"
@@ -269,8 +260,7 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeMixin(RtlMix
 				<d2l-tooltip
 					for="add-onedrive-link-button"
 					aria-hidden="true"
-					disable-focus-lock
-					.boundary="${this._tooltipBoundary}">${this.localize('addOneDriveLink')}</d2l-tooltip>
+					disable-focus-lock>${this.localize('addOneDriveLink')}</d2l-tooltip>
 
 				<div class="button-container-right">
 					<d2l-button-subtle

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -147,11 +147,6 @@ class ActivityScoreEditor extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mob
 
 	constructor() {
 		super(store);
-
-		this._tooltipBoundary = {
-			left: 5,
-			right: 400
-		};
 	}
 
 	updated(changedProperties) {
@@ -264,7 +259,7 @@ class ActivityScoreEditor extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mob
 							for="score-out-of"
 							position="bottom"
 							showing
-							.boundary="${this._tooltipBoundary}"
+							align="start"
 						>
 							${scoreOutOfError ? html`<span>${this.localize(scoreOutOfError)}</span>` : null}
 						</d2l-tooltip>


### PR DESCRIPTION
# Changes
1. Removed from `d2l-activity-attachments-picker` boundaries because they were originally added to prevent viewport overflow which is now handled by the tooltip.
1. Replaced `d2l-activity-score-editor` boundaries with start align because the left boundary of `5px` caused it to be left aligned anyway and the right bound of 400px will never be reached because the max width is 350px.