### PR TITLE
Fix undefined load errors: Set secondary href on component as prop

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-secondary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-secondary.js
@@ -93,7 +93,7 @@ class AssignmentEditorSecondary extends ActivityEditorFeaturesMixin(RtlMixin(Ent
 			<d2l-activity-assignment-evaluation-editor
 				href="${this.href}"
 				.token="${this.token}"
-				activityUsageHref=${this._activityUsageHref}>
+				.activityUsageHref=${this._activityUsageHref}>
 			</d2l-activity-assignment-evaluation-editor>
 		`;
 


### PR DESCRIPTION
Safari and legacy Edge were throwing 500 errors when trying to load the sub-components of `d2l-activity-assignment-evaluation-editor` that relied on the `activityUsageHref`. It is `undefined` when passed as an attribute, causing the sub-components to try and fetch the activity on the route `activity/edit/undefined`.