### PR TITLE
US115948 Refresh competencies summary info on competencies dialog close

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-competencies.js
+++ b/components/d2l-activity-editor/d2l-activity-competencies.js
@@ -73,7 +73,7 @@ class ActivityCompetencies extends ActivityEditorMixin(LocalizeMixin(MobxLitElem
 		];
 
 		// Launch into our "friend", the LMS, to do the thing.
-		D2L.LP.Web.UI.Legacy.MasterPages.Dialog.Open(
+		const delayedResult = D2L.LP.Web.UI.Legacy.MasterPages.Dialog.Open(
 			/*               opener: */ document.body,
 			/*             location: */ location,
 			/*          srcCallback: */ 'SrcCallback',
@@ -85,6 +85,10 @@ class ActivityCompetencies extends ActivityEditorMixin(LocalizeMixin(MobxLitElem
 			/*              buttons: */ buttons,
 			/* forceTriggerOnCancel: */ false
 		);
+
+		delayedResult.AddListener(() => {
+			store.get(this.href).loadCompetencies(true);
+		});
 	}
 
 	_renderDialogOpener(dialogUrl) {

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -52,14 +52,7 @@ export class ActivityUsage {
 		this.hasAlignments = false;
 
 		if (this.competenciesHref) {
-			const competenciesSirenEntity = await fetchEntity(this.competenciesHref, this.token);
-
-			runInAction(() => {
-				const competenciesEntity = new CompetenciesEntity(competenciesSirenEntity);
-				this.competenciesDialogUrl = competenciesEntity.dialogUrl();
-				this.associatedCompetenciesCount = competenciesEntity.associatedCount() || 0;
-				this.unevaluatedCompetenciesCount = competenciesEntity.unevaluatedCount() || 0;
-			});
+			await this.loadCompetencies();
 		} else if (this.alignmentsHref) {
 			const alignmentsEntity = await fetchEntity(this.alignmentsHref, this.token);
 
@@ -69,6 +62,21 @@ export class ActivityUsage {
 				this.hasAlignments = alignmentsCollection.getAlignments().length > 0;
 			});
 		}
+	}
+
+	async loadCompetencies(bypassCache) {
+		if (!this.competenciesHref) {
+			return;
+		}
+
+		const sirenEntity = await fetchEntity(this.competenciesHref, this.token, bypassCache);
+
+		runInAction(() => {
+			const entity = new CompetenciesEntity(sirenEntity);
+			this.competenciesDialogUrl = entity.dialogUrl();
+			this.associatedCompetenciesCount = entity.associatedCount() || 0;
+			this.unevaluatedCompetenciesCount = entity.unevaluatedCount() || 0;
+		})
 	}
 
 	setAlignmentsHref(value) {
@@ -199,5 +207,6 @@ decorate(ActivityUsage, {
 	setDates: action,
 	setAlignmentsHref: action,
 	setCanUpdateAlignments: action,
-	setHasAlignments: action
+	setHasAlignments: action,
+	loadCompetencies: action
 });

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -76,7 +76,7 @@ export class ActivityUsage {
 			this.competenciesDialogUrl = entity.dialogUrl();
 			this.associatedCompetenciesCount = entity.associatedCount() || 0;
 			this.unevaluatedCompetenciesCount = entity.unevaluatedCount() || 0;
-		})
+		});
 	}
 
 	setAlignmentsHref(value) {

--- a/components/d2l-activity-editor/state/fetch-entity.js
+++ b/components/d2l-activity-editor/state/fetch-entity.js
@@ -1,7 +1,10 @@
-export async function fetchEntity(href, token) {
-	let entity = await window.D2L.Siren.EntityStore.get(href, token);
+export async function fetchEntity(href, token, bypassCache) {
+	let entity;
+	if (!bypassCache) {
+		entity = await window.D2L.Siren.EntityStore.get(href, token);
+	}
 	if (!entity) {
-		const fetched = await window.D2L.Siren.EntityStore.fetch(href, token);
+		const fetched = await window.D2L.Siren.EntityStore.fetch(href, token, bypassCache);
 		if (!fetched || !fetched.entity) {
 			return;
 		}


### PR DESCRIPTION
Reloads the competencies entity when the competencies dialog closes. This requires forcing the fetch to bypass the entity store and cache, else it will not actually refetch. To that end I added the `bypassCache` option to the `fetchEntity` helper, which passes it on to the `EntityStore.fetch`.