### PR TITLE
Added dependabot config file

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,7 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    default_assignees:
+      - pureooze
+    directory: "/"
+    update_schedule: "daily"


### PR DESCRIPTION
To make visibility better, and easier to update the config settings I want to move the dependabot config into this repo, rather than relying on the dependabot UI. This will hopefully also make it easier to keep settings consistent between repos.

This is something similar to what we do in the lms https://github.com/Brightspace/lms/blob/master/.dependabot/config.yml