### PR TITLE
US116960 Add saving shim to activity-editor

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -31,10 +31,6 @@ class AssignmentEditor extends ActivityEditorContainerMixin(LocalizeMixin(Activi
 			 */
 			trustedSitesEndpoint: { type: String },
 			/**
-			 * If there is an error on the page. Is used to toggle the d2l-alert.
-			 */
-			isError: { type: Boolean },
-			/**
 			* based on the LaunchDarkly flag face-assignments-milestone-2
 			*/
 			milestoneTwoEnabled: { type: Boolean },
@@ -247,7 +243,7 @@ class AssignmentEditor extends ActivityEditorContainerMixin(LocalizeMixin(Activi
 			<d2l-template-primary-secondary slot="editor" width-type="${this.widthType}">
 				<slot name="editor-nav" slot="header"></slot>
 				<div slot="primary" class="d2l-activity-assignment-editor-primary-panel">
-					${this.isError ? html`<d2l-alert type="error">${this.localize('assignmentSaveError')}</d2l-alert>` : null}
+					<d2l-alert type="error" ?hidden=${!this.isError}>${this.localize('assignmentSaveError')}</d2l-alert>
 					<d2l-activity-assignment-editor-detail
 						href="${assignmentHref}"
 						.token="${this.token}">
@@ -279,7 +275,8 @@ class AssignmentEditor extends ActivityEditorContainerMixin(LocalizeMixin(Activi
 				.token=${this.token}
 				unfurlEndpoint="${this.unfurlEndpoint}"
 				trustedSitesEndpoint="${this.trustedSitesEndpoint}"
-				@d2l-request-provider="${this._onRequestProvider}">
+				@d2l-request-provider="${this._onRequestProvider}"
+				?isSaving=${this.isSaving}>
 
 				${this._editorTemplate}
 

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -273,10 +273,10 @@ class AssignmentEditor extends ActivityEditorContainerMixin(LocalizeMixin(Activi
 				telemetryId="${this.telemetryId}"
 				.href=${this.href}
 				.token=${this.token}
+				.isSaving=${this.isSaving}
 				unfurlEndpoint="${this.unfurlEndpoint}"
 				trustedSitesEndpoint="${this.trustedSitesEndpoint}"
-				@d2l-request-provider="${this._onRequestProvider}"
-				?isSaving=${this.isSaving}>
+				@d2l-request-provider="${this._onRequestProvider}">
 
 				${this._editorTemplate}
 

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -273,7 +273,7 @@ class AssignmentEditor extends ActivityEditorContainerMixin(LocalizeMixin(Activi
 				telemetryId="${this.telemetryId}"
 				.href=${this.href}
 				.token=${this.token}
-				.isSaving=${this.isSaving}
+				?is-saving=${this.isSaving}
 				unfurlEndpoint="${this.unfurlEndpoint}"
 				trustedSitesEndpoint="${this.trustedSitesEndpoint}"
 				@d2l-request-provider="${this._onRequestProvider}">

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -11,7 +11,7 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 
 	static get properties() {
 		return {
-			isSaving: { type: Boolean },
+			isSaving: { type: Boolean, attribute: 'is-saving' },
 			_backdropShown: { type: Boolean },
 			_showBackgroundTimer: { type: Object }
 		};
@@ -62,6 +62,10 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 		if (changedProperties.has('asyncState') && this.asyncState === asyncStates.complete) {
 			this.logLoadEvent(this.href, this.type, this.telemetryId);
 		}
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
 		if (changedProperties.has('isSaving')) {
 			this._toggleBackdrop(this.isSaving);
 		}

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -46,7 +46,6 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 	async validate() {
 		const activity = store.get(this.href);
 		if (activity) {
-			this._toggleBackdrop(true);
 			await activity.validate();
 		}
 	}
@@ -54,8 +53,17 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 	async save() {
 		const activity = store.get(this.href);
 		if (activity) {
-			this._toggleBackdrop(true);
 			await activity.save();
+		}
+	}
+
+	update(changedProperties) {
+		super.update(changedProperties);
+		if (changedProperties.has('asyncState') && this.asyncState === asyncStates.complete) {
+			this.logLoadEvent(this.href, this.type, this.telemetryId);
+		}
+		if (changedProperties.has('isSaving')) {
+			this._toggleBackdrop(this.isSaving);
 		}
 	}
 
@@ -68,13 +76,6 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 			clearTimeout(this._showBackgroundTimer);
 			this._showBackgroundTimer = null;
 			this._backdropShown = false;
-		}
-	}
-
-	update(changedProperties) {
-		super.update(changedProperties);
-		if (changedProperties.has('asyncState') && this.asyncState === asyncStates.complete) {
-			this.logLoadEvent(this.href, this.type, this.telemetryId);
 		}
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -93,7 +93,12 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 			<div id="editor-container" ?hidden="${this.asyncState !== asyncStates.complete}">
 				<slot name="editor"></slot>
 			</div>
-			<d2l-backdrop for-target="editor-container" ?shown="${this._backdropShown}" cut-out slow-transition></d2l-backdrop>
+			<d2l-backdrop
+				for-target="editor-container"
+				?shown="${this._backdropShown}"
+				no-animate-hide
+				slow-transition>
+			</d2l-backdrop>
 		`;
 	}
 }

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -1,3 +1,4 @@
+import '@brightspace-ui/core/components/backdrop/backdrop.js';
 import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
@@ -7,6 +8,14 @@ import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 import { shared as store } from './state/activity-store.js';
 
 class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(ActivityEditorMixin(LocalizeMixin(LitElement)))) {
+
+	static get properties() {
+		return {
+			isSaving: { type: Boolean },
+			_backdropShown: { type: Boolean },
+			_showBackgroundTimer: { type: Object }
+		};
+	}
 
 	static get styles() {
 		return css`
@@ -26,9 +35,18 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 		return getLocalizeResources(langs, import.meta.url);
 	}
 
+	constructor() {
+		super();
+
+		this.isSaving = false;
+		this._backdropShown = false;
+		this._showBackgroundTimer = null;
+	}
+
 	async validate() {
 		const activity = store.get(this.href);
 		if (activity) {
+			this._toggleBackdrop(true);
 			await activity.validate();
 		}
 	}
@@ -36,7 +54,20 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 	async save() {
 		const activity = store.get(this.href);
 		if (activity) {
+			this._toggleBackdrop(true);
 			await activity.save();
+		}
+	}
+
+	_toggleBackdrop(show) {
+		if (show && !this._showBackgroundTimer) {
+			this._showBackgroundTimer = setTimeout(() => {
+				this._backdropShown = true;
+			}, 800);
+		} else if (!show) {
+			clearTimeout(this._showBackgroundTimer);
+			this._showBackgroundTimer = null;
+			this._backdropShown = false;
 		}
 	}
 
@@ -58,9 +89,10 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 	render() {
 		return html`
 			<div ?hidden="${this.asyncState === asyncStates.complete}" class="d2l-activity-editor-loading">${this.localize('loading')}</div>
-			<div ?hidden="${this.asyncState !== asyncStates.complete}">
+			<div id="editor-container" ?hidden="${this.asyncState !== asyncStates.complete}">
 				<slot name="editor"></slot>
 			</div>
+			<d2l-backdrop for-target="editor-container" ?shown="${this.isSaving && this._backdropShown}" cut-out slow-transition></d2l-backdrop>
 		`;
 	}
 }

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -93,7 +93,7 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 			<div id="editor-container" ?hidden="${this.asyncState !== asyncStates.complete}">
 				<slot name="editor"></slot>
 			</div>
-			<d2l-backdrop for-target="editor-container" ?shown="${this.isSaving && this._backdropShown}" cut-out slow-transition></d2l-backdrop>
+			<d2l-backdrop for-target="editor-container" ?shown="${this._backdropShown}" cut-out slow-transition></d2l-backdrop>
 		`;
 	}
 }


### PR DESCRIPTION
Uses the `d2l-background` component as a shim to obscure the editor while saving is in progress. The shim will enable after 0.8s and fade in over the following 1.2s. It will disable instantly when a validation or save error occurs.

Due to the multitude of editors, the save action is coordinated in `d2l-activity-editor-container-mixin`. This is used in `d2l-activity-assignment-editor`, which in turn embeds the assignment-independent `d2l-activity-editor`. For the backdrop to remain independent of assignments, I added it to `d2l-activity-editor`, but in return need to tell that component when a save action is in progress. For that purpose I added a new prop, `isSaving`, to the `d2l-activity-editor-container-mixin.`, which is passed to `d2l-activity-editor` via the `d2l-activity-assignment-editor`.
We then simply display the backdrop based `isSaving`, with a little extra logic to enforce the 0.8s delay and avoid duplicate timers.

https://rally1.rallydev.com/#/29180338367d/detail/userstory/394462027544