### PR TITLE
Usa/astadelbauer/us118427 face attach existing rcs

### DIFF
--- a/components/d2l-activity-editor/state/conditions.js
+++ b/components/d2l-activity-editor/state/conditions.js
@@ -110,7 +110,7 @@ export class Conditions {
 			results.push({ key: key, title: dto.Text });
 		}
 
-		for (const[key, text] of this._conditionsToAdd) {
+		for (const [key, text] of this._conditionsToAdd) {
 
 			results.push({ key: key, title: text });
 		}
@@ -183,7 +183,7 @@ export class Conditions {
 
 	remove(key) {
 
-		const didRemoveNewCondition = 
+		const didRemoveNewCondition =
 			this._conditionsToCreate.delete(key)
 				|| this._conditionsToAdd.delete(key);
 		if (didRemoveNewCondition) {

--- a/components/d2l-activity-editor/state/conditions.js
+++ b/components/d2l-activity-editor/state/conditions.js
@@ -110,8 +110,9 @@ export class Conditions {
 			results.push({ key: key, title: dto.Text });
 		}
 
-		for(const[key, text] of this._conditionsToAdd){
-			results.push({ key: key, title: text })
+		for (const[key, text] of this._conditionsToAdd) {
+
+			results.push({ key: key, title: text });
 		}
 
 		return results;
@@ -222,7 +223,7 @@ export class Conditions {
 			return true;
 		}
 
-		if(this._conditionsToAdd.size > 0){
+		if (this._conditionsToAdd.size > 0) {
 			return true;
 		}
 

--- a/components/d2l-activity-editor/state/conditions.js
+++ b/components/d2l-activity-editor/state/conditions.js
@@ -18,6 +18,7 @@ export class Conditions {
 		this._conditions = new Map(); // Id -> { id, text }
 		this._conditionsToCreate = new Map(); // Key -> LegacyDTO
 		this._conditionsToRemove = new Set(); // Id
+		this._conditionsToAdd = new Map(); // Id -> text
 	}
 
 	async fetch() {
@@ -109,6 +110,10 @@ export class Conditions {
 			results.push({ key: key, title: dto.Text });
 		}
 
+		for(const[key, text] of this._conditionsToAdd){
+			results.push({ key: key, title: text })
+		}
+
 		return results;
 	}
 
@@ -138,6 +143,7 @@ export class Conditions {
 		this._conditions = new Map(entity.conditions().map(x => [x.id, x]));
 		this._conditionsToCreate = new Map();
 		this._conditionsToRemove = new Set();
+		this._conditionsToAdd = new Map();
 	}
 
 	_constructKey(dto) {
@@ -167,6 +173,8 @@ export class Conditions {
 		const isExistingCondition = this._conditions.has(dto.Id);
 		if (isExistingCondition) {
 			this._conditionsToRemove.delete(dto.Id);
+		} else if (dto.Id){
+			this._conditionsToAdd.set(dto.Id, dto.Text);
 		} else {
 			this._conditionsToCreate.set(this._constructKey(dto), dto);
 		}
@@ -174,7 +182,9 @@ export class Conditions {
 
 	remove(key) {
 
-		const didRemoveNewCondition = this._conditionsToCreate.delete(key);
+		const didRemoveNewCondition = 
+			this._conditionsToCreate.delete(key)
+				|| this._conditionsToAdd.delete(key);
 		if (didRemoveNewCondition) {
 			return;
 		}
@@ -212,6 +222,10 @@ export class Conditions {
 			return true;
 		}
 
+		if(this._conditionsToAdd.size > 0){
+			return true;
+		}
+
 		const operator = this._getSelectedOperator(this._operators);
 		if (operator !== this._operator) {
 			return true;
@@ -235,11 +249,14 @@ export class Conditions {
 			.map(this._formatNewCondition, this);
 		const removeConditions = Array
 			.from(this._conditionsToRemove);
+		const addConditions = Array
+			.from(this._conditionsToAdd.keys());
 
 		await this._entity.save({
 			Operator: this._operator,
 			RemoveConditions: removeConditions,
-			NewConditions: newConditions
+			NewConditions: newConditions,
+			AddConditions: addConditions
 		});
 		await this.fetch();
 	}
@@ -252,6 +269,7 @@ decorate(Conditions, {
 	_conditions: observable,
 	_conditionsToCreate: observable,
 	_conditionsToRemove: observable,
+	_conditionsToAdd: observable,
 	// actions
 	load: action,
 	setOperator: action,

--- a/components/d2l-activity-editor/state/conditions.js
+++ b/components/d2l-activity-editor/state/conditions.js
@@ -175,7 +175,7 @@ export class Conditions {
 		if (isExistingCondition) {
 			this._conditionsToRemove.delete(dto.Id);
 		} else if (dto.Id) {
-			this._conditionsToAdd.set(dto.Id, dto.Text);
+			this._conditionsToAdd.set(`${dto.Id}`, dto.Text);
 		} else {
 			this._conditionsToCreate.set(this._constructKey(dto), dto);
 		}

--- a/components/d2l-activity-editor/state/conditions.js
+++ b/components/d2l-activity-editor/state/conditions.js
@@ -174,7 +174,7 @@ export class Conditions {
 		const isExistingCondition = this._conditions.has(dto.Id);
 		if (isExistingCondition) {
 			this._conditionsToRemove.delete(dto.Id);
-		} else if (dto.Id){
+		} else if (dto.Id) {
 			this._conditionsToAdd.set(dto.Id, dto.Text);
 		} else {
 			this._conditionsToCreate.set(this._constructKey(dto), dto);


### PR DESCRIPTION
[US118427](https://rally1.rallydev.com/#/110294864140d/custom/110851118712?detail=%2Fuserstory%2F403690812576&fdp=true)

[LMS PR](https://git.dev.d2l/projects/CORE/repos/lms/pull-requests/13622/overview)

When we attach an existing RC using the legacy RC dialog in FACE, we only get a list of RC Ids back from the dialog. Unfortunately this was breaking when saving FACE since the HM API needed all the other data for and RC, and didn't support Ids at all. Since I didn't want to mess with the legacy dialog that's used everywhere to return more data, I ended up going with a solution where I can pass the list of Ids ("addConditions") for existing RCs to attach into the API.

Another option could have been to get the RC data from an API with the Ids or something, but this seemed silly since server-side would ultimately convert it back to the Id to attach to the activity anyway...