### PR TITLE
DE39243 Fix orgUnitId resolution for embedded iframes in HTML editor

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-html-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-editor.js
@@ -153,7 +153,7 @@ class ActivityHtmlEditor extends LocalizeMixin(LitElement) {
 				max-rows="1000"
 				fullpage-enabled="0"
 				toolbar="bold italic underline numlist bullist d2l_isf"
-				plugins="lists paste d2l_isf">
+				plugins="lists paste d2l_isf d2l_replacestring">
 
 				<div id="toolbar-shortcut-${this._htmlEditorUniqueId}" hidden="">${this.localize('ariaToolbarShortcutInstructions')}</div>
 				<div


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/detail/task/394082462304

Fixes `ou={orgUnitId}` query params in the `src` of iframes (added via html editor embed) not resolving by including the `d2l_replacestring` plugin.