### PR TITLE
Fix for failing color-contrast test

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/activity-summarizer-styles.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/activity-summarizer-styles.js
@@ -14,7 +14,7 @@ export const summarizerSummaryStyles = css`
 		padding: 0;
 		margin-top: 5px;
 		min-height: 20px;
-		color: var(--d2l-color-galena);
+		color: var(--d2l-color-tungsten);
 	}
 
 	ul.activity-summarizer-summary > li {


### PR DESCRIPTION
Running accessibility tests in https://github.com/BrightspaceHypermediaComponents/activities/pull/948 revealed a failure on an accessibility test case:

```
  d2l-activity-assignment-editor-submission-and-completion
    × passes accessibility test
      Chrome Headless 83.0.4103.106 (Windows 10)
    Error: Accessibility Violations
    ---
    Rule: color-contrast
    Impact: serious
    Elements must have sufficient color contrast (https://dequeuniversity.com/rules/axe/3.5/color-contrast?application=axeAPI)
    
    Issue target: d2l-activity-assignment-editor-submission-and-completion-editor,li:nth-child(2)
    Context: <li><!----><!---->first submission type<!----><!----></li>
    Fix any of the following:
      Element has insufficient color contrast of 3.4 (foreground color: #868c8f, background color: #ffffff, font size: 8.4pt (11.2px), font weight: normal). Expected contrast ratio of 4.5:1
    ---
```

See https://dequeuniversity.com/rules/axe/3.5/color-contrast?application=axeAPI

Before:
![image](https://user-images.githubusercontent.com/2337524/85179954-2c627800-b250-11ea-9145-ad8da8f88779.png)

After:
![image](https://user-images.githubusercontent.com/2337524/85179967-308e9580-b250-11ea-9de0-3fd0836be4d1.png)
