### PR TITLE
Hide due date label when no permissions

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -211,7 +211,6 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 				</div>
 
 				<div id="duedate-container">
-					<label class="d2l-label-text">${this.localize('dueDate')}</label>
 					<d2l-activity-due-date-editor
 						href="${activityUsageHref}"
 						.token="${this.token}">

--- a/components/d2l-activity-editor/d2l-activity-due-date-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-due-date-editor.js
@@ -1,4 +1,5 @@
 import 'd2l-datetime-picker/d2l-datetime-picker';
+import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
 import { getLocalizeResources } from './localization';
@@ -16,14 +17,14 @@ class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeMixin(MobxLitEle
 	}
 
 	static get styles() {
-		return css`
+		return [labelStyles, css`
 			:host {
 				display: block;
 			}
 			:host([hidden]) {
 				display: none;
 			}
-		`;
+		`];
 	}
 
 	static async getLocalizeResources(langs) {
@@ -91,6 +92,7 @@ class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeMixin(MobxLitEle
 		}
 
 		return html`
+			<label class="d2l-label-text" ?hidden="${!canEditDates}">${this.localize('dueDate')}</label>
 			${this.dateTemplate(dueDate, canEditDates, errorTerm)}
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-due-date-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-due-date-editor.js
@@ -1,8 +1,8 @@
 import 'd2l-datetime-picker/d2l-datetime-picker';
-import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
 import { getLocalizeResources } from './localization';
+import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { shared as store } from './state/activity-store.js';


### PR DESCRIPTION
Moved the label into component so it can be hidden along with the date picker.