### PR TITLE
US116679 Check for dirty alignments by checking presence of submit action on AlignmentsCollectionEntity

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -86,7 +86,7 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 	hasPendingChanges() {
 		const activity = store.get(this.href);
 		if (activity) {
-			return activity.dirty;
+			return activity.dirty();
 		}
 		return false;
 	}

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
@@ -111,9 +111,11 @@ export const ActivityEditorContainerMixin = superclass => class extends Activity
 	}
 
 	async _cancel() {
-		const hasPendingChanges = Array.from(this._editors).some(editor => editor.hasPendingChanges());
+		const editorsPendingChanges = await Promise.all(
+			Array.from(this._editors).map(editor => editor.hasPendingChanges())
+		);
 
-		if (hasPendingChanges) {
+		if (editorsPendingChanges.some(Boolean)) {
 			const dialog = this.shadowRoot.querySelector('d2l-dialog-confirm');
 			const action = await dialog.open();
 			if (action === 'cancel' || action === 'abort') {

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -176,8 +176,17 @@ export class ActivityUsage {
 		await this.fetch();
 	}
 
-	get dirty() {
-		return !this._entity.equals(this._makeUsageData());
+	async _alignmentsDirty() {
+		if (!this.alignmentsHref || !this.canUpdateAlignments) {
+			return false;
+		}
+
+		const alignmentsCollection = new AlignmentsCollectionEntity(await fetchEntity(this.alignmentsHref, this.token), this.token);
+		return alignmentsCollection.hasSubmitAction();
+	}
+
+	async dirty() {
+		return !this._entity.equals(this._makeUsageData()) || await this._alignmentsDirty();
 	}
 }
 


### PR DESCRIPTION
If the alignments collection has a submit action on it, the collection is dirty.
However, checking the collection for the action involves fetching it from the entity store, which is async. Thus the `dirty` prop in the activity-usage has to become an `async dirty()` function, and requires the callers to handle promises rather than plain values.

Relies on changes to siren-sdk: https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/195

https://rally1.rallydev.com/#/29180338367d/detail/userstory/391701599076