### PR TITLE
US115415 Use correct outcome tags tooltip langterm via requestProvider

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -45,7 +45,8 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 				:host([hidden]) {
 					display: none;
 				}
-				:host > div {
+				:host > div,
+				d2l-activity-outcomes {
 					padding-bottom: 20px;
 				}
 				#score-and-duedate-container {
@@ -60,10 +61,6 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 				:host([dir="rtl"]) #score-container {
 					margin-right: 0;
 					margin-left: 40px;
-				}
-				d2l-activity-outcomes:not([hidden]) {
-					display: block;
-					padding-bottom: 20px;
 				}
 			`
 		];

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -51,6 +51,10 @@ class AssignmentEditor extends ActivityEditorContainerMixin(LocalizeMixin(Activi
 			*/
 			outcomesTerm: { type: String },
 			/**
+			* based on the config variable d2l.Languages.Terminology.LearningOutcomes
+			*/
+			browseOutcomesText: { type: String },
+			/**
 			* Set the WidthType on the template to constrain page width if necessary
 			*/
 			widthType: { type: String, attribute: 'width-type' }
@@ -134,6 +138,12 @@ class AssignmentEditor extends ActivityEditorContainerMixin(LocalizeMixin(Activi
 
 		if (e.detail.key === 'd2l-provider-outcomes-term') {
 			e.detail.provider = this.outcomesTerm;
+			e.stopPropagation();
+			return;
+		}
+
+		if (e.detail.key === 'd2l-provider-browse-outcomes-text') {
+			e.detail.provider = this.browseOutcomesText;
 			e.stopPropagation();
 			return;
 		}


### PR DESCRIPTION
Also switched to declarative events in the component, simplified setting up the lang terms, and simplified the styling rules for the consumer.

https://rally1.rallydev.com/#/29180338367d/detail/userstory/382763326196