### PR TITLE
DE39632: resolving app root to support query-strings in import.meta.url

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-html-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-editor.js
@@ -4,6 +4,7 @@ import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { getLocalizeResources } from './localization.js';
 import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { resolveUrl } from '@polymer/polymer/lib/utils/resolve-url.js';
 
 class ActivityHtmlEditor extends LocalizeMixin(LitElement) {
 
@@ -125,10 +126,6 @@ class ActivityHtmlEditor extends LocalizeMixin(LitElement) {
 		this._htmlEditorUniqueId = `htmleditor-${getUniqueId()}`;
 	}
 
-	_resolveUrl() {
-		return `${import.meta.url}/../../../`;
-	}
-
 	_onContentChange() {
 		const content = this.shadowRoot.querySelector('d2l-html-editor').getContent();
 		this.dispatchEvent(new CustomEvent('d2l-activity-html-editor-change', {
@@ -145,7 +142,7 @@ class ActivityHtmlEditor extends LocalizeMixin(LitElement) {
 			<d2l-html-editor
 				id="assignment-instructions"
 				editor-id="${this._htmlEditorUniqueId}"
-				app-root="${this._resolveUrl()}"
+				app-root="${resolveUrl('../../', import.meta.url)}"
 				@change="${this._onContentChange}"
 				@input="${this._onContentChange}"
 				inline="1"


### PR DESCRIPTION
This should resolve the `Syntax error` issues in legacy-Edge with unbundled BSI builds.

@ryantmer I'm including you here as you worked on the [bit that originally switched this over](https://github.com/BrightspaceHypermediaComponents/activities/commit/c44b63592ec0fde96375a589c77e5d8cfbe36a05#diff-576a2f50ff8ed912df2d89abc0499942).

@dbatiste FYI as I'm hoping the new HTML editor can just use normal ES6 imports and not rely on this path-passing-around stuff.

Here's what was happening:
* This `resolveUrl` business is trying to send down an `app-path` attribute to the HTML editor, which should be something like `https://hostname/node_modules/d2l-activities`. The HTML editor then uses that to find its own assets like CSS files and such.
* Before this change, the `_resolveUrl` function was returning a string that ended up with a value like this: `https://hostname/node_modules/d2l-activities/components/d2l-activity-editor/d2l-activity-html-editor.js/../../../`. So it was taking the `import.meta.url` and appending `'/../../../'`.
* That... doesn't seem right. BUT, it just happens to work if you paste that into your URL bar, the browser will do some magic and "resolve" it to `https://hostname/node_modules/d2l-activities`. That's because it's treating `/d2l-activity-html-editor.js/` as a directory, and then going up 3 levels from there... which... yeah.
* However, when we moved to unbundled BSI builds, in legacy-Edge Rollup appends a `?transform-systemjs` query-string parameter to all files so that the `es-dev-server` knows to use SystemJS to load things instead. That part isn't important, but the presence of a query-string is.
* With the query-string, `import.meta.url` becomes `https://hostname/node_modules/d2l-activities/components/d2l-activity-editor/d2l-activity-html-editor.js?transform-systemjs` and now the browser ignores the `/../../../` at the end because it's just part of the query-string.

[Polymer's `resolveUrl`](https://polymer-library.polymer-project.org/3.0/api/utils/resolve-url) was intended for this kind of thing, and is used elsewhere in this project for this. It takes a baseURI and a url and resolves the URL against the baseURI. This time we only need to go out 2 levels instead of 3 because the filename isn't being treated as a directory.

I tested this in FACE in both dev and prod modes, as well as in the `d2l-activities` local demo.

Longer term, we definitely want to move away from passing around paths like this and resolving URLs using old Polymer things, but hopefully the new HTML editor will let us clean this type of thing up.