### PR TITLE
Added option to show activity type to cards

### DIFF
--- a/activities.serge.json
+++ b/activities.serge.json
@@ -19,6 +19,25 @@
       "zh-tw zh-tw"
     ]
   },{
+    "name": "activityCard",
+    "source_dir": "components/d2l-activity-card/lang",
+    "output_file_path": "components/d2l-activity-card/lang/%LANG%.json",
+    "output_lang_rewrite": [
+      "ar-sa ar",
+      "de-de de",
+      "es-mx es",
+      "fi-FI fi",
+      "fr-ca fr",
+      "ja-jp ja",
+      "ko-kr ko",
+      "nl-nl nl",
+      "pt-br pt",
+      "sv-se sv",
+      "tr-tr tr",
+      "zh-cn zh",
+      "zh-tw zh-tw"
+    ]
+  },{
     "name": "listItem",
     "source_dir": "components/d2l-activity-list-item/lang",
     "output_file_path": "components/d2l-activity-list-item/lang/%LANG%.json",

--- a/components/d2l-activity-card/ActivityCardLocalize.js
+++ b/components/d2l-activity-card/ActivityCardLocalize.js
@@ -1,0 +1,86 @@
+import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
+import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';
+import 'd2l-localize-behavior/d2l-localize-behavior.js';
+import {LangAr} from './build/lang/ar.js';
+import {LangDe} from './build/lang/de.js';
+import {LangEn} from './build/lang/en.js';
+import {LangEs} from './build/lang/es.js';
+import {LangFi} from './build/lang/fi.js';
+import {LangFr} from './build/lang/fr.js';
+import {LangJa} from './build/lang/ja.js';
+import {LangKo} from './build/lang/ko.js';
+import {LangNl} from './build/lang/nl.js';
+import {LangPt} from './build/lang/pt.js';
+import {LangSv} from './build/lang/sv.js';
+import {LangTr} from './build/lang/tr.js';
+import {LangZhtw} from './build/lang/zh-tw.js';
+import {LangZh} from './build/lang/zh.js';
+
+const LangImpl = (prefix, langObj, superClass) => class extends superClass {
+	constructor() {
+		super();
+		this[prefix] = langObj;
+	}
+};
+
+const LANGUAGES = ['ar', 'de', 'en', 'es', 'fi', 'fr', 'ja', 'ko', 'nl', 'pt', 'sv', 'tr', 'zh-tw', 'zh' ];
+
+/* @polymerMixin */
+const ActivityCardImpl = (superClass) => {
+	const langMixins = [
+		LangAr,
+		LangDe,
+		LangEn,
+		LangEs,
+		LangFi,
+		LangFr,
+		LangJa,
+		LangKo,
+		LangNl,
+		LangPt,
+		LangSv,
+		LangTr,
+		LangZhtw,
+		LangZh
+	];
+	let mixinLang = mixinBehaviors([D2L.PolymerBehaviors.LocalizeBehavior], superClass);
+	LANGUAGES.forEach((langPrefix, index)=> {
+		mixinLang = dedupingMixin(LangImpl.bind(null, langPrefix, langMixins[index])).call(null, mixinLang);
+	});
+
+	return class extends mixinLang {
+		constructor() {
+			super();
+			this.resources = {
+				'en': this.en,
+				'ar': this.ar,
+				'de': this.de,
+				'es': this.es,
+				'fi': this.fi,
+				'fr': this.fr,
+				'ja': this.ja,
+				'ko': this.ko,
+				'nl': this.nl,
+				'pt': this.pt,
+				'sv': this.sv,
+				'tr': this.tr,
+				'zh': this.zh,
+				'zh-tw': this.zhtw
+			};
+		}
+		static get properties() {
+			return {
+				locale: {
+					type: String,
+					value: function() {
+						return document.documentElement.lang
+							|| document.documentElement.getAttribute('data-lang-default')
+							|| 'en-us';
+					}
+				}
+			};
+		}
+	};
+};
+
+export const ActivityCardLocalize = dedupingMixin(ActivityCardImpl);

--- a/components/d2l-activity-card/build/lang/ar.js
+++ b/components/d2l-activity-card/build/lang/ar.js
@@ -1,0 +1,5 @@
+export const LangAr = {
+	'course': 'Course',
+	'learning-path': 'Learning Path'
+};
+

--- a/components/d2l-activity-card/build/lang/da-dk.js
+++ b/components/d2l-activity-card/build/lang/da-dk.js
@@ -1,0 +1,5 @@
+export const LangDadk = {
+	'course': 'Course',
+	'learning-path': 'Learning Path'
+};
+

--- a/components/d2l-activity-card/build/lang/de.js
+++ b/components/d2l-activity-card/build/lang/de.js
@@ -1,0 +1,5 @@
+export const LangDe = {
+	'course': 'Course',
+	'learning-path': 'Learning Path'
+};
+

--- a/components/d2l-activity-card/build/lang/en.js
+++ b/components/d2l-activity-card/build/lang/en.js
@@ -1,0 +1,5 @@
+export const LangEn = {
+	'course': 'Course',
+	'learning-path': 'Learning Path'
+};
+

--- a/components/d2l-activity-card/build/lang/es.js
+++ b/components/d2l-activity-card/build/lang/es.js
@@ -1,0 +1,5 @@
+export const LangEs = {
+	'course': 'Course',
+	'learning-path': 'Learning Path'
+};
+

--- a/components/d2l-activity-card/build/lang/fi.js
+++ b/components/d2l-activity-card/build/lang/fi.js
@@ -1,0 +1,5 @@
+export const LangFi = {
+	'course': 'Course',
+	'learning-path': 'Learning Path'
+};
+

--- a/components/d2l-activity-card/build/lang/fr-fr.js
+++ b/components/d2l-activity-card/build/lang/fr-fr.js
@@ -1,0 +1,5 @@
+export const LangFrfr = {
+	'course': 'Course',
+	'learning-path': 'Learning Path'
+};
+

--- a/components/d2l-activity-card/build/lang/fr.js
+++ b/components/d2l-activity-card/build/lang/fr.js
@@ -1,0 +1,5 @@
+export const LangFr = {
+	'course': 'Course',
+	'learning-path': 'Learning Path'
+};
+

--- a/components/d2l-activity-card/build/lang/ja.js
+++ b/components/d2l-activity-card/build/lang/ja.js
@@ -1,0 +1,5 @@
+export const LangJa = {
+	'course': 'Course',
+	'learning-path': 'Learning Path'
+};
+

--- a/components/d2l-activity-card/build/lang/ko.js
+++ b/components/d2l-activity-card/build/lang/ko.js
@@ -1,0 +1,5 @@
+export const LangKo = {
+	'course': 'Course',
+	'learning-path': 'Learning Path'
+};
+

--- a/components/d2l-activity-card/build/lang/nl.js
+++ b/components/d2l-activity-card/build/lang/nl.js
@@ -1,0 +1,5 @@
+export const LangNl = {
+	'course': 'Course',
+	'learning-path': 'Learning Path'
+};
+

--- a/components/d2l-activity-card/build/lang/pt.js
+++ b/components/d2l-activity-card/build/lang/pt.js
@@ -1,0 +1,5 @@
+export const LangPt = {
+	'course': 'Course',
+	'learning-path': 'Learning Path'
+};
+

--- a/components/d2l-activity-card/build/lang/sv.js
+++ b/components/d2l-activity-card/build/lang/sv.js
@@ -1,0 +1,5 @@
+export const LangSv = {
+	'course': 'Course',
+	'learning-path': 'Learning Path'
+};
+

--- a/components/d2l-activity-card/build/lang/tr.js
+++ b/components/d2l-activity-card/build/lang/tr.js
@@ -1,0 +1,5 @@
+export const LangTr = {
+	'course': 'Course',
+	'learning-path': 'Learning Path'
+};
+

--- a/components/d2l-activity-card/build/lang/zh-tw.js
+++ b/components/d2l-activity-card/build/lang/zh-tw.js
@@ -1,0 +1,5 @@
+export const LangZhtw = {
+	'course': 'Course',
+	'learning-path': 'Learning Path'
+};
+

--- a/components/d2l-activity-card/build/lang/zh.js
+++ b/components/d2l-activity-card/build/lang/zh.js
@@ -1,0 +1,5 @@
+export const LangZh = {
+	'course': 'Course',
+	'learning-path': 'Learning Path'
+};
+

--- a/components/d2l-activity-card/d2l-activity-card.js
+++ b/components/d2l-activity-card/d2l-activity-card.js
@@ -37,7 +37,6 @@ class D2lActivityCard extends ActivityCardLocalize(PolymerElement) {
 				.d2l-activity-card-content-container {
 					display: flex;
 					flex-direction: column;
-					text-align: center;
 					margin: -0.35rem 0 -0.1rem;
 					overflow-wrap: break-word; /* replaces 'word-wrap' in Firefox, Chrome, Safari */
 					overflow: hidden;
@@ -49,7 +48,7 @@ class D2lActivityCard extends ActivityCardLocalize(PolymerElement) {
 				}
 
 				.d2l-activity-card-activity-information {
-					display:inline-block;
+					display:block;
 				}
 
 				@keyframes pulsingAnimation {

--- a/components/d2l-activity-card/d2l-activity-card.js
+++ b/components/d2l-activity-card/d2l-activity-card.js
@@ -8,13 +8,15 @@ import 'd2l-organizations/components/d2l-organization-image/d2l-organization-ima
 import 'd2l-organizations/components/d2l-organization-info/d2l-organization-info.js';
 import 'd2l-organizations/components/d2l-organization-name/d2l-organization-name.js';
 import 'd2l-typography/d2l-typography.js';
+import '@brightspace-ui/core/components/icons/icon.js';
+import { classes as organizationClasses } from 'siren-sdk/src/organizations/OrganizationEntity.js';
 import SirenParse from 'siren-parser';
-
+import { ActivityCardLocalize } from './ActivityCardLocalize.js';
 /**
- * @customElement
+ * @customElements
  * @polymer
  */
-class D2lActivityCard extends PolymerElement {
+class D2lActivityCard extends ActivityCardLocalize(PolymerElement) {
 	static get template() {
 		return html`
 			<style include="d2l-typography-shared-styles">
@@ -35,6 +37,7 @@ class D2lActivityCard extends PolymerElement {
 				.d2l-activity-card-content-container {
 					display: flex;
 					flex-direction: column;
+					text-align: center;
 					margin: -0.35rem 0 -0.1rem;
 					overflow-wrap: break-word; /* replaces 'word-wrap' in Firefox, Chrome, Safari */
 					overflow: hidden;
@@ -43,6 +46,10 @@ class D2lActivityCard extends PolymerElement {
 
 				.d2l-activity-card-content-organization-info {
 					display: block;
+				}
+
+				.d2l-activity-card-activity-information {
+					display:inline-block;
 				}
 
 				@keyframes pulsingAnimation {
@@ -79,6 +86,14 @@ class D2lActivityCard extends PolymerElement {
 							show-organization-code="[[showOrganizationCode]]"
 							show-semester-name="[[showSemesterName]]"
 						></d2l-organization-info>
+
+
+						<template is="dom-if" if="[[_showActivityInformation(_organizationActivityLoaded, showActivityType)]]">
+							<div class="d2l-activity-card-activity-information">
+								<d2l-icon icon="tier1:course"></d2l-icon>
+								<span>[[localize(_organizationActivityType)]]</span>
+							</div>
+						</template>
 					</d2l-card-content-meta>
 				</div>
 			</d2l-card>
@@ -110,6 +125,10 @@ class D2lActivityCard extends PolymerElement {
 				type: Boolean,
 				value: false
 			},
+			showActivityType: {
+				type: Boolean,
+				value: false
+			},
 			_accessibilityData: {
 				type: Object,
 				value: function() { return {}; }
@@ -120,9 +139,14 @@ class D2lActivityCard extends PolymerElement {
 			_semester: String,
 			_organizationUrl: String,
 			_activityHomepage: String,
+			_organizationActivityType: String,
 			_imageLoading: {
 				type: Boolean,
 				value: true
+			},
+			_organizationActivityLoaded: {
+				type: Boolean,
+				value: false
 			},
 			sendEventOnClick: {
 				type: Boolean,
@@ -191,10 +215,33 @@ class D2lActivityCard extends PolymerElement {
 			this._actionEnroll = sirenEntity.getAction('assign');
 		}
 		this._activityHomepage = sirenEntity.hasLink(Rels.Activities.activityHomepage) && sirenEntity.getLinkByRel(Rels.Activities.activityHomepage).href;
+		this.href = sirenEntity.hasLink('self') && sirenEntity.getLinkByRel('self').href;
 		this._organizationUrl = sirenEntity.hasLink(Rels.organization) && sirenEntity.getLinkByRel(Rels.organization).href;
 
-		this.href = sirenEntity.hasLink('self') && sirenEntity.getLinkByRel('self').href;
+		if (this._organizationUrl) {
+			this._fetchEntity(this._organizationUrl)
+				.then(this._handleOrganizationResponse.bind(this));
+		}
 	}
+
+	_handleOrganizationResponse(organization) {
+		if (!organization) {
+			return;
+		}
+
+		this._organizationActivityType = organization.hasClass(organizationClasses.learningPath) ? organizationClasses.learningPath : organizationClasses.course;
+		this._organizationActivityLoaded = true;
+		this._activityTypeAccessible();
+		return Promise.resolve();
+	}
+
+	_activityTypeAccessible() {
+		if (this.showActivityType) {
+			this._accessibilityData.activityType = this._organizationActivityType;
+			this._accessibilityText = this._accessibilityDataToString(this._accessibilityData);
+		}
+	}
+
 	_onD2lOrganizationAccessible(e) {
 		if (e && e.detail && e.detail.organization) {
 			if (e.detail.organization.name) {
@@ -217,7 +264,8 @@ class D2lActivityCard extends PolymerElement {
 		const textData = [
 			accessibility.organizationName,
 			accessibility.organizationCode,
-			accessibility.semesterName
+			accessibility.semesterName,
+			accessibility.activityType,
 		];
 		return textData.filter(function(text) {
 			return text && typeof text === 'string';
@@ -251,6 +299,10 @@ class D2lActivityCard extends PolymerElement {
 			return;
 		}
 		return match[0];
+	}
+
+	_showActivityInformation(_organizationActivityLoaded, showActivityType) {
+		return _organizationActivityLoaded && showActivityType;
 	}
 }
 

--- a/components/d2l-activity-card/d2l-activity-card.js
+++ b/components/d2l-activity-card/d2l-activity-card.js
@@ -86,7 +86,6 @@ class D2lActivityCard extends ActivityCardLocalize(PolymerElement) {
 							show-semester-name="[[showSemesterName]]"
 						></d2l-organization-info>
 
-
 						<template is="dom-if" if="[[_showActivityInformation(_organizationActivityLoaded, showActivityType)]]">
 							<div class="d2l-activity-card-activity-information">
 								<d2l-icon icon="tier1:course"></d2l-icon>
@@ -222,7 +221,6 @@ class D2lActivityCard extends ActivityCardLocalize(PolymerElement) {
 				.then(this._handleOrganizationResponse.bind(this));
 		}
 	}
-
 	_handleOrganizationResponse(organization) {
 		if (!organization) {
 			return;
@@ -233,14 +231,12 @@ class D2lActivityCard extends ActivityCardLocalize(PolymerElement) {
 		this._activityTypeAccessible();
 		return Promise.resolve();
 	}
-
 	_activityTypeAccessible() {
 		if (this.showActivityType) {
 			this._accessibilityData.activityType = this._organizationActivityType;
 			this._accessibilityText = this._accessibilityDataToString(this._accessibilityData);
 		}
 	}
-
 	_onD2lOrganizationAccessible(e) {
 		if (e && e.detail && e.detail.organization) {
 			if (e.detail.organization.name) {
@@ -299,7 +295,6 @@ class D2lActivityCard extends ActivityCardLocalize(PolymerElement) {
 		}
 		return match[0];
 	}
-
 	_showActivityInformation(_organizationActivityLoaded, showActivityType) {
 		return _organizationActivityLoaded && showActivityType;
 	}

--- a/components/d2l-activity-card/d2l-activity-card.js
+++ b/components/d2l-activity-card/d2l-activity-card.js
@@ -64,7 +64,7 @@ class D2lActivityCard extends ActivityCardLocalize(PolymerElement) {
 				}
 			</style>
 
-			<d2l-card text="[[_accessibilityText]]" href$="[[_activityHomepage]]" on-click="_sendClickEvent">
+			<d2l-card align-center$=[[alignCenter]] text="[[_accessibilityText]]" href$="[[_activityHomepage]]" on-click="_sendClickEvent">
 				<div class="d2l-activity-card-header-container" slot="header">
 					<div class="d2l-activity-list-item-pulse-placeholder" hidden$="[[!_imageLoading]]"></div>
 					<d2l-organization-image
@@ -147,6 +147,10 @@ class D2lActivityCard extends ActivityCardLocalize(PolymerElement) {
 				value: false
 			},
 			sendEventOnClick: {
+				type: Boolean,
+				value: false,
+			},
+			alignCenter: {
 				type: Boolean,
 				value: false,
 			}

--- a/components/d2l-activity-card/lang/ar.json
+++ b/components/d2l-activity-card/lang/ar.json
@@ -1,0 +1,4 @@
+{
+  "course" : "Course",
+  "learning-path" : "Learning Path"
+}

--- a/components/d2l-activity-card/lang/da-dk.json
+++ b/components/d2l-activity-card/lang/da-dk.json
@@ -1,0 +1,4 @@
+{
+  "course" : "Course",
+  "learning-path" : "Learning Path"
+}

--- a/components/d2l-activity-card/lang/de.json
+++ b/components/d2l-activity-card/lang/de.json
@@ -1,0 +1,4 @@
+{
+  "course" : "Course",
+  "learning-path" : "Learning Path"
+}

--- a/components/d2l-activity-card/lang/en.json
+++ b/components/d2l-activity-card/lang/en.json
@@ -1,0 +1,4 @@
+{
+  "course" : "Course",
+  "learning-path" : "Learning Path"
+}

--- a/components/d2l-activity-card/lang/es.json
+++ b/components/d2l-activity-card/lang/es.json
@@ -1,0 +1,4 @@
+{
+  "course" : "Course",
+  "learning-path" : "Learning Path"
+}

--- a/components/d2l-activity-card/lang/fi.json
+++ b/components/d2l-activity-card/lang/fi.json
@@ -1,0 +1,4 @@
+{
+  "course" : "Course",
+  "learning-path" : "Learning Path"
+}

--- a/components/d2l-activity-card/lang/fr-fr.json
+++ b/components/d2l-activity-card/lang/fr-fr.json
@@ -1,0 +1,4 @@
+{
+  "course" : "Course",
+  "learning-path" : "Learning Path"
+}

--- a/components/d2l-activity-card/lang/fr.json
+++ b/components/d2l-activity-card/lang/fr.json
@@ -1,0 +1,4 @@
+{
+  "course" : "Course",
+  "learning-path" : "Learning Path"
+}

--- a/components/d2l-activity-card/lang/ja.json
+++ b/components/d2l-activity-card/lang/ja.json
@@ -1,0 +1,4 @@
+{
+  "course" : "Course",
+  "learning-path" : "Learning Path"
+}

--- a/components/d2l-activity-card/lang/ko.json
+++ b/components/d2l-activity-card/lang/ko.json
@@ -1,0 +1,4 @@
+{
+  "course" : "Course",
+  "learning-path" : "Learning Path"
+}

--- a/components/d2l-activity-card/lang/nl.json
+++ b/components/d2l-activity-card/lang/nl.json
@@ -1,0 +1,4 @@
+{
+  "course" : "Course",
+  "learning-path" : "Learning Path"
+}

--- a/components/d2l-activity-card/lang/pt.json
+++ b/components/d2l-activity-card/lang/pt.json
@@ -1,0 +1,4 @@
+{
+  "course" : "Course",
+  "learning-path" : "Learning Path"
+}

--- a/components/d2l-activity-card/lang/sv.json
+++ b/components/d2l-activity-card/lang/sv.json
@@ -1,0 +1,4 @@
+{
+  "course" : "Course",
+  "learning-path" : "Learning Path"
+}

--- a/components/d2l-activity-card/lang/tr.json
+++ b/components/d2l-activity-card/lang/tr.json
@@ -1,0 +1,4 @@
+{
+  "course" : "Course",
+  "learning-path" : "Learning Path"
+}

--- a/components/d2l-activity-card/lang/zh-tw.json
+++ b/components/d2l-activity-card/lang/zh-tw.json
@@ -1,0 +1,4 @@
+{
+  "course" : "Course",
+  "learning-path" : "Learning Path"
+}

--- a/components/d2l-activity-card/lang/zh.json
+++ b/components/d2l-activity-card/lang/zh.json
@@ -1,0 +1,4 @@
+{
+  "course" : "Course",
+  "learning-path" : "Learning Path"
+}

--- a/demo/d2l-activity-card/index.html
+++ b/demo/d2l-activity-card/index.html
@@ -63,6 +63,7 @@
 					></d2l-activity-card>
 					<d2l-activity-card
 					href="../data/base/activity.json"
+					align-center
 					send-event-on-click
 					token="a1"
 					show-organization-code

--- a/demo/d2l-activity-card/index.html
+++ b/demo/d2l-activity-card/index.html
@@ -28,7 +28,6 @@
 
 						d2l-activity-card {
 							--course-image-height: 100px;
-							height: 200px;
 							margin: 1rem auto;
 							width: 250px;
 						}
@@ -62,6 +61,14 @@
 						show-organization-code
 						show-semester-name
 					></d2l-activity-card>
+					<d2l-activity-card
+					href="../data/base/activity.json"
+					send-event-on-click
+					token="a1"
+					show-organization-code
+					show-semester-name
+					show-activity-type
+				></d2l-activity-card>
 				</template>
 			</demo-snippet>
 		</div>

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@adobe/lit-mobx": "0.0.3",
     "@brightspace-ui-labs/accordion": "^2.0.2",
     "@brightspace-ui-labs/edit-in-place": "^1.0.11",
-    "@brightspace-ui/core": "^1.29.5",
+    "@brightspace-ui/core": "^1.39.0",
     "@brightspace-ui/intl": "^3.0.1",
     "@d2l/d2l-attachment": "Brightspace/attachment#semver:^1",
     "@d2l/switch": "Brightspace/d2l-switch.git#semver:^3",


### PR DESCRIPTION
### Context:
This PR updates `d2l-activity-card` to have a new optional attribute called `show-activity-type`. Applying this property to a `d2l-activity-card` will have it display an icon and either `Course` or `Learning Path` below the current content, depending on the activity type of the card's entity.

This PR also adds an optional attribute `align-center` that will apply the `align-center` attribute to the inner `d2l-card` for center justification.

![image](https://user-images.githubusercontent.com/55998273/78711720-6ecd1780-78e5-11ea-8146-5b8cad821ee0.png)

Localization has been added to display the activity type in the correct language.

### Quality:
A demo was added to the `d2l-activity-card` demo page that demonstrates these features. Testing was done with NVDA to ensure that 'Course' is read iff the word Activity type 'Course' is shown. Other demos without the new attributes were reviewed to ensure that the appearance of this card in other projects will not be modified.
