### PR TITLE
No longer close the rubric create overlay when clicking dialogs

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -211,7 +211,10 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 				</d2l-dropdown-menu>
 			</d2l-dropdown-button-subtle>
 
-			<d2l-simple-overlay id="create-new-association-dialog">
+			<d2l-simple-overlay
+				id="create-new-association-dialog"
+				no-cancel-on-outside-click
+			>
 				<d2l-rubric-editor
 					href="${this._newlyCreatedPotentialAssociationHref}"
 					.token="${this.token}">


### PR DESCRIPTION
The overlay was closing when dialogs were used for rubric creation. This stops that from happening.