### PR TITLE
removing unnecessary fastdom

### DIFF
--- a/components/d2l-activity-card/d2l-activity-card.js
+++ b/components/d2l-activity-card/d2l-activity-card.js
@@ -1,6 +1,5 @@
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { Rels } from 'd2l-hypermedia-constants';
-import 'fastdom/fastdom.min.js';
 import 'd2l-card/d2l-card.js';
 import 'd2l-card/d2l-card-content-meta.js';
 import 'd2l-fetch/d2l-fetch.js';


### PR DESCRIPTION
`fastdom` is used elsewhere in this repo, but not in this component, so importing it isn't necessary.