### PR TITLE
US117007 - Use individual FACE Milestone 3 flags

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
@@ -89,7 +89,7 @@ class ActivityAssignmentAvailabilityEditor extends ActivityEditorFeaturesMixin(L
 
 	_renderReleaseConditionSummary() {
 
-		const shouldRenderConditionSummary = this._isMilestoneEnabled(Milestones.M3);
+		const shouldRenderConditionSummary = this._isMilestoneEnabled(Milestones.M3ReleaseConditions);
 
 		if (!shouldRenderConditionSummary) {
 			return html``;
@@ -105,7 +105,7 @@ class ActivityAssignmentAvailabilityEditor extends ActivityEditorFeaturesMixin(L
 
 	_renderReleaseConditionEditor() {
 
-		const shouldRenderConditionEditor = this._isMilestoneEnabled(Milestones.M3);
+		const shouldRenderConditionEditor = this._isMilestoneEnabled(Milestones.M3ReleaseConditions);
 
 		if (!shouldRenderConditionEditor) {
 			return html``;

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-secondary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-secondary.js
@@ -69,6 +69,9 @@ class AssignmentEditorSecondary extends ActivityEditorFeaturesMixin(RtlMixin(Ent
 	}
 
 	render() {
+		const showSubmissionCompletionAccordian = this._isMilestoneEnabled(Milestones.M2);
+		const showEvaluationAccordian = this._isMilestoneEnabled(Milestones.M2) || this._isMilestoneEnabled(Milestones.M3Competencies);
+
 		const availabilityAccordian = html`
 			<d2l-activity-assignment-availability-editor
 				href="${this._activityUsageHref}"
@@ -76,26 +79,20 @@ class AssignmentEditorSecondary extends ActivityEditorFeaturesMixin(RtlMixin(Ent
 			</d2l-activity-assignment-availability-editor>
 		`;
 
-		const shouldRenderCompletionEvaluation = this._isMilestoneEnabled(Milestones.M2);
-
-		if (!shouldRenderCompletionEvaluation) {
-			return availabilityAccordian;
-		}
-
-		const submissionCompletionCategorizationAccordian = html`
+		const submissionCompletionCategorizationAccordian = showSubmissionCompletionAccordian ? html`
 			<d2l-activity-assignment-editor-submission-and-completion-editor
 				href="${this.href}"
 				.token="${this.token}">
 			</d2l-activity-assignment-editor-submission-and-completion-editor>
-		`;
+		` : null;
 
-		const evaluationAccordian = html`
+		const evaluationAccordian = showEvaluationAccordian ? html`
 			<d2l-activity-assignment-evaluation-editor
 				href="${this.href}"
 				.token="${this.token}"
 				.activityUsageHref=${this._activityUsageHref}>
 			</d2l-activity-assignment-evaluation-editor>
-		`;
+		` : null;
 
 		return html`
 			${availabilityAccordian}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -39,10 +39,6 @@ class AssignmentEditor extends ActivityEditorContainerMixin(LocalizeMixin(Activi
 			*/
 			milestoneTwoEnabled: { type: Boolean },
 			/**
-			* based on the LaunchDarkly flag face-assignments-milestone-3
-			*/
-			milestoneThreeEnabled: { type: Boolean },
-			/**
 			* based on the LaunchDarkly flag face-assignments-milestone-3-competencies
 			*/
 			milestoneThreeCompetenciesEnabled: { type: Boolean },
@@ -126,12 +122,6 @@ class AssignmentEditor extends ActivityEditorContainerMixin(LocalizeMixin(Activi
 
 		if (e.detail.key === 'd2l-milestone-two') {
 			e.detail.provider = this.milestoneTwoEnabled;
-			e.stopPropagation();
-			return;
-		}
-
-		if (e.detail.key === 'd2l-milestone-three') {
-			e.detail.provider = this.milestoneThreeEnabled;
 			e.stopPropagation();
 			return;
 		}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -39,11 +39,31 @@ class AssignmentEditor extends ActivityEditorContainerMixin(LocalizeMixin(Activi
 			*/
 			milestoneTwoEnabled: { type: Boolean },
 			/**
-			* based on the LaunchDarkly flag face-assignments-milestone-2
+			* based on the LaunchDarkly flag face-assignments-milestone-3
 			*/
 			milestoneThreeEnabled: { type: Boolean },
 			/**
-			* based on the LaunchDarkly flag face-assignments-milestone-2
+			* based on the LaunchDarkly flag face-assignments-milestone-3-competencies
+			*/
+			milestoneThreeCompetenciesEnabled: { type: Boolean },
+			/**
+			* based on the LaunchDarkly flag face-assignments-milestone-3-default-scoring-rubric
+			*/
+			milestoneThreeDefaultScoringRubricEnabled: { type: Boolean },
+			/**
+			* based on the LaunchDarkly flag face-assignments-milestone-3-outcomes
+			*/
+			milestoneThreeOutcomesEnabled: { type: Boolean },
+			/**
+			* based on the LaunchDarkly flag face-assignments-milestone-3-release-conditions
+			*/
+			milestoneThreeReleaseConditionsEnabled: { type: Boolean },
+			/**
+			* based on the LaunchDarkly flag face-assignments-milestone-3-special-access
+			*/
+			milestoneThreeSpecialAccessEnabled: { type: Boolean },
+			/**
+			* based on the LaunchDarkly flag face-assignments-milestone-4
 			*/
 			milestoneFourEnabled: { type: Boolean },
 			/**
@@ -101,21 +121,55 @@ class AssignmentEditor extends ActivityEditorContainerMixin(LocalizeMixin(Activi
 		if (e.detail.key === 'd2l-provider-html-editor-enabled') {
 			e.detail.provider = this.htmlEditorEnabled;
 			e.stopPropagation();
+			return;
 		}
 
 		if (e.detail.key === 'd2l-milestone-two') {
 			e.detail.provider = this.milestoneTwoEnabled;
 			e.stopPropagation();
+			return;
 		}
 
 		if (e.detail.key === 'd2l-milestone-three') {
 			e.detail.provider = this.milestoneThreeEnabled;
 			e.stopPropagation();
+			return;
+		}
+
+		if (e.detail.key === 'd2l-milestone-three-competencies') {
+			e.detail.provider = this.milestoneThreeCompetenciesEnabled;
+			e.stopPropagation();
+			return;
+		}
+
+		if (e.detail.key === 'd2l-milestone-three-default-scoring-rubric') {
+			e.detail.provider = this.milestoneThreeDefaultScoringRubricEnabled;
+			e.stopPropagation();
+			return;
+		}
+
+		if (e.detail.key === 'd2l-milestone-three-outcomes') {
+			e.detail.provider = this.milestoneThreeOutcomesEnabled;
+			e.stopPropagation();
+			return;
+		}
+
+		if (e.detail.key === 'd2l-milestone-three-release-conditions') {
+			e.detail.provider = this.milestoneThreeReleaseConditionsEnabled;
+			e.stopPropagation();
+			return;
+		}
+
+		if (e.detail.key === 'd2l-milestone-three-special-access') {
+			e.detail.provider = this.milestoneThreeSpecialAccessEnabled;
+			e.stopPropagation();
+			return;
 		}
 
 		if (e.detail.key === 'd2l-milestone-four') {
 			e.detail.provider = this.milestoneFourEnabled;
 			e.stopPropagation();
+			return;
 		}
 
 		// Provides unfurl API endpoint for d2l-labs-attachment component

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
@@ -25,7 +25,7 @@ class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(Loc
 			href: { type: String },
 			token: { type: Object },
 			activityUsageHref: { type: String },
-			_m3enabled: { type: Boolean }
+			_m3CompetenciesEnabled: { type: Boolean }
 		};
 	}
 
@@ -60,7 +60,7 @@ class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(Loc
 	connectedCallback() {
 		super.connectedCallback();
 
-		this._m3enabled = this._isMilestoneEnabled(Milestones.M3);
+		this._m3CompetenciesEnabled = this._isMilestoneEnabled(Milestones.M3Competencies);
 	}
 
 	_renderAnonymousMarkingSummary() {
@@ -167,14 +167,14 @@ class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(Loc
 				</h3>
 				<ul class="d2l-body-small activity-summarizer-summary" slot="summary">
 					<li>${this._renderRubricsSummary()}</li>
-					${this._m3enabled ? html`<li>${this._renderCompetenciesSummary()}</li>` : null}
+					${this._m3CompetenciesEnabled ? html`<li>${this._renderCompetenciesSummary()}</li>` : null}
 					<li>${this._renderAnonymousMarkingSummary()}</li>
 					<li>${this._renderAnnotationsSummary()}</li>
 					<li>${this._renderTurnitinSummary()}</li>
 				</ul>
 				<div class="editors">
 					${this._renderRubricsCollectionEditor()}
-					${this._m3enabled ? this._renderCompetenciesOpener() : null}
+					${this._m3CompetenciesEnabled ? this._renderCompetenciesOpener() : null}
 					${this._renderAnnotationsEditor()}
 					${this._renderAnonymousMarkingEditor()}
 					${this._renderTurnitinEditor()}

--- a/components/d2l-activity-editor/d2l-activity-outcomes.js
+++ b/components/d2l-activity-editor/d2l-activity-outcomes.js
@@ -45,7 +45,7 @@ class ActivityOutcomes extends ActivityEditorFeaturesMixin(ActivityEditorMixin(L
 	connectedCallback() {
 		super.connectedCallback();
 
-		this._featureEnabled = this._isMilestoneEnabled(Milestones.M3);
+		this._featureEnabled = this._isMilestoneEnabled(Milestones.M3Outcomes);
 		this._browseOutcomesText = this._dispatchRequestProvider('d2l-provider-browse-outcomes-text');
 		this._outcomesTerm = this._dispatchRequestProvider('d2l-provider-outcomes-term');
 	}

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-features-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-features-mixin.js
@@ -1,6 +1,5 @@
 export const Milestones = Object.freeze({
 	M2: 'd2l-milestone-two',
-	M3: 'd2l-milestone-three',
 	M3Competencies: 'd2l-milestone-three-competencies',
 	M3DefaultScoringRubric: 'd2l-milestone-three-default-scoring-rubric',
 	M3Outcomes: 'd2l-milestone-three-outcomes',

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-features-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-features-mixin.js
@@ -1,7 +1,12 @@
 export const Milestones = Object.freeze({
 	M2: 'd2l-milestone-two',
 	M3: 'd2l-milestone-three',
-	M4: 'd2l-milestone-four'
+	M3Competencies: 'd2l-milestone-three-competencies',
+	M3DefaultScoringRubric: 'd2l-milestone-three-default-scoring-rubric',
+	M3Outcomes: 'd2l-milestone-three-outcomes',
+	M3ReleaseConditions: 'd2l-milestone-three-release-conditions',
+	M3SpecialAccess: 'd2l-milestone-three-special-access',
+	M4: 'd2l-milestone-four',
 });
 
 export const ActivityEditorFeaturesMixin = superclass => class extends superclass {

--- a/test/d2l-activity-editor/d2l-activity-outcomes.js
+++ b/test/d2l-activity-editor/d2l-activity-outcomes.js
@@ -4,7 +4,7 @@ import { ActivityUsage } from '../../components/d2l-activity-editor/state/activi
 import { shared as store } from '../../components/d2l-activity-editor/state/activity-store.js';
 
 function _requestProviderMock(e) {
-	if (e.detail.key === 'd2l-milestone-three') {
+	if (e.detail.key === 'd2l-milestone-three-outcomes') {
 		e.detail.provider = true;
 		e.stopPropagation();
 	}


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/detail/userstory/394848425652

flag -> attribute
face-assignments-milestone-3-competencies -> `milestoneThreeCompetenciesEnabled`
face-assignments-milestone-3-outcomes -> `milestoneThreeDefaultScoringRubricEnabled`
face-assignments-milestone-3-special-access -> `milestoneThreeOutcomesEnabled`
face-assignments-milestone-3-release-conditions -> `milestoneThreeReleaseConditionsEnabled`
face-assignments-milestone-3-default-scoring-rubric -> `milestoneThreeSpecialAccessEnabled`

**Accordion Visibility**
Accordion 1 / availability accordion: Always shown due to availability dates feature in M1.
Accordion 2 / submission completion accordion: Shown if M2 is on (submission options).
Accordion 3 / evaluation accordion: Shown if M2 is on (rubrics, annotations) or M3-Competencies is on.
Default Scoring Rubric also goes in the evaluation accordion, but it doesn't make sense to show the accordion just for that feature if the M2 flag is off, since Rubrics would not be visible.