### PR TITLE
Fix activity-usage mobx loading of competencies vs outcomes

### DIFF
--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -39,6 +39,11 @@ export class ActivityUsage {
 		this.canUpdateAlignments = false;
 		this.hasAlignments = false;
 
+		/** Legacy Competencies */
+		this.competenciesHref = this.alignmentsHref ? null : entity.competenciesHref();
+		this.associatedCompetenciesCount = null;
+		this.competenciesDialogUrl = null;
+
 		if (this.alignmentsHref) {
 			const alignmentsEntity = await fetchEntity(this.alignmentsHref, this.token);
 
@@ -47,14 +52,7 @@ export class ActivityUsage {
 				this.canUpdateAlignments = alignmentsCollection.canUpdateAlignments();
 				this.hasAlignments = alignmentsCollection.getAlignments().length > 0;
 			});
-		}
-
-		/** Legacy Competencies */
-		this.competenciesHref = this.alignmentsHref ? null : entity.competenciesHref();
-		this.associatedCompetenciesCount = null;
-		this.competenciesDialogUrl = null;
-
-		if (this.competenciesHref) {
+		} else if (this.competenciesHref) {
 			const competenciesSirenEntity = await fetchEntity(this.competenciesHref, this.token);
 
 			runInAction(() => {


### PR DESCRIPTION
Sync props were being set after an `await` outside of a `runInAction`, thus being set outside of an action and throwing an error. This sets up all sync props ahead of time, and then only runs one _or_ the other async workflow to avoid wrapping large code blocks in `runInAction`.