### PR TITLE
Clean up save-status component listeners

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -97,20 +97,6 @@ class AssignmentEditor extends ActivityEditorContainerMixin(LocalizeMixin(Activi
 		this.telemetryId = 'assignments';
 	}
 
-	firstUpdated(changedProperties) {
-		super.firstUpdated(changedProperties);
-
-		this.addEventListener('d2l-siren-entity-save-start', () => {
-			this.shadowRoot.querySelector('#save-status').start();
-		});
-		this.addEventListener('d2l-siren-entity-save-end', () => {
-			this.shadowRoot.querySelector('#save-status').end();
-		});
-		this.addEventListener('d2l-siren-entity-save-error', () => {
-			this.shadowRoot.querySelector('#save-status').error();
-		});
-	}
-
 	_onRequestProvider(e) {
 		if (e.detail.key === 'd2l-provider-html-editor-enabled') {
 			e.detail.provider = this.htmlEditorEnabled;


### PR DESCRIPTION
Looks like these were left over from when the save-status component was removed. It was causing some (non-breaking) console errors.