### PR TITLE
Fixing visibility editor in Edge

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-visibility-auto-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-visibility-auto-editor.js
@@ -45,8 +45,8 @@ class ActivityVisibilityAutoEditor extends SaveStatusMixin(EntityMixinLit(LitEle
 		return html`
 			<d2l-activity-visibility-editor-toggle
 				?disabled="${this.disabled}"
-				?isDraft="${this._isDraft}"
-				?canEditDraft="${this._canEditDraft}"
+				?is-draft="${this._isDraft}"
+				?can-edit-draft="${this._canEditDraft}"
 				@click="${this._updateVisibility}"
 			>
 			</d2l-activity-visibility-editor-toggle>

--- a/components/d2l-activity-editor/d2l-activity-visibility-editor-toggle.js
+++ b/components/d2l-activity-editor/d2l-activity-visibility-editor-toggle.js
@@ -10,8 +10,8 @@ class ActivityVisibilityEditorToggle extends LocalizeMixin(LitElement) {
 	static get properties() {
 		return {
 			disabled: { type: Boolean },
-			isDraft: { type: Boolean },
-			canEditDraft: { type: Boolean }
+			isDraft: { type: Boolean, attribute: 'is-draft' },
+			canEditDraft: { type: Boolean, attribute: 'can-edit-draft' }
 		};
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-visibility-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-visibility-editor.js
@@ -39,8 +39,8 @@ class ActivityVisibilityEditor extends (ActivityEditorMixin(MobxLitElement)) {
 		return html`
 			<d2l-activity-visibility-editor-toggle
 				?disabled="${this.disabled}"
-				?isDraft="${isDraft}"
-				?canEditDraft="${canEditDraft}"
+				?is-draft="${isDraft}"
+				?can-edit-draft="${canEditDraft}"
 				@click="${this._updateVisibility}"
 			>
 			</d2l-activity-visibility-editor-toggle>

--- a/test/d2l-activity-editor/d2l-activity-visibility-editor.js
+++ b/test/d2l-activity-editor/d2l-activity-visibility-editor.js
@@ -11,7 +11,7 @@ describe('d2l-activity-visibility-editor-toggle', function() {
 
 		beforeEach(async() => {
 			el = await fixture(html`
-				<d2l-activity-visibility-editor-toggle canEditDraft isDraft></d2l-activity-visibility-editor-toggle>
+				<d2l-activity-visibility-editor-toggle can-edit-draft is-draft></d2l-activity-visibility-editor-toggle>
 			`);
 		});
 
@@ -27,7 +27,7 @@ describe('d2l-activity-visibility-editor-toggle', function() {
 	describe('disabled', () => {
 		beforeEach(async() => {
 			el = await fixture(html`
-				<d2l-activity-visibility-editor-toggle isDraft></d2l-activity-visibility-editor-toggle>
+				<d2l-activity-visibility-editor-toggle is-draft></d2l-activity-visibility-editor-toggle>
 			`);
 		});
 
@@ -69,8 +69,8 @@ describe('d2l-activity-visibility-editor', function() {
 
 	describe('enabled draft', () => {
 		it('renders toggle with correct attributes', async() => {
-			expect(toggle).to.have.attr('canEditDraft');
-			expect(toggle).to.have.attr('isDraft');
+			expect(toggle).to.have.attr('can-edit-draft');
+			expect(toggle).to.have.attr('is-draft');
 		});
 	});
 
@@ -82,8 +82,8 @@ describe('d2l-activity-visibility-editor', function() {
 		});
 
 		it('renders toggle with correct attributes', async() => {
-			expect(toggle).to.not.have.attr('canEditDraft');
-			expect(toggle).to.not.have.attr('isDraft');
+			expect(toggle).to.not.have.attr('can-edit-draft');
+			expect(toggle).to.not.have.attr('is-draft');
 		});
 	});
 });

--- a/test/d2l-activity-editor/d2l-activity-visibility-editor.js
+++ b/test/d2l-activity-editor/d2l-activity-visibility-editor.js
@@ -11,7 +11,7 @@ describe('d2l-activity-visibility-editor-toggle', function() {
 
 		beforeEach(async() => {
 			el = await fixture(html`
-				<d2l-activity-visibility-editor-toggle can-edit-draft is-draft></d2l-activity-visibility-editor-toggle>
+				<d2l-activity-visibility-editor-toggle canEditDraft isDraft></d2l-activity-visibility-editor-toggle>
 			`);
 		});
 
@@ -27,7 +27,7 @@ describe('d2l-activity-visibility-editor-toggle', function() {
 	describe('disabled', () => {
 		beforeEach(async() => {
 			el = await fixture(html`
-				<d2l-activity-visibility-editor-toggle is-draft></d2l-activity-visibility-editor-toggle>
+				<d2l-activity-visibility-editor-toggle isDraft></d2l-activity-visibility-editor-toggle>
 			`);
 		});
 
@@ -69,8 +69,8 @@ describe('d2l-activity-visibility-editor', function() {
 
 	describe('enabled draft', () => {
 		it('renders toggle with correct attributes', async() => {
-			expect(toggle).to.have.attr('can-edit-draft');
-			expect(toggle).to.have.attr('is-draft');
+			expect(toggle).to.have.attr('canEditDraft');
+			expect(toggle).to.have.attr('isDraft');
 		});
 	});
 
@@ -82,8 +82,8 @@ describe('d2l-activity-visibility-editor', function() {
 		});
 
 		it('renders toggle with correct attributes', async() => {
-			expect(toggle).to.not.have.attr('can-edit-draft');
-			expect(toggle).to.not.have.attr('is-draft');
+			expect(toggle).to.not.have.attr('canEditDraft');
+			expect(toggle).to.not.have.attr('isDraft');
 		});
 	});
 });


### PR DESCRIPTION
**Context**
[DE38928](https://rally1.rallydev.com/#/detail/defect/389129634532?fdp=true)

Fixes a bug that prevents Edge users from toggling visibility for any activity, including activity collections and assignments.

**Before (Edge only)**
![Screen Shot 2020-05-07 at 11 04 26 AM](https://user-images.githubusercontent.com/2412740/81321697-ec10b700-9060-11ea-89a4-ba6995d91f3b.png)
**After**
![Screen Shot 2020-05-07 at 10 54 27 AM](https://user-images.githubusercontent.com/2412740/81321726-f5018880-9060-11ea-9115-09a287ce1342.png)

**Quality**
- [x] Manually tested with `acitivity-collection-editor` and `activity-assignment-editor` demo pages in Legacy Edge, Safari, Chrome
- [x] Manually tested with local built BSI and LE instance
- Existing tests for visibility editor altered