### PR TITLE
US116718 Use new direct-associations href to only get direct-associated rubrics

### DIFF
--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -32,7 +32,7 @@ export class ActivityUsage {
 		this.isError = false;
 		this.dates = new ActivityDates(entity);
 		this.scoreAndGrade = new ActivityScoreGrade(entity, this.token);
-		this.associationsHref = entity.getRubricAssociationsHref();
+		this.associationsHref = entity.getDirectRubricAssociationsHref();
 
 		/**
 		 * Legacy Competencies

--- a/test/d2l-activity-editor/state/activity-usage.spec.js
+++ b/test/d2l-activity-editor/state/activity-usage.spec.js
@@ -38,7 +38,7 @@ describe('Activity Usage', function() {
 			associatedGrade: () => undefined,
 			gradeCandidatesHref: () => '',
 			conditionsHref: () => undefined,
-			getRubricAssociationsHref: () => undefined,
+			getDirectRubricAssociationsHref: () => undefined,
 			newGradeCandidatesHref: () => undefined,
 			isNewGradeCandidate: () => false,
 			alignmentsHref: () => alignmentsHref,


### PR DESCRIPTION
Ensure FACE only displays directly associated rubrics, excluding those associated via Learning Objectives, by using the new `direct-associations` href.

Relies on:
https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/192
https://git.dev.d2l/projects/CORE/repos/lms/pull-requests/11835/overview

https://rally1.rallydev.com/#/29180338367d/detail/userstory/391870800084