### PR TITLE
Fix Outcomes Standards button not showing when there are no tags

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-outcomes.js
+++ b/components/d2l-activity-editor/d2l-activity-outcomes.js
@@ -98,7 +98,7 @@ class ActivityOutcomes extends ActivityEditorFeaturesMixin(ActivityEditorMixin(L
 	}
 
 	_renderTags() {
-		return html`<label class="d2l-label-text">${this._outcomesTerm}</label>
+		return html`<label class="d2l-label-text" ?hidden="${!this._hasAlignments}">${this._outcomesTerm}</label>
 			<d2l-activity-alignment-tags
 				href="${this.href}"
 				.token="${this.token}"
@@ -106,8 +106,15 @@ class ActivityOutcomes extends ActivityEditorFeaturesMixin(ActivityEditorMixin(L
 				?hide-indirect-alignments="${this.hideIndirectAlignments}"
 				browse-outcomes-text="${this._browseOutcomesText}"
 				@d2l-activity-alignment-outcomes-updated="${this._onOutcomeTagDeleted}"
-				@d2l-activity-alignment-tags-update="${this._openDialog}">
+				@d2l-activity-alignment-tags-update="${this._openDialog}"
+				@empty-changed="${this._alignmentTagsEmptyChanged}"
+				?read-only=${!this._hasAlignments}>
 			</d2l-activity-alignment-tags>`;
+	}
+
+	_alignmentTagsEmptyChanged(e) {
+		this._hasAlignments = !e.detail.value;
+		this.requestUpdate();
 	}
 
 	render() {
@@ -117,21 +124,16 @@ class ActivityOutcomes extends ActivityEditorFeaturesMixin(ActivityEditorMixin(L
 			return html``;
 		}
 
-		const {
-			canUpdateAlignments,
-			hasAlignments
-		} = activity;
-
-		if (!canUpdateAlignments) {
-			this.hidden = true;
-			return html``;
-		}
-
 		this.hidden = false;
 
+		const {
+			canUpdateAlignments
+		} = activity;
+
 		return html`
-			${hasAlignments ? this._renderTags() : this._renderDialogOpener()}
-			<d2l-dialog title-text="${this._browseOutcomesText}" ?opened="${this._opened}">
+			${this._renderTags()}
+			${canUpdateAlignments && !this._hasAlignments ? html`${this._renderDialogOpener()}` : null}
+			${canUpdateAlignments ? html`<d2l-dialog title-text="${this._browseOutcomesText}" ?opened="${this._opened}">
 				<d2l-select-outcomes
 					href="${this.href}"
 					.token="${this.token}"
@@ -139,7 +141,7 @@ class ActivityOutcomes extends ActivityEditorFeaturesMixin(ActivityEditorMixin(L
 					@d2l-alignment-list-added="${this._onDialogAdd}"
 					@d2l-alignment-list-cancelled="${this._onDialogCancel}">
 				</d2l-select-outcomes>
-			</d2l-dialog>
+			</d2l-dialog>` : null}
 		`;
 	}
 }

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -49,7 +49,6 @@ export class ActivityUsage {
 		 */
 		this.alignmentsHref = this.competenciesHref ? null : entity.alignmentsHref();
 		this.canUpdateAlignments = false;
-		this.hasAlignments = false;
 
 		if (this.competenciesHref) {
 			await this.loadCompetencies();
@@ -59,7 +58,6 @@ export class ActivityUsage {
 			runInAction(() => {
 				const alignmentsCollection = new AlignmentsCollectionEntity(alignmentsEntity);
 				this.canUpdateAlignments = alignmentsCollection.canUpdateAlignments();
-				this.hasAlignments = alignmentsCollection.getAlignments().length > 0;
 			});
 		}
 	}
@@ -85,10 +83,6 @@ export class ActivityUsage {
 
 	setCanUpdateAlignments(value) {
 		this.canUpdateAlignments = value;
-	}
-
-	setHasAlignments(value) {
-		this.hasAlignments = value;
 	}
 
 	setDraftStatus(isDraft) {
@@ -190,7 +184,6 @@ decorate(ActivityUsage, {
 	associationsHref: observable,
 	alignmentsHref: observable,
 	canUpdateAlignments: observable,
-	hasAlignments: observable,
 	competenciesHref: observable,
 	associatedCompetenciesCount: observable,
 	unevaluatedCompetenciesCount: observable,
@@ -207,6 +200,5 @@ decorate(ActivityUsage, {
 	setDates: action,
 	setAlignmentsHref: action,
 	setCanUpdateAlignments: action,
-	setHasAlignments: action,
 	loadCompetencies: action
 });

--- a/test/d2l-activity-editor/state/activity-usage.spec.js
+++ b/test/d2l-activity-editor/state/activity-usage.spec.js
@@ -92,7 +92,6 @@ describe('Activity Usage', function() {
 			expect(activity.canEditDraft).to.be.true;
 			expect(activity.canUpdateAlignments).to.be.true;
 			expect(activity.alignmentsHref).to.equal('http://alignments-href/');
-			expect(activity.hasAlignments).to.be.false;
 			expect(activity.competenciesHref).to.be.null;
 			expect(activity.associatedCompetenciesCount).to.be.null;
 			expect(activity.unevaluatedCompetenciesCount).to.be.null;
@@ -117,7 +116,6 @@ describe('Activity Usage', function() {
 			expect(activity.canEditDraft).to.be.true;
 			expect(activity.canUpdateAlignments).to.be.false;
 			expect(activity.alignmentsHref).to.be.null;
-			expect(activity.hasAlignments).to.be.false;
 			expect(activity.competenciesHref).to.equal('http://competencies-href/');
 			expect(activity.associatedCompetenciesCount).to.equal(13);
 			expect(activity.unevaluatedCompetenciesCount).to.equal(10);


### PR DESCRIPTION
https://trello.com/c/F2lNHHqC/170-removed-all-standards-tags-doesnt-go-back-to-showing-standards-button

This fixes the problem where when there are no tags and we add a tag, it wasn't showing the alignment-tags component and thus we couldn't see the added tags. It also fixes the problem where when we delete the last tag, it doesn't go back to showing the "Standards" button.

There are also changes to allow rendering of the alignment-tags component even if the user cannot update alignments. The user will still be able to see the tags, but won't be able to edit them (i.e. can't delete if alignment lacks `remove-alignment` action or can't add if lacking `start-update-alignments` action).