### PR TITLE
Set the rubric href when closing the overlay with esc

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -233,7 +233,7 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 				id="create-new-association-dialog"
 				no-cancel-on-outside-click
 				@d2l-simple-overlay-close-button-clicked="${this._clearNewRubricHref}"
-				@iron-overlay-canceled="${this._clearNewRubricHref}"
+				@d2l-simple-overlay-canceled="${this._clearNewRubricHref}"
 			>
 				${this._renderRubricEditor()}
 				<d2l-floating-buttons always-float>

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -233,6 +233,7 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 				id="create-new-association-dialog"
 				no-cancel-on-outside-click
 				@d2l-simple-overlay-close-button-clicked="${this._clearNewRubricHref}"
+				@iron-overlay-canceled="${this._clearNewRubricHref}"
 			>
 				${this._renderRubricEditor()}
 				<d2l-floating-buttons always-float>


### PR DESCRIPTION
Same setting of rubric href, just on using ESC. Follow up from Uzair's comment in last PR.