### PR TITLE
Update Travis stage names to get visual-diff bot hook working again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 - npm install
 jobs:
   include:
-  - stage: code-tests
+  - stage: Code-tests
     script:
     - npm run lint
     - |
@@ -19,14 +19,14 @@ jobs:
         npm run test:polymer:local || travis_terminate 1;
       fi
     - npm run test:js
-  - stage: visual-difference-tests
+  - stage: Visual-difference-tests
     script:
     - |
       if [ $TRAVIS_SECURE_ENV_VARS == true ]; then
         echo "Running visual difference tests...";
         npm run test:diff || travis_terminate 1;
       fi
-  - stage: update-version
+  - stage: Update-version
     script: frauci-update-version && export TRAVIS_TAG=$(frauci-get-version)
 deploy:
   provider: releases


### PR DESCRIPTION
Travis recently made a change to no longer update the case of the first letter of stage names.  Their change is behind the "enable build config validation" flag which appears to be enabled for this repo in Travis settings.  In `core` we do not have this flag enabled because it apparently causes other issues as we well, which explains why the hook still works there.

Unfortunately, currently the visual-diff bot looks for that to determine whether or not to hook into the Travis PR pipeline.  The short-term sol'n is to update the stage name to match what we expect it to be. When time permits we will update the bot to be more insensitive to the case.