### PR TITLE
Fix `d2l-activity-outcomes` taking up space when nothing is rendered

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-outcomes.js
+++ b/components/d2l-activity-editor/d2l-activity-outcomes.js
@@ -124,11 +124,15 @@ class ActivityOutcomes extends ActivityEditorFeaturesMixin(ActivityEditorMixin(L
 			return html``;
 		}
 
-		this.hidden = false;
-
 		const {
 			canUpdateAlignments
 		} = activity;
+
+		if (!canUpdateAlignments && !this._hasAlignments) {
+			this.hidden = true;
+		} else {
+			this.hidden = false;
+		}
 
 		return html`
 			${this._renderTags()}


### PR DESCRIPTION
Missed a case where `this.hidden` should be set to `true`. Without it, `d2l-activity-outcomes` does not have the `hidden` attribute set, and that causes the element to take up space due to padding.
`hidden` needs to be `true` when there are no alignments and we cannot update/edit alignments.
https://trello.com/c/RhZ3MjRM/211-outcomes-tag-takes-up-ui-space-when-not-visible