### PR TITLE
US115941 Render manage competencies button and summary

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
@@ -2,10 +2,13 @@ import './d2l-activity-assignment-annotations-editor.js';
 import './d2l-activity-assignment-annotations-summary.js';
 import './d2l-activity-assignment-anonymous-marking-editor.js';
 import './d2l-activity-assignment-anonymous-marking-summary.js';
+import '../d2l-activity-competencies.js';
+import '../d2l-activity-competencies-summary.js';
 import '../d2l-activity-rubrics/d2l-activity-rubrics-list-wrapper.js';
 import '../d2l-activity-rubrics/d2l-activity-rubrics-summary-wrapper.js';
 import './d2l-assignment-turnitin-editor.js';
 import './d2l-assignment-turnitin-summary.js';
+import { ActivityEditorFeaturesMixin, Milestones } from '../mixins/d2l-activity-editor-features-mixin.js';
 
 import { bodySmallStyles, heading3Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
@@ -14,14 +17,15 @@ import { summarizerHeaderStyles, summarizerSummaryStyles } from './activity-summ
 import { getLocalizeResources } from '../localization.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 
-class ActivityAssignmentEvaluationEditor extends LocalizeMixin(LitElement) {
+class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(LocalizeMixin(LitElement)) {
 
 	static get properties() {
 
 		return {
 			href: { type: String },
 			token: { type: Object },
-			activityUsageHref: { type: String }
+			activityUsageHref: { type: String },
+			_m3enabled: { type: Boolean }
 		};
 	}
 
@@ -50,6 +54,12 @@ class ActivityAssignmentEvaluationEditor extends LocalizeMixin(LitElement) {
 	static async getLocalizeResources(langs) {
 
 		return getLocalizeResources(langs, import.meta.url);
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+
+		this._m3enabled = this._isMilestoneEnabled(Milestones.M3);
 	}
 
 	_renderAnonymousMarkingSummary() {
@@ -123,6 +133,15 @@ class ActivityAssignmentEvaluationEditor extends LocalizeMixin(LitElement) {
 		`;
 	}
 
+	_renderCompetenciesSummary() {
+		return html`
+			<d2l-activity-competencies-summary
+				href="${this.activityUsageHref}"
+				.token="${this.token}">
+			</d2l-activity-competencies-summary>
+		`;
+	}
+
 	_renderRubricsCollectionEditor() {
 		return html`
 			<d2l-activity-rubrics-list-wrapper
@@ -132,8 +151,16 @@ class ActivityAssignmentEvaluationEditor extends LocalizeMixin(LitElement) {
 		`;
 	}
 
-	render() {
+	_renderCompetenciesOpener() {
+		return html`
+			<d2l-activity-competencies
+				href="${this.activityUsageHref}"
+				.token="${this.token}">
+			</d2l-activity-competencies>
+		`;
+	}
 
+	render() {
 		return html`
 			<d2l-labs-accordion-collapse flex header-border>
 				<h3 class="d2l-heading-3 activity-summarizer-header" slot="header">
@@ -144,11 +171,13 @@ class ActivityAssignmentEvaluationEditor extends LocalizeMixin(LitElement) {
 					<li>${this._renderAnnotationsSummary()}</li>
 					<li>${this._renderTurnitinSummary()}</li>
 					<li>${this._renderRubricsSummary()}</li>
+					${this._m3enabled ? html`<li>${this._renderCompetenciesSummary()}</li>` : null}
 				</ul>
 				${this._renderRubricsCollectionEditor()}
 				${this._renderAnnotationsEditor()}
 				${this._renderAnonymousMarkingEditor()}
 				${this._renderTurnitinEditor()}
+				${this._m3enabled ? this._renderCompetenciesOpener() : null}
 			</d2l-labs-accordion-collapse>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-competencies-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-competencies-summary.js
@@ -1,0 +1,34 @@
+import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
+import { getLocalizeResources } from './localization';
+import { html } from 'lit-element/lit-element';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { MobxLitElement } from '@adobe/lit-mobx';
+import { shared as store } from '../../components/d2l-activity-editor/state/activity-store.js';
+
+class ActivityCompetenciesSummary
+	extends ActivityEditorMixin(LocalizeMixin(MobxLitElement)) {
+
+	static async getLocalizeResources(langs) {
+		return getLocalizeResources(langs, import.meta.url);
+	}
+
+	constructor() {
+		super(store);
+	}
+
+	render() {
+		const activity = store.get(this.href);
+		if (!activity || !activity.competenciesHref) {
+			return html``;
+		}
+
+		const count = activity.associatedCompetenciesCount;
+
+		return html`${this.localize('associatedCompetencies', { count })}`;
+	}
+}
+
+customElements.define(
+	'd2l-activity-competencies-summary',
+	ActivityCompetenciesSummary
+);

--- a/components/d2l-activity-editor/d2l-activity-competencies.js
+++ b/components/d2l-activity-editor/d2l-activity-competencies.js
@@ -1,0 +1,112 @@
+import '@brightspace-ui/core/components/icons/icon.js';
+import '@brightspace-ui/core/components/button/button-subtle.js';
+import { bodyCompactStyles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
+import { css, html } from 'lit-element/lit-element';
+import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
+import { getLocalizeResources } from './localization';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { MobxLitElement } from '@adobe/lit-mobx';
+import { shared as store } from '../../components/d2l-activity-editor/state/activity-store.js';
+
+class ActivityCompetencies extends ActivityEditorMixin(LocalizeMixin(MobxLitElement)) {
+
+	static get properties() {
+		return {
+			_overrides: { type: Object },
+			_isFirstLoad: { type: Boolean }
+		};
+	}
+
+	static get styles() {
+		return [
+			bodyCompactStyles,
+			labelStyles,
+			css`
+				:host {
+					display: block;
+				}
+				:host([hidden]) {
+					display: none;
+				}
+				.competencies-icon {
+					margin-inline-end: 0.6rem;
+				}
+				.competencies-count-container {
+					display: flex;
+					align-items: center;
+				}
+				.competencies-count-text {
+					font-size: 0.7rem;
+					line-height: 0.7rem;
+				}
+			`
+		];
+	}
+
+	static async getLocalizeResources(langs) {
+		return getLocalizeResources(langs, import.meta.url);
+	}
+
+	constructor() {
+		super(store);
+	}
+
+	_openManageCompetencies() {
+		const dialogUrl = store.get(this.href).competenciesDialogUrl;
+
+		if (!dialogUrl) {
+			return;
+		}
+
+		// TODO: Open competencies dialog etc
+	}
+
+	_renderDialogOpener(dialogUrl) {
+		if (!dialogUrl) {
+			return html``;
+		}
+
+		return html`
+			<d2l-button-subtle
+				text="${this.localize('manageCompetencies')}"
+				h-align="text"
+				@click="${this._openManageCompetencies}">
+			</d2l-button-subtle>
+		`;
+	}
+
+	_renderCountText(count) {
+		const langTerm = this.localize('associatedCompetencies', { count });
+
+		if (count === 0) {
+			return html`<div class="d2l-body-compact">${langTerm}</div>`;
+		}
+
+		return html`
+			<d2l-icon class="competencies-icon" icon="tier1:user-competencies"></d2l-icon>
+			<div class="competencies-count-text">${langTerm}</div>
+		`;
+	}
+
+	render() {
+		const activity = store.get(this.href);
+		if (!activity || !activity.competenciesHref) {
+			return html``;
+		}
+
+		const {
+			associatedCompetenciesCount: count,
+			competenciesDialogUrl: dialogUrl
+		} = activity;
+
+		return html`
+			<label class="d2l-label-text">${this.localize('competencies')}</label>
+			<div class="competencies-count-container">
+				${this._renderCountText(count)}
+			</div>
+			${this._renderDialogOpener(dialogUrl)}
+		`;
+	}
+
+}
+customElements.define('d2l-activity-competencies', ActivityCompetencies);

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -51,5 +51,8 @@ export default {
 	"linkToExistingGradeItem": "Link to an existing grade item", //Radio button text
 	"points": "Points: {points}", // Text label for displaying points of a grade
 	"noGradeItems": "No existing grade items", // Reason why existing grade items cannot be linked in the choose grades dialog
-	"noGradeCreatePermission": "You do not have permission to create a new grade item" // Reason why a new grade items cannot be created in the choose grades dialog
+	"noGradeCreatePermission": "You do not have permission to create a new grade item", // Reason why a new grade items cannot be created in the choose grades dialog
+	"competencies": "Learning Objectives", //Text label for the competencies tool integration
+	"manageCompetencies": "Manage Learning Objectives", //Button text to launch competencies tool dialog
+	"associatedCompetencies": "{count, plural, =0 {No Associated Learning Objectives} =1 {1 Associated Learning Objective} other {{count} Associated Learning Objectives}}" //Label for number of associated competencies
 };

--- a/test/d2l-activity-editor/state/activity-usage.spec.js
+++ b/test/d2l-activity-editor/state/activity-usage.spec.js
@@ -1,6 +1,7 @@
 import { ActivityUsage} from '../../../components/d2l-activity-editor/state/activity-usage.js';
 import { ActivityUsageEntity } from 'siren-sdk/src/activities/ActivityUsageEntity.js';
 import { AlignmentsCollectionEntity } from 'siren-sdk/src/alignments/AlignmentsCollectionEntity.js';
+import { CompetenciesEntity } from 'siren-sdk/src/competencies/CompetenciesEntity.js';
 import { expect } from 'chai';
 import { fetchEntity } from '../../../components/d2l-activity-editor/state/fetch-entity.js';
 import sinon from 'sinon';
@@ -8,32 +9,43 @@ import { when } from 'mobx';
 
 jest.mock('siren-sdk/src/activities/ActivityUsageEntity.js');
 jest.mock('siren-sdk/src/alignments/AlignmentsCollectionEntity.js');
+jest.mock('siren-sdk/src/competencies/CompetenciesEntity.js');
 jest.mock('../../../components/d2l-activity-editor/state/fetch-entity.js');
 
 describe('Activity Usage', function() {
 
-	const defaultEntityMock = {
-		startDate: () => '2020-01-22T04:59:00.000Z',
-		dueDate: () => '2020-01-23T04:59:00.000Z',
-		endDate: () => '2020-01-24T04:59:00.000Z',
-		canEditDates: () => true,
-		isDraft: () => true,
-		canEditDraft: () => true,
-		scoreOutOf: () => 10,
-		inGrades: () => true,
-		gradeType: () => 'Points',
-		canEditScoreOutOf: () => true,
-		canSeeGrades: () => true,
-		canEditGrades: () => true,
-		gradeHref: () => '',
-		associatedGrade: () => undefined,
-		gradeCandidatesHref: () => '',
-		conditionsHref: () => undefined,
-		getRubricAssociationsHref: () => undefined,
-		newGradeCandidatesHref: () => undefined,
-		isNewGradeCandidate: () => false,
-		alignmentsHref: () => 'http://alignments-href/'
-	};
+	function defaultEntityMock(useCompetencies) {
+		const alignmentsHref = useCompetencies ? null : 'http://alignments-href/';
+		const competenciesHref = useCompetencies ? 'http://competencies-href/' : null;
+		const associatedCompetenciesCount = useCompetencies ? 13 : null;
+		const competenciesDialogUrl = useCompetencies ? 'http://competencies-dialog-href/' : null;
+
+		return {
+			startDate: () => '2020-01-22T04:59:00.000Z',
+			dueDate: () => '2020-01-23T04:59:00.000Z',
+			endDate: () => '2020-01-24T04:59:00.000Z',
+			canEditDates: () => true,
+			isDraft: () => true,
+			canEditDraft: () => true,
+			scoreOutOf: () => 10,
+			inGrades: () => true,
+			gradeType: () => 'Points',
+			canEditScoreOutOf: () => true,
+			canSeeGrades: () => true,
+			canEditGrades: () => true,
+			gradeHref: () => '',
+			associatedGrade: () => undefined,
+			gradeCandidatesHref: () => '',
+			conditionsHref: () => undefined,
+			getRubricAssociationsHref: () => undefined,
+			newGradeCandidatesHref: () => undefined,
+			isNewGradeCandidate: () => false,
+			alignmentsHref: () => alignmentsHref,
+			competenciesHref: () => competenciesHref,
+			associatedCompetenciesCount: () => associatedCompetenciesCount,
+			competenciesDialogUrl: () => competenciesDialogUrl
+		};
+	}
 
 	afterEach(() => {
 		sinon.restore();
@@ -49,7 +61,7 @@ describe('Activity Usage', function() {
 			sirenEntity = sinon.stub();
 
 			ActivityUsageEntity.mockImplementation(() => {
-				return defaultEntityMock;
+				return defaultEntityMock();
 			});
 
 			AlignmentsCollectionEntity.mockImplementation(() => {
@@ -59,10 +71,17 @@ describe('Activity Usage', function() {
 				};
 			});
 
+			CompetenciesEntity.mockImplementation(() => {
+				return {
+					dialogUrl: () => 'http://competencies-dialog-href/',
+					associatedCount: () => 13
+				};
+			});
+
 			fetchEntity.mockImplementation(() => Promise.resolve(sirenEntity));
 		});
 
-		it('fetches', async() => {
+		it('fetches with alignments (learning outcomes)', async() => {
 			const activity = new ActivityUsage('http://1', 'token');
 			await activity.fetch();
 
@@ -71,10 +90,37 @@ describe('Activity Usage', function() {
 			expect(activity.canUpdateAlignments).to.be.true;
 			expect(activity.alignmentsHref).to.equal('http://alignments-href/');
 			expect(activity.hasAlignments).to.be.false;
+			expect(activity.competenciesHref).to.be.null;
+			expect(activity.associatedCompetenciesCount).to.be.null;
+			expect(activity.competenciesDialogUrl).to.be.null;
 
 			expect(fetchEntity.mock.calls.length).to.equal(2);
 			expect(fetchEntity.mock.calls[0][0]).to.equal('http://1');
 			expect(fetchEntity.mock.calls[1][0]).to.equal('http://alignments-href/');
+			expect(ActivityUsageEntity.mock.calls[0][0]).to.equal(sirenEntity);
+			expect(ActivityUsageEntity.mock.calls[0][1]).to.equal('token');
+		});
+
+		it('fetches with competencies', async() => {
+			ActivityUsageEntity.mockImplementation(() => {
+				return defaultEntityMock(true);
+			});
+
+			const activity = new ActivityUsage('http://1', 'token');
+			await activity.fetch();
+
+			expect(activity.isDraft).to.be.true;
+			expect(activity.canEditDraft).to.be.true;
+			expect(activity.canUpdateAlignments).to.be.false;
+			expect(activity.alignmentsHref).to.be.null;
+			expect(activity.hasAlignments).to.be.false;
+			expect(activity.competenciesHref).to.equal('http://competencies-href/');
+			expect(activity.associatedCompetenciesCount).to.equal(13);
+			expect(activity.competenciesDialogUrl).to.equal('http://competencies-dialog-href/');
+
+			expect(fetchEntity.mock.calls.length).to.equal(2);
+			expect(fetchEntity.mock.calls[0][0]).to.equal('http://1');
+			expect(fetchEntity.mock.calls[1][0]).to.equal('http://competencies-href/');
 			expect(ActivityUsageEntity.mock.calls[0][0]).to.equal(sirenEntity);
 			expect(ActivityUsageEntity.mock.calls[0][1]).to.equal('token');
 		});
@@ -85,7 +131,7 @@ describe('Activity Usage', function() {
 			sirenEntity = sinon.stub();
 
 			ActivityUsageEntity.mockImplementation(() => {
-				return defaultEntityMock;
+				return defaultEntityMock();
 			});
 
 			fetchEntity.mockImplementation(() => sirenEntity);
@@ -112,7 +158,7 @@ describe('Activity Usage', function() {
 		beforeEach(() => {
 			sirenEntity = sinon.stub();
 
-			ActivityUsageEntity.mockImplementation(() => Object.assign({}, defaultEntityMock,	{
+			ActivityUsageEntity.mockImplementation(() => Object.assign({}, defaultEntityMock(),	{
 				save
 			}));
 


### PR DESCRIPTION
Adds a "Manage Learning Objectives" button (and supporting summary components) as part of the "Evaluation & Feedback" accordion when legacy competencies are available (as determined by the API).

Relies on siren-sdk changes https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/185
Flagged behind FACE milestone M3.