### PR TITLE
DE39307 Fix remote plugin Quicklink URL formatting

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -123,11 +123,55 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeMixin(RtlMix
 		// Required for the async handler below to work in Edge
 		const event = opener();
 		event.AddListener(async event => {
-			const quicklinkUrl = `/d2l/api/lp/unstable/${this._orgUnitId}/quickLinks/${event.m_typeKey}/${event.m_id}`;
+			const quicklinkUrl = this._formatQuickLinkUrl(event);
 			const response = await fetch(quicklinkUrl);
 			const json = await response.json();
 			this._addToCollection(attachmentStore.createLink(event.m_title, json.QuickLinkTemplate));
 		});
+	}
+
+	get _sources() {
+		return {
+			announcement: 'news',
+			assignment: 'dropbox',
+			calendar: 'schedule',
+			chat: 'chat',
+			checklist: 'checklist',
+			content: 'content',
+			courseFile: 'coursefile',
+			discussion: 'discuss',
+			ePortfolio: 'epobject',
+			formTemplate: 'form',
+			googleDrive: 'google-drive',
+			lti: 'lti',
+			oneDrive: 'one-drive',
+			quiz: 'quiz',
+			selfAssessment: 'selfassess',
+			survey: 'survey',
+			url: 'url'
+		};
+	}
+
+	_formatQuickLinkUrl(event) {
+		if (event.m_typeKey === this._sources.url) {
+			return event.m_url;
+		}
+
+		const isRemotePlugin = Boolean(
+			event.m_url &&
+			event.m_url.length > 0 &&
+			!Object.values(this._sources).includes(event.m_typeKey)
+		);
+
+		if (isRemotePlugin) {
+			if (/^(http|https|ftp):\/\//i.test(event.m_url)) {
+				return event.m_url;
+			} else {
+				return decodeURIComponent(event.m_url).replace(/\{orgUnitId\}/gi, this._orgUnitId);
+			}
+		}
+
+		return `/d2l/api/lp/unstable/${this._orgUnitId}/quickLinks/${event.m_typeKey}/${event.m_id}`;
 	}
 
 	_addToCollection(attachment) {

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -123,10 +123,8 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeMixin(RtlMix
 		// Required for the async handler below to work in Edge
 		const event = opener();
 		event.AddListener(async event => {
-			const quicklinkUrl = this._formatQuickLinkUrl(event);
-			const response = await fetch(quicklinkUrl);
-			const json = await response.json();
-			this._addToCollection(attachmentStore.createLink(event.m_title, json.QuickLinkTemplate));
+			const quicklinkTemplate = await this._getQuickLinkTemplate(event);
+			this._addToCollection(attachmentStore.createLink(event.m_title, quicklinkTemplate));
 		});
 	}
 
@@ -152,7 +150,7 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeMixin(RtlMix
 		};
 	}
 
-	_formatQuickLinkUrl(event) {
+	async _getQuickLinkTemplate(event) {
 		if (event.m_typeKey === this._sources.url) {
 			return event.m_url;
 		}
@@ -167,11 +165,14 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeMixin(RtlMix
 			if (/^(http|https|ftp):\/\//i.test(event.m_url)) {
 				return event.m_url;
 			} else {
-				return decodeURIComponent(event.m_url).replace(/\{orgUnitId\}/gi, this._orgUnitId);
+				return decodeURIComponent(event.m_url);
 			}
 		}
 
-		return `/d2l/api/lp/unstable/${this._orgUnitId}/quickLinks/${event.m_typeKey}/${event.m_id}`;
+		const quicklinkUrl = `/d2l/api/lp/unstable/${this._orgUnitId}/quickLinks/${event.m_typeKey}/${event.m_id}`;
+		const response = await fetch(quicklinkUrl);
+		const json = await response.json();
+		return json.QuickLinkTemplate;
 	}
 
 	_addToCollection(attachment) {


### PR DESCRIPTION
Remote plugin attachments were not getting the special handling that they require. 
The basic logic in this change is taken from the [AppLoader LMS code](https://git.dev.d2l/projects/CORE/repos/apploader/browse/D2L.LP.AppLoader/Apps/Loaders/IFrame/V1/Picker.js#118).

https://rally1.rallydev.com/#/29180338367d/detail/defect/394851792936
