### PR TITLE
DE38866: announcing "rubric added" and "rubric removed" for screenrea…

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -6,6 +6,7 @@ import 'd2l-rubric/editor/d2l-rubric-editor.js';
 import 'd2l-simple-overlay/d2l-simple-overlay.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
+import { announce } from '@brightspace-ui/core/helpers/announce.js';
 import { Association } from 'siren-sdk/src/activities/Association.js';
 import { getLocalizeResources } from '../localization.js';
 import { heading4Styles } from '@brightspace-ui/core/components/typography/styles.js';
@@ -81,6 +82,7 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 		const entity = store.get(this.href);
 		if (e && e.detail && e.detail.associations) {
 			entity.addAssociations(e.detail.associations);
+			announce(this.localize('txtRubricAdded'));
 		}
 		this._toggleDialog(false);
 	}
@@ -105,9 +107,8 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 			return;
 		}
 		entity.addAssociations([this._newlyCreatedPotentialAssociation]);
-
 		this._closeEditNewAssociationOverlay();
-
+		announce(this.localize('txtRubricAdded'));
 	}
 
 	async _createNewAssociation() {

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
@@ -3,6 +3,7 @@ import '@brightspace-ui/core/components/dialog/dialog';
 import '@brightspace-ui/core/components/dialog/dialog-confirm';
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
+import { announce } from '@brightspace-ui/core/helpers/announce.js';
 import { getLocalizeResources } from '../localization.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
@@ -53,8 +54,8 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeMixin(RtlMix
 		if (!entity) {
 			return;
 		}
-
 		entity.deleteAssociation(e.target.dataset.id);
+		announce(this.localize('txtRubricRemoved'));
 	}
 
 	async save() {

--- a/components/d2l-activity-editor/d2l-activity-rubrics/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/lang/en.js
@@ -11,5 +11,7 @@ export default {
 	"txtNoRubricAdded": "No rubric added", // rubric summary for no rubrics
 	"txtRubricsAdded": "{count, plural, =1 {1 rubric added} other {{count} rubrics added}}", // count of asoociated rubrics
 	"txtOpenRubricPreview": "Open Rubrics preview dialog", //Text for opening rubric preview dialog
-	"txtDeleteRubric": "Delete Rubric" // Text for deleting rubric icon
+	"txtDeleteRubric": "Delete Rubric", // Text for deleting rubric icon
+	"txtRubricAdded": "Rubric added", // Text for notifying screenreader rubric was added
+	"txtRubricRemoved": "Rubric removed" // Text for notifying screenreader rubric was removed 
 };

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "wct-mocha": "^1.0.1",
     "whatwg-fetch": "^3.0.0"
   },
-  "version": "3.52.167",
+  "version": "3.52.168",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",


### PR DESCRIPTION
[DE38866](https://rally1.rallydev.com/#/110294864140d/detail/defect/388169402680)

Tl;dr: this is better than we had before, but not perfect.  It works well with NVDA + FF, and mostly works OK with other combos. I wasn't able to test with VO yet, and wasn't able to get my local to load in Edge to try that out.  

I submitted a bug for the weird announce accumulating message thing: https://github.com/BrightspaceUI/core/issues/526.  Allan mentioned he *might* have a fix in the works, and it *might* make it better, but no guarantee on timelines or whether it causes worse regressions than what it fixes.

After chatting with Joseph, it seems this is probably an edge case anyway since most times there will only be 1 rubric for an assignment, and even if there are multiple, the user would have to be doing subsequent rubric adds/deletes within 10 seconds of each other.  