### PR TITLE
Consolidate lang files to one for d2l-activity-editor to fix importing

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-editor.js
@@ -1,14 +1,13 @@
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from '../localization.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { assignments as store } from './state/assignment-store.js';
 
 class ActivityAssignmentAnnotationsEditor
-	extends ActivityEditorMixin(RtlMixin(LocalizeMixin(MobxLitElement))) {
+	extends ActivityEditorMixin(RtlMixin(LocalizeActivityEditor(MobxLitElement))) {
 
 	static get styles() {
 
@@ -36,11 +35,6 @@ class ActivityAssignmentAnnotationsEditor
 		];
 	}
 
-	static async getLocalizeResources(langs) {
-
-		return getLocalizeResources(langs, import.meta.url);
-	}
-
 	constructor() {
 
 		super(store);
@@ -66,13 +60,13 @@ class ActivityAssignmentAnnotationsEditor
 
 		return html`
 			<label class="d2l-label-text">
-				${this.localize('annotationTools')}
+				${this.localize('d2l-activity-assignment-editor.annotationTools')}
 			</label>
 			<d2l-input-checkbox
 				@change="${this._toggleAnnotationToolsAvailability}"
 				?checked="${entity.annotationToolsAvailable}"
-				ariaLabel="${this.localize('annotationToolDescription')}">
-				${this.localize('annotationToolDescription')}
+				ariaLabel="${this.localize('d2l-activity-assignment-editor.annotationToolDescription')}">
+				${this.localize('d2l-activity-assignment-editor.annotationToolDescription')}
 			</d2l-input-checkbox>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-summary.js
@@ -1,17 +1,11 @@
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from '../localization.js';
 import { html } from 'lit-element/lit-element.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { assignments as store } from './state/assignment-store.js';
 
 class ActivityAssignmentAnnotationsSummary
-	extends ActivityEditorMixin(LocalizeMixin(MobxLitElement)) {
-
-	static async getLocalizeResources(langs) {
-
-		return getLocalizeResources(langs, import.meta.url);
-	}
+	extends ActivityEditorMixin(LocalizeActivityEditor(MobxLitElement)) {
 
 	constructor() {
 
@@ -32,7 +26,7 @@ class ActivityAssignmentAnnotationsSummary
 			return html``;
 		}
 
-		return html`${this.localize('txtAnnotationsOff')}`;
+		return html`${this.localize('d2l-activity-assignment-editor.txtAnnotationsOff')}`;
 	}
 }
 

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-editor.js
@@ -3,14 +3,13 @@ import 'd2l-inputs/d2l-input-checkbox-spacer.js';
 import { bodySmallStyles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from '../localization.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { assignments as store } from './state/assignment-store.js';
 
 class ActivityAssignmentAnonymousMarkingEditor
-	extends ActivityEditorMixin(RtlMixin(LocalizeMixin(MobxLitElement))) {
+	extends ActivityEditorMixin(RtlMixin(LocalizeActivityEditor(MobxLitElement))) {
 
 	static get styles() {
 
@@ -50,11 +49,6 @@ class ActivityAssignmentAnonymousMarkingEditor
 		];
 	}
 
-	static async getLocalizeResources(langs) {
-
-		return getLocalizeResources(langs, import.meta.url);
-	}
-
 	constructor() {
 
 		super(store);
@@ -80,14 +74,14 @@ class ActivityAssignmentAnonymousMarkingEditor
 
 		return html`
 			<label class="d2l-label-text">
-				${this.localize('lblAnonymousMarking')}
+				${this.localize('d2l-activity-assignment-editor.lblAnonymousMarking')}
 			</label>
 			<d2l-input-checkbox
 				@change="${this._saveAnonymousMarking}"
 				?checked="${entity.isAnonymousMarkingEnabled}"
 				?disabled="${!entity.canEditAnonymousMarking}"
-				ariaLabel="${this.localize('chkAnonymousMarking')}">
-				${this.localize('chkAnonymousMarking')}
+				ariaLabel="${this.localize('d2l-activity-assignment-editor.chkAnonymousMarking')}">
+				${this.localize('d2l-activity-assignment-editor.chkAnonymousMarking')}
 			</d2l-input-checkbox>
 			<d2l-input-checkbox-spacer
 				class="d2l-body-small"

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-summary.js
@@ -1,12 +1,11 @@
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from '../localization';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { assignments as store } from './state/assignment-store.js';
 
 class ActivityAssignmentAnonymousMarkingSummary
-	extends ActivityEditorMixin(LocalizeMixin(MobxLitElement)) {
+	extends ActivityEditorMixin(LocalizeActivityEditor(MobxLitElement)) {
 
 	static get styles() {
 
@@ -19,11 +18,6 @@ class ActivityAssignmentAnonymousMarkingSummary
 				display: none;
 			}
 		`;
-	}
-
-	static async getLocalizeResources(langs) {
-
-		return getLocalizeResources(langs, import.meta.url);
 	}
 
 	constructor() {
@@ -43,7 +37,7 @@ class ActivityAssignmentAnonymousMarkingSummary
 			return html``;
 		}
 
-		return html`${this.localize('anonymousGradingEnabled')}`;
+		return html`${this.localize('d2l-activity-assignment-editor.anonymousGradingEnabled')}`;
 	}
 }
 customElements.define(

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
@@ -9,12 +9,11 @@ import { bodySmallStyles, heading3Styles, heading4Styles } from '@brightspace-ui
 import { css, html } from 'lit-element/lit-element.js';
 import { summarizerHeaderStyles, summarizerSummaryStyles } from './activity-summarizer-styles.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from '../localization.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { shared as store } from '../state/activity-store.js';
 
-class ActivityAssignmentAvailabilityEditor extends ActivityEditorFeaturesMixin(LocalizeMixin(ActivityEditorMixin(MobxLitElement))) {
+class ActivityAssignmentAvailabilityEditor extends ActivityEditorFeaturesMixin(LocalizeActivityEditor(ActivityEditorMixin(MobxLitElement))) {
 
 	static get properties() {
 
@@ -53,10 +52,6 @@ class ActivityAssignmentAvailabilityEditor extends ActivityEditorFeaturesMixin(L
 			summarizerHeaderStyles,
 			summarizerSummaryStyles,
 		];
-	}
-
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
 	}
 
 	constructor() {
@@ -118,10 +113,10 @@ class ActivityAssignmentAvailabilityEditor extends ActivityEditorFeaturesMixin(L
 		return html`
 			<div class="editor">
 				<h3 class="d2l-heading-4">
-					${this.localize('hdrReleaseConditions')}
+					${this.localize('d2l-activity-assignment-editor.hdrReleaseConditions')}
 				</h3>
 				<d2l-activity-usage-conditions-editor
-					description="${this.localize('hlpReleaseConditions')}"
+					description="${this.localize('d2l-activity-assignment-editor.hlpReleaseConditions')}"
 					href="${this.href}"
 					.token="${this.token}">
 				</d2l-activity-usage-conditions-editor>
@@ -144,10 +139,10 @@ class ActivityAssignmentAvailabilityEditor extends ActivityEditorFeaturesMixin(L
 		return html`
 			<div class="editor">
 				<h3 class="d2l-heading-4">
-					${this.localize('hdrSpecialAccess')}
+					${this.localize('d2l-activity-assignment-editor.hdrSpecialAccess')}
 				</h3>
 				<d2l-activity-special-access-editor
-					description="${this.localize('hlpSpecialAccess')}"
+					description="${this.localize('d2l-activity-assignment-editor.hlpSpecialAccess')}"
 					href="${this.href}"
 					.token="${this.token}">
 				</d2l-activity-special-access-editor>
@@ -177,7 +172,7 @@ class ActivityAssignmentAvailabilityEditor extends ActivityEditorFeaturesMixin(L
 				?opened=${this._isOpened()}
 				@d2l-labs-accordion-collapse-state-changed=${this._onAccordionStateChange}>
 				<h3 class="d2l-heading-3 activity-summarizer-header" slot="header">
-					${this.localize('hdrAvailability')}
+					${this.localize('d2l-activity-assignment-editor.hdrAvailability')}
 				</h3>
 				<ul class="d2l-body-small activity-summarizer-summary" slot="summary">
 					<li>${this._renderAvailabilityDatesSummary()}</li>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -15,17 +15,16 @@ import { shared as attachmentStore } from '../d2l-activity-attachments/state/att
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { ErrorHandlingMixin } from '../error-handling-mixin.js';
-import { getLocalizeResources } from '../localization.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LinksInMessageProcessor } from '@d2l/d2l-attachment/helpers/links-in-message-processor.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { SaveStatusMixin } from '../save-status-mixin.js';
 import { shared as store } from './state/assignment-store.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 
-class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMixinLit(LocalizeMixin(RtlMixin(ActivityEditorMixin(MobxLitElement)))))) {
+class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMixinLit(LocalizeActivityEditor(RtlMixin(ActivityEditorMixin(MobxLitElement)))))) {
 
 	static get properties() {
 		return {
@@ -65,10 +64,6 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 				}
 			`
 		];
-	}
-
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
 	}
 
 	constructor() {
@@ -181,14 +176,14 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 
 		return html`
 			<div id="assignment-name-container">
-				<label class="d2l-label-text" for="assignment-name">${this.localize('name')}*</label>
+				<label class="d2l-label-text" for="assignment-name">${this.localize('d2l-activity-assignment-editor.name')}*</label>
 				<d2l-input-text
 					id="assignment-name"
 					maxlength="128"
 					value="${name}"
 					@change="${this._saveOnChange('name')}"
 					@input="${this._saveNameOnInput}"
-					aria-label="${this.localize('name')}"
+					aria-label="${this.localize('d2l-activity-assignment-editor.name')}"
 					?disabled="${!canEditName}"
 					aria-invalid="${this._nameError ? 'true' : ''}"
 					prevent-submit>
@@ -203,7 +198,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 
 			<div id="score-and-duedate-container">
 				<div id="score-container">
-					<label class="d2l-label-text">${this.localize('scoreOutOf')}</label>
+					<label class="d2l-label-text">${this.localize('d2l-activity-assignment-editor.scoreOutOf')}</label>
 					<d2l-activity-score-editor
 						href="${activityUsageHref}"
 						.token="${this.token}"
@@ -220,12 +215,12 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 			</div>
 
 			<div id="assignment-instructions-container">
-				<label class="d2l-label-text">${this.localize('instructions')}</label>
+				<label class="d2l-label-text">${this.localize('d2l-activity-assignment-editor.instructions')}</label>
 				<d2l-activity-text-editor
 					.value="${instructions}"
 					.richtextEditorConfig="${instructionsRichTextEditorConfig}"
 					@d2l-activity-text-editor-change="${this._saveInstructionsOnChange}"
-					ariaLabel="${this.localize('instructions')}"
+					ariaLabel="${this.localize('d2l-activity-assignment-editor.instructions')}"
 					?disabled="${!canEditInstructions}">
 				</d2l-activity-text-editor>
 			</div>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-footer.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-footer.js
@@ -3,12 +3,10 @@ import '../d2l-activity-visibility-editor.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { AssignmentEntity } from 'siren-sdk/src/activities/assignments/AssignmentEntity.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
-import { getLocalizeResources } from '../localization.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { SaveStatusMixin } from '../save-status-mixin.js';
 
-class AssignmentEditorFooter extends SaveStatusMixin(EntityMixinLit(RtlMixin(LocalizeMixin(LitElement)))) {
+class AssignmentEditorFooter extends SaveStatusMixin(EntityMixinLit(RtlMixin(LitElement))) {
 
 	static get properties() {
 		return {
@@ -43,10 +41,6 @@ class AssignmentEditorFooter extends SaveStatusMixin(EntityMixinLit(RtlMixin(Loc
 					}
 			}
 		`;
-	}
-
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
 	}
 
 	constructor() {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-secondary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-secondary.js
@@ -6,12 +6,10 @@ import { ActivityEditorFeaturesMixin, Milestones } from '../mixins/d2l-activity-
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { AssignmentEntity } from 'siren-sdk/src/activities/assignments/AssignmentEntity.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
-import { getLocalizeResources } from '../localization.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 
-class AssignmentEditorSecondary extends ActivityEditorFeaturesMixin(RtlMixin(EntityMixinLit(LocalizeMixin(LitElement)))) {
+class AssignmentEditorSecondary extends ActivityEditorFeaturesMixin(RtlMixin(EntityMixinLit(LitElement))) {
 
 	static get properties() {
 		return {
@@ -39,10 +37,6 @@ class AssignmentEditorSecondary extends ActivityEditorFeaturesMixin(RtlMixin(Ent
 				}
 			`
 		];
-	}
-
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
 	}
 
 	constructor() {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -6,15 +6,14 @@ import { css, html } from 'lit-element/lit-element.js';
 import { summarizerHeaderStyles, summarizerSummaryStyles } from './activity-summarizer-styles.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { classMap } from 'lit-html/directives/class-map.js';
-import { getLocalizeResources } from '../localization.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { radioStyles } from '@brightspace-ui/core/components/inputs/input-radio-styles.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';
 import { shared as store } from './state/assignment-store.js';
 
-class ActivityAssignmentSubmissionAndCompletionEditor extends ActivityEditorMixin(RtlMixin(LocalizeMixin(MobxLitElement))) {
+class ActivityAssignmentSubmissionAndCompletionEditor extends ActivityEditorMixin(RtlMixin(LocalizeActivityEditor(MobxLitElement))) {
 
 	static get styles() {
 		return [
@@ -52,10 +51,6 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends ActivityEditorMixi
 		];
 	}
 
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
-	}
-
 	_saveCompletionTypeOnChange(event) {
 		store.getAssignment(this.href).setCompletionType(event.target.value);
 	}
@@ -87,7 +82,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends ActivityEditorMixi
 		return html `
 			<div id="assignment-type-container">
 				<label class="d2l-label-text">
-					${this.localize('txtAssignmentType')}
+					${this.localize('d2l-activity-assignment-editor.txtAssignmentType')}
 				</label>
 				<d2l-activity-assignment-type-editor
 					href="${this.href}"
@@ -132,7 +127,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends ActivityEditorMixi
 		return html`
 			<div id="assignment-files-submission-limit-container">
 				<label class="d2l-label-text" for="assignment-files-submission-limit-container">
-					${this.localize('filesSubmissionLimit')}
+					${this.localize('d2l-activity-assignment-editor.filesSubmissionLimit')}
 				</label>
 
 				<label class="${classMap({'files-submission-limit-unlimited': true, ...radioClasses})}">
@@ -145,7 +140,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends ActivityEditorMixi
 						?disabled=${isReadOnly}
 						?checked="${assignment.filesSubmissionLimit === 'unlimited'}"
 					>
-					${this.localize('UnlimitedFilesPerSubmission')}
+					${this.localize('d2l-activity-assignment-editor.UnlimitedFilesPerSubmission')}
 				</label>
 
 				<label class="${classMap({'files-submission-limit-one': true, ...radioClasses})}">
@@ -158,7 +153,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends ActivityEditorMixi
 						?disabled=${isReadOnly}
 						?checked="${assignment.filesSubmissionLimit === 'onefilepersubmission'}"
 					>
-					${this.localize('OneFilePerSubmission')}
+					${this.localize('d2l-activity-assignment-editor.OneFilePerSubmission')}
 				</label>
 			</div>
 		`;
@@ -177,7 +172,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends ActivityEditorMixi
 		return html `
 			<div id="assignment-submissions-rule-container">
 				<label class="d2l-label-text" for="assignment-submissions-rule-container">
-					${this.localize('submissionsRule')}
+					${this.localize('d2l-activity-assignment-editor.submissionsRule')}
 				</label>
 
 				${assignment.submissionsRuleOptions.map((x) => html`
@@ -202,7 +197,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends ActivityEditorMixi
 		return html `
 			<div id="assignment-submission-type-container">
 				<label class="d2l-label-text" for="assignment-submission-type">
-					${this.localize('submissionType')}
+					${this.localize('d2l-activity-assignment-editor.submissionType')}
 				</label>
 				<select
 					id="assignment-submission-type"
@@ -236,7 +231,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends ActivityEditorMixi
 		return html `
 			<div id="assignment-completion-type-container" ?hidden="${completionHidden}">
 				<label class="d2l-label-text" for="assignment-completion-type">
-					${this.localize('completionType')}
+					${this.localize('d2l-activity-assignment-editor.completionType')}
 				</label>
 				<select
 					id="assignment-completion-type"
@@ -258,7 +253,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends ActivityEditorMixi
 		return html`
 			<d2l-labs-accordion-collapse class="accordion" flex header-border>
 				<h3 class="d2l-heading-3 activity-summarizer-header" slot="header">
-					${this.localize('submissionCompletionAndCategorization')}
+					${this.localize('d2l-activity-assignment-editor.submissionCompletionAndCategorization')}
 				</h3>
 				<ul class="d2l-body-small activity-summarizer-summary" slot="summary">
 					<li>${this._renderAssignmentTypeSummary()}</li>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -9,12 +9,11 @@ import '@brightspace-ui/core/components/dialog/dialog-confirm.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorContainerMixin } from '../mixins/d2l-activity-editor-container-mixin.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from '../localization.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { shared as store } from './state/assignment-store.js';
 
-class AssignmentEditor extends ActivityEditorContainerMixin(LocalizeMixin(ActivityEditorMixin(MobxLitElement))) {
+class AssignmentEditor extends ActivityEditorContainerMixin(LocalizeActivityEditor(ActivityEditorMixin(MobxLitElement))) {
 
 	static get properties() {
 		return {
@@ -98,9 +97,7 @@ class AssignmentEditor extends ActivityEditorContainerMixin(LocalizeMixin(Activi
 		`;
 	}
 
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
-	}
+
 
 	constructor() {
 		super(store);
@@ -243,7 +240,7 @@ class AssignmentEditor extends ActivityEditorContainerMixin(LocalizeMixin(Activi
 			<d2l-template-primary-secondary slot="editor" width-type="${this.widthType}">
 				<slot name="editor-nav" slot="header"></slot>
 				<div slot="primary" class="d2l-activity-assignment-editor-primary-panel">
-					<d2l-alert type="error" ?hidden=${!this.isError}>${this.localize('assignmentSaveError')}</d2l-alert>
+					<d2l-alert type="error" ?hidden=${!this.isError}>${this.localize('d2l-activity-assignment-editor.assignmentSaveError')}</d2l-alert>
 					<d2l-activity-assignment-editor-detail
 						href="${assignmentHref}"
 						.token="${this.token}">
@@ -282,9 +279,9 @@ class AssignmentEditor extends ActivityEditorContainerMixin(LocalizeMixin(Activi
 
 			</d2l-activity-editor>
 
-			<d2l-dialog-confirm title-text="${this.localize('discardChangesTitle')}" text=${this.localize('discardChangesQuestion')}>
-				<d2l-button slot="footer" primary dialog-action="confirm">${this.localize('yesLabel')}</d2l-button>
-				<d2l-button slot="footer" dialog-action="cancel">${this.localize('noLabel')}</d2l-button>
+			<d2l-dialog-confirm title-text="${this.localize('d2l-activity-assignment-editor.discardChangesTitle')}" text=${this.localize('d2l-activity-assignment-editor.discardChangesQuestion')}>
+				<d2l-button slot="footer" primary dialog-action="confirm">${this.localize('d2l-activity-assignment-editor.yesLabel')}</d2l-button>
+				<d2l-button slot="footer" dialog-action="cancel">${this.localize('d2l-activity-assignment-editor.noLabel')}</d2l-button>
 			</d2l-dialog-confirm>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
@@ -14,10 +14,9 @@ import { bodySmallStyles, heading3Styles } from '@brightspace-ui/core/components
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { summarizerHeaderStyles, summarizerSummaryStyles } from './activity-summarizer-styles.js';
 
-import { getLocalizeResources } from '../localization.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from '../mixins/d2l-activity-editor-lang-mixin.js';
 
-class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(LocalizeMixin(LitElement)) {
+class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(LocalizeActivityEditor(LitElement)) {
 
 	static get properties() {
 
@@ -51,11 +50,6 @@ class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(Loc
 			`,
 			summarizerHeaderStyles,
 			summarizerSummaryStyles];
-	}
-
-	static async getLocalizeResources(langs) {
-
-		return getLocalizeResources(langs, import.meta.url);
 	}
 
 	connectedCallback() {
@@ -165,7 +159,7 @@ class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(Loc
 		return html`
 			<d2l-labs-accordion-collapse flex header-border>
 				<h3 class="d2l-heading-3 activity-summarizer-header" slot="header">
-					${this.localize('evaluationAndFeedback')}
+					${this.localize('d2l-activity-assignment-editor.evaluationAndFeedback')}
 				</h3>
 				<ul class="d2l-body-small activity-summarizer-summary" slot="summary">
 					${this._m2Enabled ? html`<li>${this._renderRubricsSummary()}</li>` : null}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
@@ -1,15 +1,14 @@
 import { bodyCompactStyles, bodySmallStyles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from '../localization.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { radioStyles } from '@brightspace-ui/core/components/inputs/input-radio-styles.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';
 import { assignments as store } from './state/assignment-store.js';
 
-class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeMixin(MobxLitElement))) {
+class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeActivityEditor(MobxLitElement))) {
 
 	static get styles() {
 		return [
@@ -56,10 +55,6 @@ class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeMixin(Mo
 		];
 	}
 
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
-	}
-
 	constructor() {
 		super(store);
 	}
@@ -97,15 +92,15 @@ class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeMixin(Mo
 		const isIndividualAssignmentType = assignment.isIndividualAssignmentType;
 
 		if (assignment.assignmentHasSubmissions) {
-			return this.localize('folderTypeCannotChange');
+			return this.localize('d2l-activity-assignment-editor.folderTypeCannotChange');
 		}
 
 		if (isIndividualAssignmentType && assignment.groupCategories.length === 0) {
-			return this.localize('folderTypeNoGroups');
+			return this.localize('d2l-activity-assignment-editor.folderTypeNoGroups');
 		}
 
 		if (!isIndividualAssignmentType) {
-			return this.localize('folderTypeCreateGroups');
+			return this.localize('d2l-activity-assignment-editor.folderTypeCreateGroups');
 		}
 
 		return;
@@ -122,9 +117,9 @@ class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeMixin(Mo
 		const infoText = this._getInformationText(assignment);
 		const isReadOnly = assignment.isReadOnly;
 		const groupTypeDisabled = assignment.isGroupAssignmentTypeDisabled;
-		const folderTypeText =	isIndividualType ? this.localize('txtIndividual') : this.localize('txtGroup');
+		const folderTypeText =	isIndividualType ? this.localize('d2l-activity-assignment-editor.txtIndividual') : this.localize('d2l-activity-assignment-editor.txtGroup');
 		const groupTypeText = !isIndividualType && assignment.selectedGroupCategoryName
-			? this.localize('txtGroupCategoryWithName', 'groupCategory', assignment.selectedGroupCategoryName)
+			? this.localize('d2l-activity-assignment-editor.txtGroupCategoryWithName', 'groupCategory', assignment.selectedGroupCategoryName)
 			: '';
 
 		return html`
@@ -144,7 +139,7 @@ class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeMixin(Mo
 						@change="${this._setIndividualAssignmentType}"
 						?checked="${isIndividualType}"
 					>
-					${this.localize('txtIndividual')}
+					${this.localize('d2l-activity-assignment-editor.txtIndividual')}
 				</label>
 				<label class="d2l-input-radio-label ${groupTypeDisabled ? 'd2l-input-radio-label-disabled' : ''}">
 					<input
@@ -156,10 +151,10 @@ class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeMixin(Mo
 						?checked="${!isIndividualType}"
 						?disabled="${groupTypeDisabled}"
 					>
-					${this.localize('txtGroup')}
+					${this.localize('d2l-activity-assignment-editor.txtGroup')}
 				</label>
 				<div class="select-list group-info" ?hidden="${isIndividualType}">
-					<label class="d2l-label-text">${this.localize('txtGroupCategory')}</label>
+					<label class="d2l-label-text">${this.localize('d2l-activity-assignment-editor.txtGroupCategory')}</label>
 					<select
 						class="d2l-input-select block-select"
 						id="assignemnt-group-categories"

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-summary.js
@@ -1,12 +1,11 @@
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from '../localization.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { assignments as store } from './state/assignment-store.js';
 
-class AssignmentTypeSummary extends ActivityEditorMixin(RtlMixin(LocalizeMixin(MobxLitElement))) {
+class AssignmentTypeSummary extends ActivityEditorMixin(RtlMixin(LocalizeActivityEditor(MobxLitElement))) {
 
 	static get styles() {
 		return css`
@@ -19,10 +18,6 @@ class AssignmentTypeSummary extends ActivityEditorMixin(RtlMixin(LocalizeMixin(M
 		`;
 	}
 
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
-	}
-
 	constructor() {
 		super(store);
 	}
@@ -30,7 +25,7 @@ class AssignmentTypeSummary extends ActivityEditorMixin(RtlMixin(LocalizeMixin(M
 	render() {
 		const assignment = store.get(this.href);
 		if (assignment && !assignment.isIndividualAssignmentType) {
-			return html`${this.localize('txtGroupAssignmentSummary')}`;
+			return html`${this.localize('d2l-activity-assignment-editor.txtGroupAssignmentSummary')}`;
 		}
 
 		return html``;

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-assignment-turnitin-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-assignment-turnitin-editor.js
@@ -3,13 +3,12 @@ import '@brightspace-ui/core/components/icons/icon.js';
 import { bodySmallStyles, heading4Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from '../localization';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { assignments as store } from './state/assignment-store.js';
 
 class AssignmentTurnitinEditor
-	extends ActivityEditorMixin(LocalizeMixin(MobxLitElement)) {
+	extends ActivityEditorMixin(LocalizeActivityEditor(MobxLitElement)) {
 
 	static get styles() {
 
@@ -48,11 +47,6 @@ class AssignmentTurnitinEditor
 		];
 	}
 
-	static async getLocalizeResources(langs) {
-
-		return getLocalizeResources(langs, import.meta.url);
-	}
-
 	constructor() {
 
 		super(store);
@@ -74,13 +68,13 @@ class AssignmentTurnitinEditor
 		const buttons = [
 			{
 				Key: 'save',
-				Text: this.localize('btnSave'),
+				Text: this.localize('d2l-activity-assignment-editor.btnSave'),
 				ResponseType: 1, // D2L.Dialog.ResponseType.Positive
 				IsPrimary: true,
 				IsEnabled: true
 			},
 			{
-				Text: this.localize('btnCancel'),
+				Text: this.localize('d2l-activity-assignment-editor.btnCancel'),
 				ResponseType: 2, // D2L.Dialog.ResponseType.Negative
 				IsPrimary: false,
 				IsEnabled: true
@@ -96,7 +90,7 @@ class AssignmentTurnitinEditor
 			/*      responseDataKey: */ 'result',
 			/*                width: */ 960,
 			/*               height: */ 960,
-			/*            closeText: */ this.localize('btnCloseDialog'),
+			/*            closeText: */ this.localize('d2l-activity-assignment-editor.btnCloseDialog'),
 			/*              buttons: */ buttons,
 			/* forceTriggerOnCancel: */ false
 		);
@@ -136,7 +130,7 @@ class AssignmentTurnitinEditor
 				originalityCheckItem = html`
 					<li class="feature-summary-item">
 						<d2l-icon icon="tier1:check"></d2l-icon>
-						${this.localize('txtOriginalityCheckOn')}
+						${this.localize('d2l-activity-assignment-editor.txtOriginalityCheckOn')}
 					</li>
 				`;
 			}
@@ -146,7 +140,7 @@ class AssignmentTurnitinEditor
 				gradeMarkItem = html`
 					<li class="feature-summary-item">
 						<d2l-icon icon="tier1:check"></d2l-icon>
-						${this.localize('txtGradeMarkOn')}
+						${this.localize('d2l-activity-assignment-editor.txtGradeMarkOn')}
 					</li>
 				`;
 			}
@@ -161,11 +155,11 @@ class AssignmentTurnitinEditor
 
 		return html`
 			<div id="assignment-turnitin-container" ?hidden="${!isEditorDisplayed}">
-				<h4 class="d2l-heading-4">${this.localize('hdrTurnitin')}</h4>
-				<p class="help-text d2l-body-small">${this.localize('hlpTurnitin')}</p>
+				<h4 class="d2l-heading-4">${this.localize('d2l-activity-assignment-editor.hdrTurnitin')}</h4>
+				<p class="help-text d2l-body-small">${this.localize('d2l-activity-assignment-editor.hlpTurnitin')}</p>
 				${featureSummary}
 				<d2l-button-subtle
-					text="${this.localize('btnEditTurnitin')}"
+					text="${this.localize('d2l-activity-assignment-editor.btnEditTurnitin')}"
 					@click="${this._onClickEdit}"
 					?hidden="${!canEditTurnitin}">
 				</d2l-button-subtle>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-assignment-turnitin-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-assignment-turnitin-summary.js
@@ -1,18 +1,12 @@
 import '@brightspace-ui/core/components/icons/icon.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from '../localization';
 import { html } from 'lit-element/lit-element';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { assignments as store } from './state/assignment-store.js';
 
 class AssignmentTurnitinSummary
-	extends ActivityEditorMixin(LocalizeMixin(MobxLitElement)) {
-
-	static async getLocalizeResources(langs) {
-
-		return getLocalizeResources(langs, import.meta.url);
-	}
+	extends ActivityEditorMixin(LocalizeActivityEditor(MobxLitElement)) {
 
 	constructor() {
 
@@ -30,7 +24,7 @@ class AssignmentTurnitinSummary
 
 		if (isOriginalityCheckEnabled || isGradeMarkEnabled) {
 
-			return html`${this.localize('txtTurnitinOn')}`;
+			return html`${this.localize('d2l-activity-assignment-editor.txtTurnitinOn')}`;
 
 		}
 

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -66,10 +66,6 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeActivityEdit
 		`;
 	}
 
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
-	}
-
 	constructor() {
 		super(store);
 

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -8,13 +8,12 @@ import 'd2l-dropdown/d2l-dropdown-menu.js';
 import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { shared as attachmentStore } from './state/attachment-store.js';
-import { getLocalizeResources } from '../localization';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin';
+import { LocalizeActivityEditor } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin';
 import { shared as store } from './state/attachment-collections-store.js';
 
-class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeMixin(RtlMixin(MobxLitElement))) {
+class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeActivityEditor(RtlMixin(MobxLitElement))) {
 
 	static get styles() {
 		return css`
@@ -250,76 +249,76 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeMixin(RtlMix
 				<d2l-button-icon
 					id="add-file-button"
 					icon="d2l-tier1:upload"
-					text="${this.localize('addFile')}"
+					text="${this.localize('d2l-activity-attachments.addFile')}"
 					?hidden="${!canAddFile}"
 					@click="${this._launchAddFileDialog}">
 				</d2l-button-icon>
 				<d2l-tooltip
 					for="add-file-button"
 					aria-hidden="true"
-					disable-focus-lock>${this.localize('addFile')}</d2l-tooltip>
+					disable-focus-lock>${this.localize('d2l-activity-attachments.addFile')}</d2l-tooltip>
 					<!-- Important: keep tooltip content inline, otherwise screenreader gets confused -->
 				<d2l-button-icon
 					id="add-quicklink-button"
 					icon="d2l-tier1:quicklink"
-					text="${this.localize('addQuicklink')}"
+					text="${this.localize('d2l-activity-attachments.addQuicklink')}"
 					?hidden="${!canAddLink}"
 					@click="${this._launchAddQuicklinkDialog}">
 				</d2l-button-icon>
 				<d2l-tooltip
 					for="add-quicklink-button"
 					aria-hidden="true"
-					disable-focus-lock>${this.localize('addQuicklink')}</d2l-tooltip>
+					disable-focus-lock>${this.localize('d2l-activity-attachments.addQuicklink')}</d2l-tooltip>
 
 				<d2l-button-icon
 					id="add-link-button"
 					icon="d2l-tier1:link"
-					text="${this.localize('addLink')}"
+					text="${this.localize('d2l-activity-attachments.addLink')}"
 					?hidden="${!canAddLink}"
 					@click="${this._launchAddLinkDialog}">
 				</d2l-button-icon>
 				<d2l-tooltip
 					for="add-link-button"
 					aria-hidden="true"
-					disable-focus-lock>${this.localize('addLink')}</d2l-tooltip>
+					disable-focus-lock>${this.localize('d2l-activity-attachments.addLink')}</d2l-tooltip>
 
 				<d2l-button-icon
 					id="add-google-drive-link-button"
 					icon="d2l-tier1:google-drive"
-					text="${this.localize('addGoogleDriveLink')}"
+					text="${this.localize('d2l-activity-attachments.addGoogleDriveLink')}"
 					?hidden="${!canAddGoogleDriveLink}"
 					@click="${this._launchAddGoogleDriveLinkDialog}">
 				</d2l-button-icon>
 				<d2l-tooltip
 					for="add-google-drive-link-button"
 					aria-hidden="true"
-					disable-focus-lock>${this.localize('addGoogleDriveLink')}</d2l-tooltip>
+					disable-focus-lock>${this.localize('d2l-activity-attachments.addGoogleDriveLink')}</d2l-tooltip>
 
 				<d2l-button-icon
 					id="add-onedrive-link-button"
 					icon="d2l-tier1:one-drive"
-					text="${this.localize('addOneDriveLink')}"
+					text="${this.localize('d2l-activity-attachments.addOneDriveLink')}"
 					?hidden="${!canAddOneDriveLink}"
 					@click="${this._launchAddOneDriveLinkDialog}">
 				</d2l-button-icon>
 				<d2l-tooltip
 					for="add-onedrive-link-button"
 					aria-hidden="true"
-					disable-focus-lock>${this.localize('addOneDriveLink')}</d2l-tooltip>
+					disable-focus-lock>${this.localize('d2l-activity-attachments.addOneDriveLink')}</d2l-tooltip>
 
 				<div class="button-container-right">
 					<d2l-button-subtle
 						id="record-audio-button"
 						icon="tier1:mic"
 						?hidden="${!canRecordAudio}"
-						text="${this.localize('recordAudio')}"
+						text="${this.localize('d2l-activity-attachments.recordAudio')}"
 						@click="${this._launchRecordAudioDialog}">
 					</d2l-button-subtle>
 					<d2l-button-subtle
 						id="record-video-button"
 						icon="tier1:file-video"
 						?hidden="${!canRecordVideo}"
-						text="${this.localize('recordVideo')}"
+						text="${this.localize('d2l-activity-attachments.recordVideo')}"
 						@click="${this._launchRecordVideoDialog}">
 					</d2l-button-subtle>
 				</div>
@@ -330,35 +329,35 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeMixin(RtlMix
 						id="attach-dropdown"
 						class="d2l-dropdown-opener opener-border-0 option-menu-toggle"
 						icon="d2l-tier1:attach"
-						text="${this.localize('attach')}">
+						text="${this.localize('d2l-activity-attachments.attach')}">
 					</d2l-button-icon>
 					<d2l-tooltip for="attach-dropdown"
-						position="top" disable-focus-lock>${this.localize('attach')}
+						position="top" disable-focus-lock>${this.localize('d2l-activity-attachments.attach')}
 					</d2l-tooltip>
 					<d2l-dropdown-menu id="dropdown" align="end" no-pointer vertical-offset="6px">
-						<d2l-menu role="menu" label="${this.localize('attach')}">
+						<d2l-menu role="menu" label="${this.localize('d2l-activity-attachments.attach')}">
 							<d2l-menu-item
-								text="${this.localize('addFileMenu')}"
+								text="${this.localize('d2l-activity-attachments.addFileMenu')}"
 								?hidden="${!canAddFile}"
 								@d2l-menu-item-select="${this._launchAddFileDialog}"
 							></d2l-menu-item>
 							<d2l-menu-item
-								text="${this.localize('addQuicklinkMenu')}"
+								text="${this.localize('d2l-activity-attachments.addQuicklinkMenu')}"
 								?hidden="${!canAddLink}"
 								@d2l-menu-item-select="${this._launchAddQuicklinkDialog}"
 							></d2l-menu-item>
 							<d2l-menu-item
-								text="${this.localize('addLinkMenu')}"
+								text="${this.localize('d2l-activity-attachments.addLinkMenu')}"
 								?hidden="${!canAddLink}"
 								@d2l-menu-item-select="${this._launchAddLinkDialog}"
 							></d2l-menu-item>
 							<d2l-menu-item
-								text="${this.localize('addGoogleDriveLinkMenu')}"
+								text="${this.localize('d2l-activity-attachments.addGoogleDriveLinkMenu')}"
 								?hidden="${!canAddGoogleDriveLink}"
 								@d2l-menu-item-select="${this._launchAddGoogleDriveLinkDialog}"
 							></d2l-menu-item>
 							<d2l-menu-item
-								text="${this.localize('addOneDriveLinkMenu')}"
+								text="${this.localize('d2l-activity-attachments.addOneDriveLinkMenu')}"
 								?hidden="${!canAddLink}"
 								@d2l-menu-item-select="${this._launchAddOneDriveLinkDialog}"
 							></d2l-menu-item>
@@ -370,21 +369,21 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeMixin(RtlMix
 						id="record-audio-button-small"
 						icon="tier1:mic"
 						?hidden="${!canRecordAudio}"
-						text="${this.localize('recordAudio')}"
+						text="${this.localize('d2l-activity-attachments.recordAudio')}"
 						@click="${this._launchRecordAudioDialog}">
 					</d2l-button-icon>
 					<d2l-tooltip for="record-audio-button-small"
-						position="top" disable-focus-lock>${this.localize('recordAudio')}
+						position="top" disable-focus-lock>${this.localize('d2l-activity-attachments.recordAudio')}
 					</d2l-tooltip>
 					<d2l-button-icon
 						id="record-video-button-small"
 						icon="tier1:file-video"
 						?hidden="${!canRecordVideo}"
-						text="${this.localize('recordVideo')}"
+						text="${this.localize('d2l-activity-attachments.recordVideo')}"
 						@click="${this._launchRecordVideoDialog}">
 					</d2l-button-icon>
 					<d2l-tooltip for="record-video-button-small"
-						position="top" disable-focus-lock>${this.localize('recordVideo')}
+						position="top" disable-focus-lock>${this.localize('d2l-activity-attachments.recordVideo')}
 					</d2l-tooltip>
 				</span>
 			</div>

--- a/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
@@ -1,13 +1,12 @@
 import 'd2l-datetime-picker/d2l-datetime-picker';
 import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from './localization';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from './mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { shared as store } from './state/activity-store.js';
 
-class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeMixin(MobxLitElement))) {
+class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeActivityEditor(MobxLitElement))) {
 	static get styles() {
 		return [labelStyles, css`
 			:host {
@@ -21,10 +20,6 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeMixin
 				min-height: 62px; /* Hack to force a consistent the height for the old datetime picker. Can hopefully be removed when the new picker is used. */
 			}
 		`];
-	}
-
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
 	}
 
 	constructor() {
@@ -68,17 +63,17 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeMixin
 		}
 
 		return html`
-			<label class="d2l-label-text" ?hidden=${!canEditDates}>${this.localize('startDate')}</label>
+			<label class="d2l-label-text" ?hidden=${!canEditDates}>${this.localize('d2l-activity-editor.startDate')}</label>
 			<div id="startdate-container" ?hidden=${!canEditDates}>
 				<d2l-datetime-picker
 					hide-label
 					name="startDate"
 					id="startDate"
-					date-label="${this.localize('startDate')}"
-					time-label="${this.localize('startTime')}"
+					date-label="${this.localize('d2l-activity-editor.startDate')}"
+					time-label="${this.localize('d2l-activity-editor.startTime')}"
 					datetime="${startDate}"
 					overrides="${this._overrides}"
-					placeholder="${this.localize('noStartDate')}"
+					placeholder="${this.localize('d2l-activity-editor.noStartDate')}"
 					aria-invalid="${startDateErrorTerm ? 'true' : 'false'}"
 					invalid="${startDateErrorTerm}"
 					tooltip-red
@@ -87,17 +82,17 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeMixin
 					@d2l-datetime-picker-datetime-cleared="${this._onStartDatetimePickerDatetimeCleared}">
 				</d2l-datetime-picker>
 			</div>
-			<label class="d2l-label-text" ?hidden=${!canEditDates}>${this.localize('endDate')}</label>
+			<label class="d2l-label-text" ?hidden=${!canEditDates}>${this.localize('d2l-activity-editor.endDate')}</label>
 			<div id="enddate-container" ?hidden=${!canEditDates}>
 				<d2l-datetime-picker
 					hide-label
 					name="endDate"
 					id="endDate"
-					date-label="${this.localize('endDate')}"
-					time-label="${this.localize('endTime')}"
+					date-label="${this.localize('d2l-activity-editor.endDate')}"
+					time-label="${this.localize('d2l-activity-editor.endTime')}"
 					datetime="${endDate}"
 					overrides="${this._overrides}"
-					placeholder="${this.localize('noEndDate')}"
+					placeholder="${this.localize('d2l-activity-editor.noEndDate')}"
 					aria-invalid="${endDateErrorTerm ? 'true' : 'false'}"
 					invalid="${endDateErrorTerm}"
 					tooltip-red

--- a/components/d2l-activity-editor/d2l-activity-availability-dates-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-summary.js
@@ -1,17 +1,12 @@
 import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
 import { formatDate } from '@brightspace-ui/intl/lib/dateTime.js';
-import { getLocalizeResources } from './localization';
 import { html } from 'lit-element/lit-element';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from './mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { shared as store } from './state/activity-store.js';
 
 class ActivityAvailabilityDatesSummary
-	extends ActivityEditorMixin(LocalizeMixin(MobxLitElement)) {
-
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
-	}
+	extends ActivityEditorMixin(LocalizeActivityEditor(MobxLitElement)) {
 
 	constructor() {
 		super();
@@ -45,13 +40,13 @@ class ActivityAvailabilityDatesSummary
 		let text;
 
 		if (startDate && endDate) {
-			text = this.localize('txtAvailabilityStartAndEnd', { startDate, endDate });
+			text = this.localize('d2l-activity-editor.txtAvailabilityStartAndEnd', { startDate, endDate });
 		} else if (startDate) {
-			text = this.localize('txtAvailabilityStartOnly', { startDate });
+			text = this.localize('d2l-activity-editor.txtAvailabilityStartOnly', { startDate });
 		} else if (endDate) {
-			text = this.localize('txtAvailabilityEndOnly', { endDate });
+			text = this.localize('d2l-activity-editor.txtAvailabilityEndOnly', { endDate });
 		} else {
-			text = this.localize('txtAvailabilityNeither');
+			text = this.localize('d2l-activity-editor.txtAvailabilityNeither');
 		}
 
 		return html`${text}`;

--- a/components/d2l-activity-editor/d2l-activity-competencies-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-competencies-summary.js
@@ -1,16 +1,11 @@
 import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from './localization';
 import { html } from 'lit-element/lit-element';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from './mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { shared as store } from '../../components/d2l-activity-editor/state/activity-store.js';
 
 class ActivityCompetenciesSummary
-	extends ActivityEditorMixin(LocalizeMixin(MobxLitElement)) {
-
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
-	}
+	extends ActivityEditorMixin(LocalizeActivityEditor(MobxLitElement)) {
 
 	constructor() {
 		super(store);
@@ -27,7 +22,7 @@ class ActivityCompetenciesSummary
 			return html``;
 		}
 
-		return html`${this.localize('competenciesCountSummary', { count })}`;
+		return html`${this.localize('d2l-activity-editor.competenciesCountSummary', { count })}`;
 	}
 }
 

--- a/components/d2l-activity-editor/d2l-activity-competencies.js
+++ b/components/d2l-activity-editor/d2l-activity-competencies.js
@@ -3,13 +3,12 @@ import '@brightspace-ui/core/components/button/button-subtle.js';
 import { bodySmallStyles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from './localization';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from './mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { shared as store } from '../../components/d2l-activity-editor/state/activity-store.js';
 
-class ActivityCompetencies extends ActivityEditorMixin(RtlMixin(LocalizeMixin(MobxLitElement))) {
+class ActivityCompetencies extends ActivityEditorMixin(RtlMixin(LocalizeActivityEditor(MobxLitElement))) {
 
 	static get properties() {
 		return {
@@ -58,10 +57,6 @@ class ActivityCompetencies extends ActivityEditorMixin(RtlMixin(LocalizeMixin(Mo
 		];
 	}
 
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
-	}
-
 	constructor() {
 		super(store);
 	}
@@ -76,7 +71,7 @@ class ActivityCompetencies extends ActivityEditorMixin(RtlMixin(LocalizeMixin(Mo
 		const location = new D2L.LP.Web.Http.UrlLocation(dialogUrl);
 		const buttons = [
 			{
-				Text: this.localize('btnClose'),
+				Text: this.localize('d2l-activity-editor.d2l-activity-editor.btnClose'),
 				ResponseType: 2, // D2L.Dialog.ResponseType.Negative
 				IsPrimary: false,
 				IsEnabled: true
@@ -92,7 +87,7 @@ class ActivityCompetencies extends ActivityEditorMixin(RtlMixin(LocalizeMixin(Mo
 			/*      responseDataKey: */ 'result',
 			/*                width: */ 960,
 			/*               height: */ 960,
-			/*            closeText: */ this.localize('btnCloseDialog'),
+			/*            closeText: */ this.localize('d2l-activity-editor.d2l-activity-editor.btnCloseDialog'),
 			/*              buttons: */ buttons,
 			/* forceTriggerOnCancel: */ false
 		);
@@ -111,7 +106,7 @@ class ActivityCompetencies extends ActivityEditorMixin(RtlMixin(LocalizeMixin(Mo
 
 		return html`
 			<d2l-button-subtle
-				text="${this.localize('manageCompetencies')}"
+				text="${this.localize('d2l-activity-editor.d2l-activity-editor.manageCompetencies')}"
 				h-align="text"
 				@click="${this._openManageCompetencies}">
 			</d2l-button-subtle>
@@ -119,7 +114,7 @@ class ActivityCompetencies extends ActivityEditorMixin(RtlMixin(LocalizeMixin(Mo
 	}
 
 	_renderCountText(count) {
-		const langTerm = this.localize('competenciesCount', { count });
+		const langTerm = this.localize('d2l-activity-editor.d2l-activity-editor.competenciesCount', { count });
 
 		if (count === 0) {
 			return html`<div id="no-learning-objectives-summary" class="d2l-body-small">${langTerm}</div>`;
@@ -139,7 +134,7 @@ class ActivityCompetencies extends ActivityEditorMixin(RtlMixin(LocalizeMixin(Mo
 		return html`
 			<div class="competencies-count-container">
 				<d2l-icon class="competencies-icon alert-icon" icon="tier1:alert"></d2l-icon>
-				<div class="competencies-count-text">${this.localize('unevaluatedCompetencies', { count })}</div>
+				<div class="competencies-count-text">${this.localize('d2l-activity-editor.d2l-activity-editor.unevaluatedCompetencies', { count })}</div>
 			</div>
 		`;
 	}
@@ -157,7 +152,7 @@ class ActivityCompetencies extends ActivityEditorMixin(RtlMixin(LocalizeMixin(Mo
 		} = activity;
 
 		return html`
-			<label class="d2l-label-text">${this.localize('competencies')}</label>
+			<label class="d2l-label-text">${this.localize('d2l-activity-editor.d2l-activity-editor.competencies')}</label>
 			<div class="competencies-count-container">
 				${this._renderCountText(count)}
 			</div>

--- a/components/d2l-activity-editor/d2l-activity-conditions-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-conditions-editor.js
@@ -5,15 +5,14 @@ import 'd2l-dropdown/d2l-dropdown-menu.js';
 import { bodyCompactStyles, bodySmallStyles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from './localization';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from './mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';
 import store from './state/conditions-store.js';
 
 class ActivityConditionsEditor
-	extends ActivityEditorMixin(RtlMixin(LocalizeMixin(MobxLitElement))) {
+	extends ActivityEditorMixin(RtlMixin(LocalizeActivityEditor(MobxLitElement))) {
 
 	static get properties() {
 
@@ -51,10 +50,6 @@ class ActivityConditionsEditor
 			`,
 			...this.listItemStyles
 		];
-	}
-
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
 	}
 
 	static get listItemStyles() {
@@ -124,7 +119,7 @@ class ActivityConditionsEditor
 
 			return html`
 				<p class="d2l-label-text">
-					${this.localize('lblConditionsOperator')}
+					${this.localize('d2l-activity-editor.lblConditionsOperator')}
 				</p>
 			`;
 		}
@@ -161,7 +156,7 @@ class ActivityConditionsEditor
 		return html`
 			<div>
 				<label class="d2l-label-text" for="operator">
-					${this.localize('lblConditionsOperator')}
+					${this.localize('d2l-activity-editor.lblConditionsOperator')}
 				</label>
 				<select
 					class="d2l-input-select"
@@ -199,7 +194,7 @@ class ActivityConditionsEditor
 				</span>
 				<span class="d2l-list-item-deleter">
 					<d2l-button-icon
-						text="${this.localize('btnRemoveCondition')}"
+						text="${this.localize('d2l-activity-editor.btnRemoveCondition')}"
 						icon="tier1:close-large"
 						data-key="${key}"
 						@click="${this._removeCondition}">
@@ -332,7 +327,7 @@ class ActivityConditionsEditor
 		if (canAttachExisting) {
 			attachExistingTemplate = html`
 				<d2l-menu-item
-					text="${this.localize('btnAddExisting')}"
+					text="${this.localize('d2l-activity-editor.btnAddExisting')}"
 					@d2l-menu-item-select="${this._addExisting}">
 				</d2l-menu-item>
 			`;
@@ -342,7 +337,7 @@ class ActivityConditionsEditor
 		if (canCreateNew) {
 			createNewTemplate = html`
 				<d2l-menu-item
-					text="${this.localize('btnCreateNew')}"
+					text="${this.localize('d2l-activity-editor.btnCreateNew')}"
 					@d2l-menu-item-select="${this._createNew}">
 				</d2l-menu-item>
 			`;
@@ -350,9 +345,9 @@ class ActivityConditionsEditor
 
 		return html`
 			<d2l-dropdown-button-subtle
-				text="${this.localize('btnAddReleaseCondition')}">
+				text="${this.localize('d2l-activity-editor.btnAddReleaseCondition')}">
 				<d2l-dropdown-menu>
-					<d2l-menu label="${this.localize('btnAddReleaseCondition')}">
+					<d2l-menu label="${this.localize('d2l-activity-editor.btnAddReleaseCondition')}">
 						${createNewTemplate}
 						${attachExistingTemplate}
 					</d2l-menu>

--- a/components/d2l-activity-editor/d2l-activity-conditions-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-conditions-summary.js
@@ -1,16 +1,11 @@
 import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from './localization';
 import { html } from 'lit-element/lit-element';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from './mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import store from './state/conditions-store.js';
 
 class ActivityConditionsSummary
-	extends ActivityEditorMixin(LocalizeMixin(MobxLitElement)) {
-
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
-	}
+	extends ActivityEditorMixin(LocalizeActivityEditor(MobxLitElement)) {
 
 	constructor() {
 		super(store);
@@ -28,7 +23,7 @@ class ActivityConditionsSummary
 			return html``;
 		}
 
-		return html`${this.localize('txtNumReleaseConditions', { count })}`;
+		return html`${this.localize('d2l-activity-editor.txtNumReleaseConditions', { count })}`;
 	}
 }
 

--- a/components/d2l-activity-editor/d2l-activity-due-date-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-due-date-editor.js
@@ -1,13 +1,12 @@
 import 'd2l-datetime-picker/d2l-datetime-picker';
 import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from './localization';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from './mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { shared as store } from './state/activity-store.js';
 
-class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeMixin(MobxLitElement)) {
+class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeActivityEditor(MobxLitElement)) {
 
 	static get properties() {
 		return {
@@ -25,10 +24,6 @@ class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeMixin(MobxLitEle
 				display: none;
 			}
 		`];
-	}
-
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
 	}
 
 	constructor() {
@@ -52,11 +47,11 @@ class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeMixin(MobxLitEle
 					hide-label
 					name="date"
 					id="date"
-					date-label="${this.localize('dueDate')}"
-					time-label="${this.localize('dueTime')}"
+					date-label="${this.localize('d2l-activity-editor.dueDate')}"
+					time-label="${this.localize('d2l-activity-editor.dueTime')}"
 					datetime="${date}"
 					overrides="${this._overrides}"
-					placeholder="${this.localize('noDueDate')}"
+					placeholder="${this.localize('d2l-activity-editor.noDueDate')}"
 					aria-invalid="${errorTerm ? 'true' : 'false'}"
 					invalid="${errorTerm}"
 					tooltip-red
@@ -92,7 +87,7 @@ class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeMixin(MobxLitEle
 		}
 
 		return html`
-			<label class="d2l-label-text" ?hidden="${!canEditDates}">${this.localize('dueDate')}</label>
+			<label class="d2l-label-text" ?hidden="${!canEditDates}">${this.localize('d2l-activity-editor.dueDate')}</label>
 			${this.dateTemplate(dueDate, canEditDates, errorTerm)}
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-editor-buttons.js
+++ b/components/d2l-activity-editor/d2l-activity-editor-buttons.js
@@ -1,9 +1,8 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
-import { getLocalizeResources } from './localization.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from './mixins/d2l-activity-editor-lang-mixin.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 
-class ActivityEditorButtons extends RtlMixin(LocalizeMixin(LitElement)) {
+class ActivityEditorButtons extends RtlMixin(LocalizeActivityEditor(LitElement)) {
 
 	static get styles() {
 		return css`
@@ -37,10 +36,6 @@ class ActivityEditorButtons extends RtlMixin(LocalizeMixin(LitElement)) {
 		`;
 	}
 
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
-	}
-
 	_save() {
 		const event = new CustomEvent('d2l-activity-editor-save', {
 			bubbles: true,
@@ -61,9 +56,9 @@ class ActivityEditorButtons extends RtlMixin(LocalizeMixin(LitElement)) {
 
 	render() {
 		return html`
-			<d2l-button class="desktop" primary @click="${this._save}">${this.localize('btnSave')}</d2l-button>
-			<d2l-button class="mobile footerBtn" primary @click="${this._save}">${this.localize('btnSaveMobile')}</d2l-button>
-			<d2l-button class="footerBtn" @click="${this._cancel}">${this.localize('btnCancel')}</d2l-button>
+			<d2l-button class="desktop" primary @click="${this._save}">${this.localize('d2l-activity-editor.btnSave')}</d2l-button>
+			<d2l-button class="mobile footerBtn" primary @click="${this._save}">${this.localize('d2l-activity-editor.btnSaveMobile')}</d2l-button>
+			<d2l-button class="footerBtn" @click="${this._cancel}">${this.localize('d2l-activity-editor.btnCancel')}</d2l-button>
 		`;
 	}
 }

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -3,11 +3,10 @@ import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/as
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
 import { ActivityEditorTelemetryMixin } from './mixins/d2l-activity-editor-telemetry-mixin';
-import { getLocalizeResources } from './localization';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from './mixins/d2l-activity-editor-lang-mixin.js';
 import { shared as store } from './state/activity-store.js';
 
-class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(ActivityEditorMixin(LocalizeMixin(LitElement)))) {
+class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(ActivityEditorMixin(LocalizeActivityEditor(LitElement)))) {
 
 	static get properties() {
 		return {
@@ -28,10 +27,6 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 				padding: 20px;
 			}
 		`;
-	}
-
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
 	}
 
 	constructor() {
@@ -83,7 +78,7 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 
 	render() {
 		return html`
-			<div ?hidden="${this.asyncState === asyncStates.complete}" class="d2l-activity-editor-loading">${this.localize('loading')}</div>
+			<div ?hidden="${this.asyncState === asyncStates.complete}" class="d2l-activity-editor-loading">${this.localize('d2l-activity-editor.loading')}</div>
 			<div id="editor-container" ?hidden="${this.asyncState !== asyncStates.complete}">
 				<slot name="editor"></slot>
 			</div>

--- a/components/d2l-activity-editor/d2l-activity-grades-dialog.js
+++ b/components/d2l-activity-editor/d2l-activity-grades-dialog.js
@@ -8,14 +8,13 @@ import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
 import { bodySmallStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { formatNumber } from '@brightspace-ui/intl/lib/number.js';
-import { getLocalizeResources } from './localization';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from './mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { radioStyles } from '@brightspace-ui/core/components/inputs/input-radio-styles.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { shared as store } from './state/activity-store.js';
 
-class ActivityGradesDialog extends ActivityEditorMixin(LocalizeMixin(RtlMixin(MobxLitElement))) {
+class ActivityGradesDialog extends ActivityEditorMixin(LocalizeActivityEditor(RtlMixin(MobxLitElement))) {
 
 	static get properties() {
 		return {
@@ -56,10 +55,6 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mo
 			}
 			`
 		];
-	}
-
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
 	}
 
 	constructor() {
@@ -131,7 +126,7 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mo
 		} = activity.scoreAndGrade;
 
 		return html`
-			<d2l-dialog title-text="${this.localize('chooseFromGrades')}" @d2l-dialog-open="${this._onDialogOpen}">
+			<d2l-dialog title-text="${this.localize('d2l-activity-editor.chooseFromGrades')}" @d2l-dialog-open="${this._onDialogOpen}">
 				<label class="d2l-input-radio-label ${!this._canLinkNewGrade ? 'd2l-input-radio-label-disabled' : ''}">
 					<input
 						type="radio"
@@ -140,7 +135,7 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mo
 						?disabled="${!this._canLinkNewGrade}"
 						.checked="${this._createNewRadioChecked}"
 						@change="${this._dialogRadioChanged}">
-					${this.localize('createAndLinkToNewGradeItem')}
+					${this.localize('d2l-activity-editor.createAndLinkToNewGradeItem')}
 				</label>
 				<d2l-input-radio-spacer ?hidden="${!this._createNewRadioChecked && this._canLinkNewGrade}">
 					${this._canLinkNewGrade ? html`
@@ -149,7 +144,7 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mo
 							<div>
 								<div class="d2l-activity-grades-dialog-create-new-activity-name">${newGradeName}</div>
 								<div class="d2l-body-small">${scoreOutOf && !scoreOutOfError ? html`
-									${this.localize('points', { points: formatNumber(scoreOutOf, { maximumFractionDigits: 2 })})}
+									${this.localize('d2l-activity-editor.points', { points: formatNumber(scoreOutOf, { maximumFractionDigits: 2 })})}
 								` : null }
 								</div>
 							</div>
@@ -157,7 +152,7 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mo
 						<d2l-activity-grade-category-selector href="${this.href}" .token="${this.token}"></d2l-activity-grade-category-selector>
 					` : html`
 						<div class="d2l-body-small">
-							${this.localize('noGradeCreatePermission')}
+							${this.localize('d2l-activity-editor.noGradeCreatePermission')}
 						</div>
 					`}
 				</d2l-input-radio-spacer>
@@ -169,18 +164,18 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mo
 						?disabled="${!this._hasGradeCandidates}"
 						.checked="${!this._createNewRadioChecked && this._hasGradeCandidates}"
 						@change="${this._dialogRadioChanged}">
-					${this.localize('linkToExistingGradeItem')}
+					${this.localize('d2l-activity-editor.linkToExistingGradeItem')}
 				</label>
 				<d2l-input-radio-spacer ?hidden="${this._createNewRadioChecked && this._hasGradeCandidates}" ?disabled="${!this._hasGradeCandidates}">
 					${this._hasGradeCandidates ? html`<d2l-activity-grade-candidate-selector
 						href="${this.href}"
 						.token="${this.token}">
 					</d2l-activity-grade-candidate-selector>` : html`<div class="d2l-body-small">
-						${this.localize('noGradeItems')}
+						${this.localize('d2l-activity-editor.noGradeItems')}
 					</div>`}
 				</d2l-input-radio-spacer>
-				<d2l-button slot="footer" primary dialog-action="done">${this.localize('ok')}</d2l-button>
-				<d2l-button slot="footer" dialog-action="cancel">${this.localize('cancel')}</d2l-button>
+				<d2l-button slot="footer" primary dialog-action="done">${this.localize('d2l-activity-editor.ok')}</d2l-button>
+				<d2l-button slot="footer" dialog-action="cancel">${this.localize('d2l-activity-editor.cancel')}</d2l-button>
 			</d2l-dialog>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grade-candidate-selector.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grade-candidate-selector.js
@@ -2,13 +2,12 @@ import { css, html } from 'lit-element/lit-element';
 import { formatNumber, formatPercent } from '@brightspace-ui/intl/lib/number.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { bodySmallStyles } from '@brightspace-ui/core/components/typography/styles.js';
-import { getLocalizeResources } from '../localization.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles';
 import { shared as store } from '../state/activity-store.js';
 
-class ActivityGradeCandidateSelector extends ActivityEditorMixin(LocalizeMixin(MobxLitElement)) {
+class ActivityGradeCandidateSelector extends ActivityEditorMixin(LocalizeActivityEditor(MobxLitElement)) {
 	static get properties() {
 		return {};
 	}
@@ -27,10 +26,6 @@ class ActivityGradeCandidateSelector extends ActivityEditorMixin(LocalizeMixin(M
 			}
 			`
 		];
-	}
-
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
 	}
 
 	constructor() {
@@ -86,7 +81,7 @@ class ActivityGradeCandidateSelector extends ActivityEditorMixin(LocalizeMixin(M
 
 		return html`
 			<select
-				aria-label="${this.localize('gradeItem')}"
+				aria-label="${this.localize('d2l-activity-grades.gradeItem')}"
 				id="grade-candidates"
 				class="d2l-input-select"
 				@change="${this._setSelected}"
@@ -94,8 +89,8 @@ class ActivityGradeCandidateSelector extends ActivityEditorMixin(LocalizeMixin(M
 				${this._renderGradeCandidateTemplates(gradeCandidates, selected)}
 			</select>
 			<div class="d2l-body-small d2l-activity-grade-candidate-selector-points-and-weight">
-				${formattedPoints ? html`${this.localize('points', { points: formattedPoints })}` : ''}
-				${formattedWeight ? html`• ${this.localize('weight', { weight: formattedWeight })}` : ''}
+				${formattedPoints ? html`${this.localize('d2l-activity-grades.points', { points: formattedPoints })}` : ''}
+				${formattedWeight ? html`• ${this.localize('d2l-activity-grades.weight', { weight: formattedWeight })}` : ''}
 			</div>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grade-category-selector.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grade-category-selector.js
@@ -1,13 +1,12 @@
 import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from '../localization.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles';
 import { shared as store } from '../state/activity-store.js';
 
-class ActivityGradeCategorySelector extends ActivityEditorMixin(LocalizeMixin(MobxLitElement)) {
+class ActivityGradeCategorySelector extends ActivityEditorMixin(LocalizeActivityEditor(MobxLitElement)) {
 	static get properties() {
 		return {};
 	}
@@ -32,10 +31,6 @@ class ActivityGradeCategorySelector extends ActivityEditorMixin(LocalizeMixin(Mo
 			}
 			`
 		];
-	}
-
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
 	}
 
 	constructor() {
@@ -66,7 +61,7 @@ class ActivityGradeCategorySelector extends ActivityEditorMixin(LocalizeMixin(Mo
 
 		return html`
 			<div id="d2l-activity-grade-category-selector">
-				<label class="d2l-label-text">${this.localize('newGradeItemCategory')}</label>
+				<label class="d2l-label-text">${this.localize('d2l-activity-grades.newGradeItemCategory')}</label>
 				<select
 					id="grade-categories"
 					class="d2l-input-select"
@@ -74,7 +69,7 @@ class ActivityGradeCategorySelector extends ActivityEditorMixin(LocalizeMixin(Mo
 					>
 					${gradeCandidates.map(gc => html`
 						<option value="${gc.href}" .selected="${selected && gc.href === selected.href}">
-							${gc.name ? gc.name : this.localize('noGradeItemCategory')}
+							${gc.name ? gc.name : this.localize('d2l-activity-grades.noGradeItemCategory')}
 						</option>
 					`)};
 				</select>

--- a/components/d2l-activity-editor/d2l-activity-html-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-editor.js
@@ -1,12 +1,11 @@
 import 'd2l-html-editor/d2l-html-editor.js';
 import 'd2l-html-editor/d2l-html-editor-client.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
-import { getLocalizeResources } from './localization.js';
 import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from './mixins/d2l-activity-editor-lang-mixin.js';
 import { resolveUrl } from '@polymer/polymer/lib/utils/resolve-url.js';
 
-class ActivityHtmlEditor extends LocalizeMixin(LitElement) {
+class ActivityHtmlEditor extends LocalizeActivityEditor(LitElement) {
 
 	static get properties() {
 		return {
@@ -117,10 +116,6 @@ class ActivityHtmlEditor extends LocalizeMixin(LitElement) {
 		`;
 	}
 
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
-	}
-
 	constructor() {
 		super();
 		this._htmlEditorUniqueId = `htmleditor-${getUniqueId()}`;
@@ -152,7 +147,7 @@ class ActivityHtmlEditor extends LocalizeMixin(LitElement) {
 				toolbar="bold italic underline numlist bullist d2l_isf"
 				plugins="lists paste d2l_isf d2l_replacestring">
 
-				<div id="toolbar-shortcut-${this._htmlEditorUniqueId}" hidden="">${this.localize('ariaToolbarShortcutInstructions')}</div>
+				<div id="toolbar-shortcut-${this._htmlEditorUniqueId}" hidden="">${this.localize('d2l-activity-editor.ariaToolbarShortcutInstructions')}</div>
 				<div
 					class="d2l-html-editor-container"
 					id="${this._htmlEditorUniqueId}"

--- a/components/d2l-activity-editor/d2l-activity-outcomes.js
+++ b/components/d2l-activity-editor/d2l-activity-outcomes.js
@@ -4,14 +4,13 @@ import 'd2l-activity-alignments/d2l-select-outcomes.js';
 import { ActivityEditorFeaturesMixin, Milestones } from './mixins/d2l-activity-editor-features-mixin.js';
 import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from './localization';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from './mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { shared as store } from './state/activity-store.js';
 
-class ActivityOutcomes extends ActivityEditorFeaturesMixin(ActivityEditorMixin(LocalizeMixin(RtlMixin(MobxLitElement)))) {
+class ActivityOutcomes extends ActivityEditorFeaturesMixin(ActivityEditorMixin(LocalizeActivityEditor(RtlMixin(MobxLitElement)))) {
 
 	static get properties() {
 		return {
@@ -34,10 +33,6 @@ class ActivityOutcomes extends ActivityEditorFeaturesMixin(ActivityEditorMixin(L
 				display: none;
 			}
 		`];
-	}
-
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
 	}
 
 	constructor() {

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -8,14 +8,13 @@ import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { announce } from '@brightspace-ui/core/helpers/announce.js';
 import { Association } from 'siren-sdk/src/activities/Association.js';
-import { getLocalizeResources } from '../localization.js';
 import { heading4Styles } from '@brightspace-ui/core/components/typography/styles.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import store from './state/association-collection-store.js';
 
-class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(LocalizeMixin(MobxLitElement))) {
+class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(LocalizeActivityEditor(MobxLitElement))) {
 
 	static get properties() {
 		return {
@@ -55,10 +54,6 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 		];
 	}
 
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
-	}
-
 	constructor() {
 		super(store);
 		this._newlyCreatedPotentialAssociation = {};
@@ -84,7 +79,7 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 		const entity = store.get(this.href);
 		if (e && e.detail && e.detail.associations) {
 			entity.addAssociations(e.detail.associations);
-			announce(this.localize('txtRubricAdded'));
+			announce(this.localize('d2l-activity-rubrics.txtRubricAdded'));
 		}
 		this._toggleDialog(false);
 	}
@@ -110,7 +105,7 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 		}
 		entity.addAssociations([this._newlyCreatedPotentialAssociation]);
 		this._closeEditNewAssociationOverlay();
-		announce(this.localize('txtRubricAdded'));
+		announce(this.localize('d2l-activity-rubrics.txtRubricAdded'));
 	}
 
 	async _createNewAssociation() {
@@ -168,18 +163,18 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 
 		return html`
 		<d2l-dropdown-button-subtle
-			text="${this.localize('btnAddRubric')}"
+			text="${this.localize('d2l-activity-rubrics.btnAddRubric')}"
 		>
 			<d2l-dropdown-menu align="start">
-				<d2l-menu label="${this.localize('btnAddRubric')}">
+				<d2l-menu label="${this.localize('d2l-activity-rubrics.btnAddRubric')}">
 					<d2l-menu-item
-						text="${this.localize('btnCreateNew')}"
+						text="${this.localize('d2l-activity-rubrics.btnCreateNew')}"
 						@d2l-menu-item-select="${this._createNewAssociation}"
 						?hidden=${!canCreatePotentialAssociation}
 					>
 					</d2l-menu-item>
 					<d2l-menu-item
-						text="${this.localize('btnAddExisting')}"
+						text="${this.localize('d2l-activity-rubrics.btnAddExisting')}"
 						@d2l-menu-item-select="${this._openAttachRubricDialog}"
 						?hidden=${!canCreateAssociation}
 					>
@@ -202,7 +197,7 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 		return html`
 			<div class="rubric-heading-container">
 				<h3 class="d2l-heading-4 rubric-heading-title">
-					${this.localize('hdrRubrics')}
+					${this.localize('d2l-activity-rubrics.hdrRubrics')}
 				</h3>
 			</div>
 			<d2l-activity-rubrics-list-editor
@@ -215,7 +210,7 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 
 			<d2l-simple-overlay
 				id="create-new-association-dialog"
-				close-simple-overlay-alt-text="${this.localize('btnClose')}"
+				close-simple-overlay-alt-text="${this.localize('d2l-activity-rubrics.btnClose')}"
 				no-cancel-on-outside-click
 				@d2l-simple-overlay-close-button-clicked="${this._clearNewRubricHref}"
 				@d2l-simple-overlay-canceled="${this._clearNewRubricHref}"
@@ -223,10 +218,10 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 				${this._renderRubricEditor()}
 				<d2l-floating-buttons always-float>
 					<d2l-button primary @click="${this._attachRubric}">
-						${this.localize('btnAttachRubric')}
+						${this.localize('d2l-activity-rubrics.btnAttachRubric')}
 					</d2l-button>
 					<d2l-button @click="${this._closeEditNewAssociationOverlay}">
-						${this.localize('btnCancel')}
+						${this.localize('d2l-activity-rubrics.btnCancel')}
 					</d2l-button>
 				</d2l-floating-buttons>
 			</d2l-simple-overlay>
@@ -236,7 +231,7 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 				@associations-done-work="${this._closeAttachRubricDialog}"
 				@associations-resize-dialog="${this._resizeDialog}"
 				width="700"
-				title-text="${this.localize('txtAddExisting')}"
+				title-text="${this.localize('d2l-activity-rubrics.txtAddExisting')}"
 			>
 				<d2l-add-associations
 					.token="${this.token}"

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
@@ -4,13 +4,13 @@ import '@brightspace-ui/core/components/dialog/dialog-confirm';
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { announce } from '@brightspace-ui/core/helpers/announce.js';
-import { getLocalizeResources } from '../localization.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import store from './state/association-collection-store';
 
-class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeMixin(RtlMixin((MobxLitElement)))) {
+
+class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEditor(RtlMixin((MobxLitElement)))) {
 
 	static get styles() {
 		return [
@@ -41,10 +41,6 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeMixin(RtlMix
 		];
 	}
 
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
-	}
-
 	constructor() {
 		super(store);
 	}
@@ -55,7 +51,7 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeMixin(RtlMix
 			return;
 		}
 		entity.deleteAssociation(e.target.dataset.id);
-		announce(this.localize('txtRubricRemoved'));
+		announce(this.localize('d2l-activity-rubrics.txtRubricRemoved'));
 	}
 
 	async save() {
@@ -86,7 +82,7 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeMixin(RtlMix
 					icon="tier1:close-default"
 					data-id="${association.rubricHref}"
 					@click="${this._deleteAssociation}"
-					text=${this.localize('txtDeleteRubric')}
+					text=${this.localize('d2l-activity-rubrics.txtDeleteRubric')}
 				></d2l-button-icon>
 			</div>
 			`;

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-wrapper.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-wrapper.js
@@ -1,17 +1,11 @@
 import './d2l-activity-rubrics-list-container';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from '../localization';
 import { html } from 'lit-element/lit-element';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { shared as store } from '../state/activity-store';
 
 class ActivityRubricsListWrapper
-	extends ActivityEditorMixin(LocalizeMixin(MobxLitElement)) {
-
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
-	}
+	extends ActivityEditorMixin(MobxLitElement) {
 
 	constructor() {
 		super(store);

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-summary-wrapper.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-summary-wrapper.js
@@ -1,17 +1,11 @@
 import './d2l-activity-rubrics-summary';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from '../localization';
 import { html } from 'lit-element/lit-element';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { shared as store } from '../state/activity-store';
 
 class ActivityRubricsSummaryWrapper
-	extends ActivityEditorMixin(LocalizeMixin(MobxLitElement)) {
-
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
-	}
+	extends ActivityEditorMixin(MobxLitElement) {
 
 	constructor() {
 		super(store);

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-summary.js
@@ -1,16 +1,11 @@
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from '../localization';
 import { html } from 'lit-element/lit-element';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import store from '../d2l-activity-rubrics/state/association-collection-store.js';
 
 class ActivityRubricsSummary
-	extends ActivityEditorMixin(LocalizeMixin(MobxLitElement)) {
-
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
-	}
+	extends ActivityEditorMixin(LocalizeActivityEditor(MobxLitElement)) {
 
 	constructor() {
 		super(store);
@@ -24,10 +19,10 @@ class ActivityRubricsSummary
 
 		const associationsCount = entity.fetchAttachedAssociationsCount();
 		if (associationsCount <= 0) {
-			return html`${this.localize('txtNoRubricAdded')}`;
+			return html`${this.localize('d2l-activity-rubrics.txtNoRubricAdded')}`;
 		}
 
-		return html`${this.localize('txtRubricsAdded', 'count', associationsCount)}`;
+		return html`${this.localize('d2l-activity-rubrics.txtRubricsAdded', 'count', associationsCount)}`;
 	}
 }
 

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -12,14 +12,13 @@ import 'd2l-tooltip/d2l-tooltip';
 import { bodyCompactStyles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from './localization';
 import { inputStyles } from '@brightspace-ui/core/components/inputs/input-styles.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from './mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { shared as store } from './state/activity-store.js';
 
-class ActivityScoreEditor extends ActivityEditorMixin(LocalizeMixin(RtlMixin(MobxLitElement))) {
+class ActivityScoreEditor extends ActivityEditorMixin(LocalizeActivityEditor(RtlMixin(MobxLitElement))) {
 
 	static get properties() {
 		return {
@@ -141,10 +140,6 @@ class ActivityScoreEditor extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mob
 		];
 	}
 
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
-	}
-
 	constructor() {
 		super(store);
 	}
@@ -212,12 +207,12 @@ class ActivityScoreEditor extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mob
 		const scoreAndGrade = store.get(this.href).scoreAndGrade;
 		return scoreAndGrade.inGrades ? html`
 			<d2l-menu-item
-				text="${this.localize('removeFromGrades')}"
+				text="${this.localize('d2l-activity-editor.removeFromGrades')}"
 				@d2l-menu-item-select="${this._removeFromGrades}"
 			></d2l-menu-item>
 		` : scoreAndGrade.canEditGrades ? html`
 			<d2l-menu-item
-				text="${this.localize('addToGrades')}"
+				text="${this.localize('d2l-activity-editor.addToGrades')}"
 				@d2l-menu-item-select="${this._addToGrades}"
 			></d2l-menu-item>
 		` : null;
@@ -252,9 +247,9 @@ class ActivityScoreEditor extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mob
 			<div id="ungraded-button-container">
 				<button id="ungraded" class="d2l-input"
 					@click="${this._setGraded}"
-					aria-label="${this.localize('addAGrade')}"
+					aria-label="${this.localize('d2l-activity-editor.addAGrade')}"
 				>
-					${this.localize('ungraded')}
+					${this.localize('d2l-activity-editor.ungraded')}
 				</button>
 			</div>
 		` : html`
@@ -262,7 +257,7 @@ class ActivityScoreEditor extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mob
 				<div id="score-out-of-container">
 					<d2l-input-text
 						id="score-out-of"
-						label="${this.localize('scoreOutOf')}"
+						label="${this.localize('d2l-activity-editor.scoreOutOf')}"
 						label-hidden
 						value="${scoreOutOf}"
 						size=4
@@ -290,18 +285,18 @@ class ActivityScoreEditor extends ActivityEditorMixin(LocalizeMixin(RtlMixin(Mob
 						<d2l-dropdown>
 							<button class="d2l-label-text grade-info d2l-dropdown-opener">
 								${inGrades ? html`<d2l-icon icon="tier1:grade"></d2l-icon>` : null}
-								<div>${inGrades ? this.localize('inGrades') : this.localize('notInGrades')}</div>
+								<div>${inGrades ? this.localize('d2l-activity-editor.inGrades') : this.localize('d2l-activity-editor.notInGrades')}</div>
 								<d2l-icon icon="tier1:chevron-down"></d2l-icon>
 							</button>
 							<d2l-dropdown-menu id="grade-dropdown" align="start" no-pointer vertical-offset="3px">
-								<d2l-menu label="${inGrades ? this.localize('inGrades') : this.localize('notInGrades')}">
+								<d2l-menu label="${inGrades ? this.localize('d2l-activity-editor.inGrades') : this.localize('d2l-activity-editor.notInGrades')}">
 									<d2l-menu-item
-										text="${this.localize('chooseFromGrades')}"
+										text="${this.localize('d2l-activity-editor.chooseFromGrades')}"
 										@d2l-menu-item-select="${this._chooseFromGrades}"
 									></d2l-menu-item>
 									${this._addOrRemoveMenuItem()}
 									<d2l-menu-item
-										text="${this.localize('setUngraded')}"
+										text="${this.localize('d2l-activity-editor.setUngraded')}"
 										@d2l-menu-item-select="${this._setUngraded}"
 									></d2l-menu-item>
 								</d2l-menu>

--- a/components/d2l-activity-editor/d2l-activity-special-access-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-special-access-editor.js
@@ -4,13 +4,12 @@ import '@brightspace-ui/core/components/button/button-subtle.js';
 import { bodySmallStyles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
-import { getLocalizeResources } from './localization';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from './mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { shared as store } from './state/activity-store.js';
 
-class ActivitySpecialAccessEditor extends ActivityEditorMixin(RtlMixin(LocalizeMixin(MobxLitElement))) {
+class ActivitySpecialAccessEditor extends ActivityEditorMixin(RtlMixin(LocalizeActivityEditor(MobxLitElement))) {
 
 	static get properties() {
 
@@ -44,10 +43,6 @@ class ActivitySpecialAccessEditor extends ActivityEditorMixin(RtlMixin(LocalizeM
 		];
 	}
 
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, import.meta.url);
-	}
-
 	constructor() {
 		super();
 		this.description = '';
@@ -63,8 +58,8 @@ class ActivitySpecialAccessEditor extends ActivityEditorMixin(RtlMixin(LocalizeM
 				</p>
 			`;
 		} else {
-			const specialAccessTypeDescription = isRestricted ? html`${this.localize('specialAccessRestrictedText')}` : html`${this.localize('specialAccessNotRestrictedText')}`;
-			const userCountText = html`${this.localize('specialAccessCount', { count: userCount })}`;
+			const specialAccessTypeDescription = isRestricted ? html`${this.localize('d2l-activity-editor.specialAccessRestrictedText')}` : html`${this.localize('d2l-activity-editor.specialAccessNotRestrictedText')}`;
+			const userCountText = html`${this.localize('d2l-activity-editor.specialAccessCount', { count: userCount })}`;
 			return html`
 				<label class="d2l-label-text">${specialAccessTypeDescription}</label>
 				<div class="special-access-user-count-container">
@@ -78,7 +73,7 @@ class ActivitySpecialAccessEditor extends ActivityEditorMixin(RtlMixin(LocalizeM
 	_renderManageButton() {
 		return html`
 			<d2l-button-subtle
-				text="${this.localize('btnManageSpecialAccess')}">
+				text="${this.localize('d2l-activity-editor.btnManageSpecialAccess')}">
 			</d2l-button-subtle>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-visibility-editor-toggle.js
+++ b/components/d2l-activity-editor/d2l-activity-visibility-editor-toggle.js
@@ -1,12 +1,11 @@
 import '@brightspace-ui/core/components/switch/switch-visibility.js';
 import { css, html, LitElement } from 'lit-element/lit-element';
 import { classMap } from 'lit-html/directives/class-map.js';
-import { getLocalizeResources } from './localization';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditor } from './mixins/d2l-activity-editor-lang-mixin.js';
 import { offscreenStyles } from '@brightspace-ui/core/components/offscreen/offscreen.js';
 
 const baseUrl = import.meta.url;
-class ActivityVisibilityEditorToggle extends LocalizeMixin(LitElement) {
+class ActivityVisibilityEditorToggle extends LocalizeActivityEditor(LitElement) {
 
 	static get properties() {
 		return {
@@ -26,10 +25,6 @@ class ActivityVisibilityEditorToggle extends LocalizeMixin(LitElement) {
 				display: none;
 			}
 		`];
-	}
-
-	static async getLocalizeResources(langs) {
-		return getLocalizeResources(langs, baseUrl);
 	}
 
 	constructor() {
@@ -77,7 +72,7 @@ class ActivityVisibilityEditorToggle extends LocalizeMixin(LitElement) {
 				<div class="d2l-label-text">
 					<d2l-icon icon="${this.isDraft ? 'tier1:visibility-hide' : 'tier1:visibility-show'}"></d2l-icon>
 					<span class="${classMap({'d2l-offscreen': this._textHidden})}">
-						${this.isDraft ? this.localize('hidden') : this.localize('visible')}
+						${this.isDraft ? this.localize('d2l-activity-editor.hidden') : this.localize('d2l-activity-editor.visible')}
 					</span>
 				</div>
 			`;

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -75,5 +75,11 @@ export default {
 	"d2l-activity-rubrics.txtDeleteRubric": "zzDelete Rubric", // Text for deleting rubric icon
 	"d2l-activity-rubrics.btnClose": "Close", // X button for exiting the create new rubric overlay
 	"d2l-activity-rubrics.txtRubricAdded": "Rubric added", // Text for notifying screenreader rubric was added
-	"d2l-activity-rubrics.txtRubricRemoved": "Rubric removed" // Text for notifying screenreader rubric was removed 
+	"d2l-activity-rubrics.txtRubricRemoved": "Rubric removed", // Text for notifying screenreader rubric was removed 
+
+	"d2l-activity-grades.points": "Points: {points}", // Text label for displaying points of a grade
+	"d2l-activity-grades.weight": "Weight: {weight}", // Text label for displaying weight of a grade
+	"d2l-activity-grades.gradeItem": "Grade Item", //ARIA label for grade-item picker when linking an activity to an existing grade item
+	"d2l-activity-grades.newGradeItemCategory": "Grade Category", // Label for selecting a category dropdown
+	"d2l-activity-grades.noGradeItemCategory": "No Category", // Category dropdown text for not selecting a category
 };

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -82,4 +82,21 @@ export default {
 	"d2l-activity-grades.gradeItem": "Grade Item", //ARIA label for grade-item picker when linking an activity to an existing grade item
 	"d2l-activity-grades.newGradeItemCategory": "Grade Category", // Label for selecting a category dropdown
 	"d2l-activity-grades.noGradeItemCategory": "No Category", // Category dropdown text for not selecting a category
+
+	"d2l-activity-attachments.addGoogleDriveLink": "Attach from Google Drive", // Tooltip for a button that adds a link to a Google Drive file
+	"d2l-activity-attachments.ddFile": "File Upload", // Tooltip for a button that opens a file upload dialog
+	"d2l-activity-attachments.addLink": "Attach Weblink", // Tooltip for a button that adds a link to a URL
+	"d2l-activity-attachments.addOneDriveLink": "Attach from OneDrive", // Tooltip for a button that adds a link to a OneDrive file
+	"d2l-activity-attachments.addQuicklink": "Attach Link to Existing Activity", // Tooltip for a button that adds a link to an existing activity
+	"d2l-activity-attachments.back": "Back", // Text for a back button
+	"d2l-activity-attachments.closeDialog": "Close Dialog", // ARIA text for button to close dialog
+	"d2l-activity-attachments.recordAudio": "Record Audio", // Text for a button that opens a dialog to record audio
+	"d2l-activity-attachments.recordVideo": "Record Video", // Text for a button that opens a dialog to record video
+	"d2l-activity-attachments.save": "Save", // Text for a save button,
+	"d2l-activity-attachments.attach": "Attach", // Text for Attach button to open attachment row
+	"d2l-activity-attachments.addGoogleDriveLinkMenu": "Google Drive", // Attach menu item text
+	"d2l-activity-attachments.addFileMenu": "File Upload", // Attach menu item text
+	"d2l-activity-attachments.addLinkMenu": "Weblink", // Attach menu item text
+	"d2l-activity-attachments.addOneDriveLinkMenu": "OneDrive", // Attach menu item text
+	"d2l-activity-attachments.addQuicklinkMenu": "Existing Activity" // Attach menu item text
 };

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -61,5 +61,19 @@ export default {
 	"btnManageSpecialAccess": "Manage Special Access", // manage special access button
 	"specialAccessRestrictedText": "Only users with special access can see this folder", // restricted special access description
 	"specialAccessNotRestrictedText": "Users can submit outside normal availability dates", // not restricted special access description
-	"specialAccessCount": "{count, plural, =1 {1 user} other {{count} users}} with special access" // Label for number of special access users
+	"specialAccessCount": "{count, plural, =1 {1 user} other {{count} users}} with special access", // Label for number of special access users
+
+	"d2l-activity-rubrics.btnAddRubric": "Add rubric", //text for add rubric button
+	"d2l-activity-rubrics.btnCreateNew": "Create New", //Text for create new dropdown
+	"d2l-activity-rubrics.btnAddExisting": "Add Existing", //Text for Add Existing dropdown
+	"d2l-activity-rubrics.hdrRubrics": "Rubrics", //Header for the rubrics section
+	"d2l-activity-rubrics.btnAttachRubric": "zzAttach Rubric", //Button for the attach new rubric overlay
+	"d2l-activity-rubrics.btnCancel": "Cancel", //Button for canceling out of the attach new rubric overlay
+	"d2l-activity-rubrics.txtAddExisting": "zzzAdd Existing", //Title for the attach rubrics dialog,
+	"d2l-activity-rubrics.txtNoRubricAdded": "No rubric added", // rubric summary for no rubrics
+	"d2l-activity-rubrics.txtRubricsAdded": "{count, plural, =1 {1 rubric added} other {{count} rubrics added}}", // count of asoociated rubrics
+	"d2l-activity-rubrics.txtDeleteRubric": "zzDelete Rubric", // Text for deleting rubric icon
+	"d2l-activity-rubrics.btnClose": "Close", // X button for exiting the create new rubric overlay
+	"d2l-activity-rubrics.txtRubricAdded": "Rubric added", // Text for notifying screenreader rubric was added
+	"d2l-activity-rubrics.txtRubricRemoved": "Rubric removed" // Text for notifying screenreader rubric was removed 
 };

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -1,72 +1,72 @@
 /* eslint quotes: 0 */
 
 export default {
-	"btnEditReleaseConditions": "Edit Release Conditions", // edit release conditions button
-	"btnAddReleaseCondition": "Add Release Condition", // add release condition button
-	"btnCreateNew": "Create New", // create new button
-	"btnAddExisting": "Add Existing", // add existing button
-	"btnRemoveCondition": "Remove Condition", // remove condition button
-	"lblConditionsOperator": "To view this item, users must satisfy", // conditions operator label
-	"txtNumReleaseConditions": "{count, plural, =1 {{count} Release Condition} other {{count} Release Conditions}}", // num release condition text
-	"btnCancel": "Cancel", // cancel button
-	"btnSave": "Save and Close", // save and close button
-	"btnSaveMobile": "Save", // save and close button for mobile devices
-	"dueDate": "Due Date", // ARIA label for the due date field when creating/editing an activity
-	"endDate": "End Date", // ARIA label for the end date field when creating/editing an activity
-	"startDate": "Start Date", // ARIA label for the start date field when creating/editing an activity
-	"dueTime": "Due Time", // ARIA label for the due time field when creating/editing an activity
-	"endTime": "End Time", // ARIA label for the end time field when creating/editing an activity
-	"startTime": "Start Time", // ARIA label for the start time field when creating/editing an activity
-	"hidden": "Hidden", // Label displayed with the visibility switch when hidden
-	"noDueDate": "No due date", // Placeholder text for due date field when no due date is set
-	"noEndDate": "No end date", // Placeholder text for due date field when no due date is set
-	"noStartDate": "No start date", // Placeholder text for due date field when no due date is set
-	"visible": "Visible", // Label displayed with the visibility switch when visible
-	"txtAvailabilityStartAndEnd": "Availability starts {startDate} and ends {endDate}", // start/end text
-	"txtAvailabilityStartOnly": "Availability starts {startDate}", // start only text
-	"txtAvailabilityEndOnly": "Availability ends {endDate}", // end only text
-	"txtAvailabilityNeither": "Always available", // always available text
-	"ungraded": "Ungraded", // State of score field when there is no score and no grade item, when creating/editing an activity
-	"inGrades": "In Grades", // State of the grades field when there is a score, and an associated grade item
-	"notInGrades": "Not in Grades", // State of the grades field when there is a score, but no associated grade item
-	"addToGrades": "Add to Grades", // Menu item for adding grade association
-	"addAGrade": "Add a Grade", //ARIA label to add a grade to the activity
-	"removeFromGrades": "Remove from Grades", // Menu item for removing grade association
-	"setUngraded": "Reset to Ungraded", // Menu item for setting the activity to ungraded
-	"scoreOutOf": "Score Out Of", // ARIA label for the score out of field, when creating/editing an activity
-	"emptyScoreOutOfError": "A points value must be specified for activities in Grades", // Error message to inform user that the score out of value is a required field when a grade item is associated
-	"invalidScoreOutOfError": "Score Out Of must be greater than or equal to 0.01 and less than or equal to 9,999,999,999", // Error message when an invalid score out of value is entered
-	"loading": "Loading...", // Message displayed while page is loading
-	"ok": "OK", // Text of dialog button to commit action
-	"cancel": "Cancel", // Text of dialog button to cancel action
-	"ariaToolbarShortcutInstructions": "Press ALT-F10 for toolbar, and press ESC to exit toolbar once inside.", // Instructions for screenreader users on how to enter and exit the html editor toolbar
-	"chooseFromGrades": "Choose from Grades", // Link text and dialog title for the edit grades dialog,
-	"hdrRubrics": "Rubrics", //Header for the rubrics section
-	"startBeforeEndDate": "Start Date must be before End Date",
-	"dueBetweenStartEndDate": "Due Date must be after Start Date and before or equal to End Date",
-	"dueAfterStartDate": "Due Date must be after Start Date",
-	"dueBeforeEndDate": "Due Date must be before or equal to End Date",
-	"createAndLinkToNewGradeItem": "Create and link to a new grade item", //Radio button text
-	"linkToExistingGradeItem": "Link to an existing grade item", //Radio button text
-	"points": "Points: {points}", // Text label for displaying points of a grade
-	"noGradeItems": "No existing grade items", // Reason why existing grade items cannot be linked in the choose grades dialog
-	"noGradeCreatePermission": "You do not have permission to create a new grade item", // Reason why a new grade items cannot be created in the choose grades dialog
-	"competencies": "Learning Objectives", //Text label for the competencies tool integration
-	"manageCompetencies": "Manage Learning Objectives", //Button text to launch competencies tool dialog
-	"competenciesCount": "{count, plural, =0 {No learning objectives} =1 {1 attached} other {{count} attached}}", //Label for number of associated competencies
-	"competenciesCountSummary": "{count, plural, =0 {No learning objectives} =1 {1 learning objective} other {{count} learning objectives}}",
-	"unevaluatedCompetencies": "{count, plural, =1 {1 missing assessment} other {{count} missing assessments}}", //Label for number of unevalated associated competencies
-	"btnClose": "Close", //Label for Close button
-	"btnCloseDialog": "Close this Dialog", // close dialog button
-	"btnManageSpecialAccess": "Manage Special Access", // manage special access button
-	"specialAccessRestrictedText": "Only users with special access can see this folder", // restricted special access description
-	"specialAccessNotRestrictedText": "Users can submit outside normal availability dates", // not restricted special access description
-	"specialAccessCount": "{count, plural, =1 {1 user} other {{count} users}} with special access", // Label for number of special access users
+	"d2l-activity-editor.btnEditReleaseConditions": "Edit Release Conditions", // edit release conditions button
+	"d2l-activity-editor.btnAddReleaseCondition": "Add Release Condition", // add release condition button
+	"d2l-activity-editor.btnCreateNew": "Create New", // create new button
+	"d2l-activity-editor.btnAddExisting": "Add Existing", // add existing button
+	"d2l-activity-editor.btnRemoveCondition": "Remove Condition", // remove condition button
+	"d2l-activity-editor.lblConditionsOperator": "To view this item, users must satisfy", // conditions operator label
+	"d2l-activity-editor.txtNumReleaseConditions": "{count, plural, =1 {{count} Release Condition} other {{count} Release Conditions}}", // num release condition text
+	"d2l-activity-editor.btnCancel": "Cancel", // cancel button
+	"d2l-activity-editor.btnSave": "Save and Close", // save and close button
+	"d2l-activity-editor.btnSaveMobile": "Save", // save and close button for mobile devices
+	"d2l-activity-editor.dueDate": "Due Date", // ARIA label for the due date field when creating/editing an activity
+	"d2l-activity-editor.endDate": "End Date", // ARIA label for the end date field when creating/editing an activity
+	"d2l-activity-editor.startDate": "Start Date", // ARIA label for the start date field when creating/editing an activity
+	"d2l-activity-editor.dueTime": "Due Time", // ARIA label for the due time field when creating/editing an activity
+	"d2l-activity-editor.endTime": "End Time", // ARIA label for the end time field when creating/editing an activity
+	"d2l-activity-editor.startTime": "Start Time", // ARIA label for the start time field when creating/editing an activity
+	"d2l-activity-editor.hidden": "Hidden", // Label displayed with the visibility switch when hidden
+	"d2l-activity-editor.noDueDate": "No due date", // Placeholder text for due date field when no due date is set
+	"d2l-activity-editor.noEndDate": "No end date", // Placeholder text for due date field when no due date is set
+	"d2l-activity-editor.noStartDate": "No start date", // Placeholder text for due date field when no due date is set
+	"d2l-activity-editor.visible": "Visible", // Label displayed with the visibility switch when visible
+	"d2l-activity-editor.txtAvailabilityStartAndEnd": "Availability starts {startDate} and ends {endDate}", // start/end text
+	"d2l-activity-editor.txtAvailabilityStartOnly": "Availability starts {startDate}", // start only text
+	"d2l-activity-editor.txtAvailabilityEndOnly": "Availability ends {endDate}", // end only text
+	"d2l-activity-editor.txtAvailabilityNeither": "Always available", // always available text
+	"d2l-activity-editor.ungraded": "Ungraded", // State of score field when there is no score and no grade item, when creating/editing an activity
+	"d2l-activity-editor.inGrades": "In Grades", // State of the grades field when there is a score, and an associated grade item
+	"d2l-activity-editor.notInGrades": "Not in Grades", // State of the grades field when there is a score, but no associated grade item
+	"d2l-activity-editor.addToGrades": "Add to Grades", // Menu item for adding grade association
+	"d2l-activity-editor.addAGrade": "Add a Grade", //ARIA label to add a grade to the activity
+	"d2l-activity-editor.removeFromGrades": "Remove from Grades", // Menu item for removing grade association
+	"d2l-activity-editor.setUngraded": "Reset to Ungraded", // Menu item for setting the activity to ungraded
+	"d2l-activity-editor.scoreOutOf": "Score Out Of", // ARIA label for the score out of field, when creating/editing an activity
+	"d2l-activity-editor.emptyScoreOutOfError": "A points value must be specified for activities in Grades", // Error message to inform user that the score out of value is a required field when a grade item is associated
+	"d2l-activity-editor.invalidScoreOutOfError": "Score Out Of must be greater than or equal to 0.01 and less than or equal to 9,999,999,999", // Error message when an invalid score out of value is entered
+	"d2l-activity-editor.loading": "Loading...", // Message displayed while page is loading
+	"d2l-activity-editor.ok": "OK", // Text of dialog button to commit action
+	"d2l-activity-editor.cancel": "Cancel", // Text of dialog button to cancel action
+	"d2l-activity-editor.ariaToolbarShortcutInstructions": "Press ALT-F10 for toolbar, and press ESC to exit toolbar once inside.", // Instructions for screenreader users on how to enter and exit the html editor toolbar
+	"d2l-activity-editor.chooseFromGrades": "Choose from Grades", // Link text and dialog title for the edit grades dialog,
+	"d2l-activity-editor.hdrRubrics": "Rubrics", //Header for the rubrics section
+	"d2l-activity-editor.startBeforeEndDate": "Start Date must be before End Date",
+	"d2l-activity-editor.dueBetweenStartEndDate": "Due Date must be after Start Date and before or equal to End Date",
+	"d2l-activity-editor.dueAfterStartDate": "Due Date must be after Start Date",
+	"d2l-activity-editor.dueBeforeEndDate": "Due Date must be before or equal to End Date",
+	"d2l-activity-editor.createAndLinkToNewGradeItem": "Create and link to a new grade item", //Radio button text
+	"d2l-activity-editor.linkToExistingGradeItem": "Link to an existing grade item", //Radio button text
+	"d2l-activity-editor.points": "Points: {points}", // Text label for displaying points of a grade
+	"d2l-activity-editor.noGradeItems": "No existing grade items", // Reason why existing grade items cannot be linked in the choose grades dialog
+	"d2l-activity-editor.noGradeCreatePermission": "You do not have permission to create a new grade item", // Reason why a new grade items cannot be created in the choose grades dialog
+	"d2l-activity-editor.competencies": "Learning Objectives", //Text label for the competencies tool integration
+	"d2l-activity-editor.manageCompetencies": "Manage Learning Objectives", //Button text to launch competencies tool dialog
+	"d2l-activity-editor.competenciesCount": "{count, plural, =0 {No learning objectives} =1 {1 attached} other {{count} attached}}", //Label for number of associated competencies
+	"d2l-activity-editor.competenciesCountSummary": "{count, plural, =0 {No learning objectives} =1 {1 learning objective} other {{count} learning objectives}}",
+	"d2l-activity-editor.unevaluatedCompetencies": "{count, plural, =1 {1 missing assessment} other {{count} missing assessments}}", //Label for number of unevalated associated competencies
+	"d2l-activity-editor.btnClose": "Close", //Label for Close button
+	"d2l-activity-editor.btnCloseDialog": "Close this Dialog", // close dialog button
+	"d2l-activity-editor.btnManageSpecialAccess": "Manage Special Access", // manage special access button
+	"d2l-activity-editor.specialAccessRestrictedText": "Only users with special access can see this folder", // restricted special access description
+	"d2l-activity-editor.specialAccessNotRestrictedText": "Users can submit outside normal availability dates", // not restricted special access description
+	"d2l-activity-editor.specialAccessCount": "{count, plural, =1 {1 user} other {{count} users}} with special access", // Label for number of special access users
 
 	"d2l-activity-rubrics.btnAddRubric": "Add rubric", //text for add rubric button
 	"d2l-activity-rubrics.btnCreateNew": "Create New", //Text for create new dropdown
 	"d2l-activity-rubrics.btnAddExisting": "Add Existing", //Text for Add Existing dropdown
-	"d2l-activity-rubrics.hdrRubrics": "Rubrics", //Header for the rubrics section
+	"d2l-activity-rubrics.hdrRubrics": "zzRubrics", //Header for the rubrics section
 	"d2l-activity-rubrics.btnAttachRubric": "Attach Rubric", //Button for the attach new rubric overlay
 	"d2l-activity-rubrics.btnCancel": "Cancel", //Button for canceling out of the attach new rubric overlay
 	"d2l-activity-rubrics.txtAddExisting": "Add Existing", //Title for the attach rubrics dialog,

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -66,7 +66,7 @@ export default {
 	"d2l-activity-rubrics.btnAddRubric": "Add rubric", //text for add rubric button
 	"d2l-activity-rubrics.btnCreateNew": "Create New", //Text for create new dropdown
 	"d2l-activity-rubrics.btnAddExisting": "Add Existing", //Text for Add Existing dropdown
-	"d2l-activity-rubrics.hdrRubrics": "zzRubrics", //Header for the rubrics section
+	"d2l-activity-rubrics.hdrRubrics": "Rubrics", //Header for the rubrics section
 	"d2l-activity-rubrics.btnAttachRubric": "Attach Rubric", //Button for the attach new rubric overlay
 	"d2l-activity-rubrics.btnCancel": "Cancel", //Button for canceling out of the attach new rubric overlay
 	"d2l-activity-rubrics.txtAddExisting": "Add Existing", //Title for the attach rubrics dialog,

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -67,12 +67,12 @@ export default {
 	"d2l-activity-rubrics.btnCreateNew": "Create New", //Text for create new dropdown
 	"d2l-activity-rubrics.btnAddExisting": "Add Existing", //Text for Add Existing dropdown
 	"d2l-activity-rubrics.hdrRubrics": "Rubrics", //Header for the rubrics section
-	"d2l-activity-rubrics.btnAttachRubric": "zzAttach Rubric", //Button for the attach new rubric overlay
+	"d2l-activity-rubrics.btnAttachRubric": "Attach Rubric", //Button for the attach new rubric overlay
 	"d2l-activity-rubrics.btnCancel": "Cancel", //Button for canceling out of the attach new rubric overlay
-	"d2l-activity-rubrics.txtAddExisting": "zzzAdd Existing", //Title for the attach rubrics dialog,
+	"d2l-activity-rubrics.txtAddExisting": "Add Existing", //Title for the attach rubrics dialog,
 	"d2l-activity-rubrics.txtNoRubricAdded": "No rubric added", // rubric summary for no rubrics
 	"d2l-activity-rubrics.txtRubricsAdded": "{count, plural, =1 {1 rubric added} other {{count} rubrics added}}", // count of asoociated rubrics
-	"d2l-activity-rubrics.txtDeleteRubric": "zzDelete Rubric", // Text for deleting rubric icon
+	"d2l-activity-rubrics.txtDeleteRubric": "Delete Rubric", // Text for deleting rubric icon
 	"d2l-activity-rubrics.btnClose": "Close", // X button for exiting the create new rubric overlay
 	"d2l-activity-rubrics.txtRubricAdded": "Rubric added", // Text for notifying screenreader rubric was added
 	"d2l-activity-rubrics.txtRubricRemoved": "Rubric removed", // Text for notifying screenreader rubric was removed 
@@ -98,5 +98,53 @@ export default {
 	"d2l-activity-attachments.addFileMenu": "File Upload", // Attach menu item text
 	"d2l-activity-attachments.addLinkMenu": "Weblink", // Attach menu item text
 	"d2l-activity-attachments.addOneDriveLinkMenu": "OneDrive", // Attach menu item text
-	"d2l-activity-attachments.addQuicklinkMenu": "Existing Activity" // Attach menu item text
+	"d2l-activity-attachments.addQuicklinkMenu": "Existing Activity", // Attach menu item text
+
+	"d2l-activity-assignment-editor.hdrReleaseConditions": "Release Conditions", // release conditions heading
+	"d2l-activity-assignment-editor.hlpReleaseConditions": "Users are not able to access or view the assignment unless they meet the release conditions.", // release conditions help
+	"d2l-activity-assignment-editor.completionType": "Marked as completed", // Label for the completion type field when creating/editing an assignment
+	"d2l-activity-assignment-editor.lblAnonymousMarking": "Anonymous Marking", // Label for anonymous marking
+	"d2l-activity-assignment-editor.chkAnonymousMarking": "Hide student names during assessment", // Checkbox for anonymous marking
+	"d2l-activity-assignment-editor.dueDate": "Due Date", // ARIA label for the due date field when creating/editing an activity
+	"d2l-activity-assignment-editor.txtAnnotationsOff": "Annotations off", // annotations off text
+	"d2l-activity-assignment-editor.emptyNameError": "Name is required", // Error message to inform user that the assignment name is a required field
+	"d2l-activity-assignment-editor.instructions": "Instructions", // Label for the instruction field when creating/editing an assignment
+	"d2l-activity-assignment-editor.hdrTurnitin": "Turnitin Integration", // turnitin heading
+	"d2l-activity-assignment-editor.hlpTurnitin": "Turnitin® adds additional functionality to evaluation.", // turnitin help
+	"d2l-activity-assignment-editor.btnEditTurnitin": "Manage Turnitin", // edit turnitin button
+	"d2l-activity-assignment-editor.btnCloseDialog": "Close this Dialog", // close dialog button
+	"d2l-activity-assignment-editor.txtOriginalityCheckOn": "Originality Check On", // originality check on text
+	"d2l-activity-assignment-editor.txtGradeMarkOn": "GradeMark On", // grade mark on text
+	"d2l-activity-assignment-editor.txtTurnitinOn": "Turnitin enabled", // turnitin on text
+	"d2l-activity-assignment-editor.btnCancel": "Cancel", // cancel button
+	"d2l-activity-assignment-editor.btnSave": "Save", // save button
+	"d2l-activity-assignment-editor.hdrAvailability": "Availability Dates & Conditions", // availability header
+	"d2l-activity-assignment-editor.name": "Name", // Label for the name field when creating/editing an activity
+	"d2l-activity-assignment-editor.submissionType": "Submission Type", // Label for the submission type field when creating/editing an assignment
+	"d2l-activity-assignment-editor.annotationTools": "Annotation Tools", // Label for enabling/disabling Annotation Tools when creating/editing an assignment
+	"d2l-activity-assignment-editor.annotationToolDescription": "Make annotation tools available for assessment", //Description next to the checkbox for annotation tools when creating/editing an assignment
+	"d2l-activity-assignment-editor.scoreOutOf": "Score Out Of", // Label for the score-out-of field when creating/editing an activity
+	"d2l-activity-assignment-editor.anonymousGradingEnabled": "Anonymous marking", // Summary message for accordion when anonymous grading is enabled
+	"d2l-activity-assignment-editor.evaluationAndFeedback": "Evaluation & Feedback", // Header text for the evaluation and feedback summarizer
+	"d2l-activity-assignment-editor.txtAssignmentType": "Assignment Type", // Label for assignment type
+	"d2l-activity-assignment-editor.txtIndividual": "Individual Assignment", // Label for individual assignment type
+	"d2l-activity-assignment-editor.txtGroup": "Group Assignment", // Label for group assignment type,
+	"d2l-activity-assignment-editor.txtGroupCategoryWithName": "Group Category: {groupCategory}", //Label for the group category {groupCategory} is the name of the group category
+	"d2l-activity-assignment-editor.txtGroupCategory": "Group Category", // Label for group category,
+	"d2l-activity-assignment-editor.txtGroupAssignmentSummary": "Group assignment", // Summary message for accordion when assignment type is set to group
+	"d2l-activity-assignment-editor.submissionCompletionAndCategorization": "Submission & Completion", // Label for the availability and dates summarizer
+	"d2l-activity-assignment-editor.assignmentSaveError": "Your assignment wasn't saved. Please correct the fields outlined in red.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
+	"d2l-activity-assignment-editor.folderTypeCannotChange": "Assignment type cannot be changed once submissions are present", // Folder type cannot change
+	"d2l-activity-assignment-editor.folderTypeNoGroups": "No groups exist. Create new groups in the Groups tool.", // Folder type no groups
+	"d2l-activity-assignment-editor.folderTypeCreateGroups": "Create new groups in the Groups tool.", // Folder type create groups
+	"d2l-activity-assignment-editor.discardChangesTitle": "Discard changes?", // Discard Changes User Prompt
+	"d2l-activity-assignment-editor.discardChangesQuestion": "Are you sure you want to discard your changes?", // Discard Changes User Prompt
+	"d2l-activity-assignment-editor.yesLabel": "Yes",
+	"d2l-activity-assignment-editor.noLabel": "No",
+	"d2l-activity-assignment-editor.filesSubmissionLimit": "Files Allowed Per Submission",
+	"d2l-activity-assignment-editor.UnlimitedFilesPerSubmission": "Unlimited",
+	"d2l-activity-assignment-editor.OneFilePerSubmission": "One File",
+	"d2l-activity-assignment-editor.submissionsRule": "Submissions",
+	"d2l-activity-assignment-editor.hdrSpecialAccess": "Special Access", // special access heading
+	"d2l-activity-assignment-editor.hlpSpecialAccess": "Special Access allows assignments to be available to only a select group of users or individualized due dates for certain users.", // special access help
 };

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-lang-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-lang-mixin.js
@@ -1,0 +1,65 @@
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+
+export const LocalizeActivityEditor = superclass => class extends LocalizeMixin(superclass) {
+
+	static async getLocalizeResources(langs) {
+		let translations;
+		for await (const lang of langs) {
+			switch (lang) {
+				case 'ar':
+					translations = await import('../lang/ar.js');
+                    break;
+                case 'da-dk':
+					translations = await import('../lang/da-dk.js');
+					break;
+				case 'de':
+					translations = await import('../lang/de.js');
+					break;
+				case 'en':
+					translations = await import('../lang/en.js');
+					break;
+				case 'es':
+					translations = await import('../lang/es.js');
+					break;
+				case 'fr':
+					translations = await import('../lang/fr.js');
+					break;
+				case 'ja':
+					translations = await import('../lang/ja.js');
+					break;
+				case 'ko':
+					translations = await import('../lang/ko.js');
+					break;
+				case 'nl':
+					translations = await import('../lang/nl.js');
+					break;
+				case 'pt':
+					translations = await import('../lang/pt.js');
+					break;
+				case 'sv':
+					translations = await import('../lang/sv.js');
+					break;
+				case 'tr':
+					translations = await import('../lang/tr.js');
+					break;
+				case 'zh-tw':
+					translations = await import('../lang/zh-tw.js');
+					break;
+				case 'zh':
+					translations = await import('../lang/zh.js');
+					break;
+			}
+			if (translations && translations.default) {
+				return {
+					language: lang,
+					resources: translations.default
+				};
+			}
+		}
+		translations = await import('../lang/en.js');
+		return {
+			language: 'en',
+			resources: translations.default
+		};
+	}
+};


### PR DESCRIPTION
[DE39632](https://rally1.rallydev.com/#/detail/defect/400393435268?fdp=true): Convert BSI builds to be unbundled > FACE lang terms fail to load in legacy-Edge

Since the BSI switched to be unbundled, the dynamic loading of the lang files was causing issues for roll up to find the lang files. This was also causing the legacy-edge version to not get the lang files

Solution:
- Move all the `d2l-activity-editor` lang terms into one file, and have one mixin that points to a specific lang  `import('en.js');`
- Namespace all the lang terms in the file so we know where they are being used
- Update all the components to point to the new mixin
- Remove the old `getLocalizeResources` call

This will also reduce our lang calls to 1 from 4, however it's possible we will retrieve more lang terms than needed if some components are not used together.


Translations files incoming, this is just the `en.js` and the components pointing to the new mixin.