### PR TITLE
Prevent undefined href from being coerced into a string

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
@@ -144,7 +144,7 @@ class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(Loc
 	_renderRubricsCollectionEditor() {
 		return html`
 			<d2l-activity-rubrics-list-wrapper
-				href="${this.activityUsageHref}"
+				.href="${this.activityUsageHref}"
 				.token="${this.token}">
 			</d2l-activity-rubrics-list-wrapper>
 		`;

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -260,7 +260,7 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 			>
 				<d2l-add-associations
 					.token="${this.token}"
-					href="${this.activityUsageHref}"
+					.href="${this.activityUsageHref}"
 					type="rubrics"
 					skipSave
 				></d2l-add-associations>

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-wrapper.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-wrapper.js
@@ -26,7 +26,7 @@ class ActivityRubricsListWrapper
 			<d2l-activity-rubrics-list-container
 				href="${entity.associationsHref}"
 				.token="${this.token}"
-				activityUsageHref=${this.href}>
+				.activityUsageHref=${this.href}>
 			</d2l-activity-rubrics-list-container>
 		`;
 	}


### PR DESCRIPTION
Fixes the issue in attaching existing rubrics in Edge where an `undefined` href was being coerced into the string `undefined` which then caused the request to go 💥 