### PR TITLE
when focus is on 'ungraded' button, screen reader announcement will b…

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -235,6 +235,7 @@ class ActivityScoreEditor extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mob
 			<div id="ungraded-button-container">
 				<button id="ungraded" class="d2l-input"
 					@click="${this._setGraded}"
+					aria-label="${this.localize('addAGrade')}"
 				>
 					${this.localize('ungraded')}
 				</button>

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -31,6 +31,7 @@ export default {
 	"inGrades": "In Grades", // State of the grades field when there is a score, and an associated grade item
 	"notInGrades": "Not in Grades", // State of the grades field when there is a score, but no associated grade item
 	"addToGrades": "Add to Grades", // Menu item for adding grade association
+	"addAGrade": "Add a Grade", //ARIA label to add a grade to the activity
 	"removeFromGrades": "Remove from Grades", // Menu item for removing grade association
 	"setUngraded": "Reset to Ungraded", // Menu item for setting the activity to ungraded
 	"scoreOutOf": "Score Out Of", // ARIA label for the score out of field, when creating/editing an activity


### PR DESCRIPTION
when focus is on 'ungraded' button, screen reader announcement will be 'add a grade button'
a11y FACE Trello card: https://trello.com/c/DD6GiKEb/4-face-score-out-of-field-is-labeled-as-ungraded-should-it-be-add-a-grade