### PR TITLE
DE39197 - get completionTypeValue from siren-sdk

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -92,8 +92,7 @@ export class Assignment {
 		this.canEditSubmissionType = entity.canEditSubmissionType();
 		this.canEditCompletionType = entity.canEditCompletionType();
 		this.submissionType = String(entity.submissionType().value);
-		const completionType = entity.completionType();
-		this.completionType = completionType ? String(completionType.value) : String(0);
+		this.completionType = entity.completionTypeValue();
 
 		this.canEditSubmissionsRule = entity.canEditSubmissionsRule();
 		this.submissionsRule = entity.submissionsRule() || 'keepall';
@@ -113,6 +112,7 @@ export class Assignment {
 		if (entity.canEditCompletionType()) {
 			this.completionTypeOptions =  this._getCompletionTypeOptions(validCompletionTypes);
 		} else {
+			const completionType = entity.completionType();
 			this.completionTypeOptions = completionType ? [completionType] : [];
 		}
 

--- a/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
@@ -72,6 +72,7 @@ describe('Assignment ', function() {
 				filesSubmissionLimit: () => 'unlimited',
 				submissionType: () => { return {title: 'On paper submission', value: 2}; },
 				completionType: () => { return {title: 'Manually by learners', value: 2}; },
+				completionTypeValue: () => { return '2'; },
 				isGroupAssignmentTypeDisabled: () => false,
 				isIndividualAssignmentType: () => true,
 				getAssignmentTypeGroupCategoryOptions: () => [],


### PR DESCRIPTION
Because the dirty/equals check sits in siren-sdk, it doesn't know that we are substituting an undefined completionType value with String(0) in activities, so the dirty check always fails. Instead, let's add a get `completionTypeValue` function to siren-sdk that can be used by both activities and the siren-sdk dirty/equals check.