### PR TITLE
Fix lang term keys based on changes to lang term loading for activity editor

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-grades-dialog.js
+++ b/components/d2l-activity-editor/d2l-activity-grades-dialog.js
@@ -126,7 +126,7 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeActivityEditorMix
 		} = activity.scoreAndGrade;
 
 		return html`
-			<d2l-dialog title-text="${this.localize('chooseFromGrades')}" width="460" @d2l-dialog-open="${this._onDialogOpen}">
+			<d2l-dialog title-text="${this.localize('editor.chooseFromGrades')}" width="460" @d2l-dialog-open="${this._onDialogOpen}">
 				<label class="d2l-input-radio-label ${!this._canLinkNewGrade ? 'd2l-input-radio-label-disabled' : ''}">
 					<input
 						type="radio"
@@ -135,7 +135,7 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeActivityEditorMix
 						?disabled="${!this._canLinkNewGrade}"
 						.checked="${this._createNewRadioChecked}"
 						@change="${this._dialogRadioChanged}">
-					${this.localize('createAndLinkToNewGradeItem')}
+					${this.localize('editor.createAndLinkToNewGradeItem')}
 				</label>
 				<d2l-input-radio-spacer ?hidden="${!this._createNewRadioChecked && this._canLinkNewGrade}">
 					${this._canLinkNewGrade ? html`
@@ -144,7 +144,7 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeActivityEditorMix
 							<div>
 								<div class="d2l-activity-grades-dialog-create-new-activity-name">${newGradeName}</div>
 								<div class="d2l-body-small">${scoreOutOf && !scoreOutOfError ? html`
-									${this.localize('points', { points: formatNumber(scoreOutOf, { maximumFractionDigits: 2 })})}
+									${this.localize('editor.points', { points: formatNumber(scoreOutOf, { maximumFractionDigits: 2 })})}
 								` : null }
 								</div>
 							</div>
@@ -152,7 +152,7 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeActivityEditorMix
 						<d2l-activity-grade-category-selector href="${this.href}" .token="${this.token}"></d2l-activity-grade-category-selector>
 					` : html`
 						<div class="d2l-body-small">
-							${this.localize('noGradeCreatePermission')}
+							${this.localize('editor.noGradeCreatePermission')}
 						</div>
 					`}
 				</d2l-input-radio-spacer>
@@ -164,18 +164,18 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeActivityEditorMix
 						?disabled="${!this._hasGradeCandidates}"
 						.checked="${!this._createNewRadioChecked && this._hasGradeCandidates}"
 						@change="${this._dialogRadioChanged}">
-					${this.localize('linkToExistingGradeItem')}
+					${this.localize('editor.linkToExistingGradeItem')}
 				</label>
 				<d2l-input-radio-spacer ?hidden="${this._createNewRadioChecked && this._hasGradeCandidates}" ?disabled="${!this._hasGradeCandidates}">
 					${this._hasGradeCandidates ? html`<d2l-activity-grade-candidate-selector
 						href="${this.href}"
 						.token="${this.token}">
 					</d2l-activity-grade-candidate-selector>` : html`<div class="d2l-body-small">
-						${this.localize('noGradeItems')}
+						${this.localize('editor.noGradeItems')}
 					</div>`}
 				</d2l-input-radio-spacer>
-				<d2l-button slot="footer" primary dialog-action="done">${this.localize('ok')}</d2l-button>
-				<d2l-button slot="footer" dialog-action="cancel">${this.localize('cancel')}</d2l-button>
+				<d2l-button slot="footer" primary dialog-action="done">${this.localize('editor.ok')}</d2l-button>
+				<d2l-button slot="footer" dialog-action="cancel">${this.localize('editor.cancel')}</d2l-button>
 			</d2l-dialog>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -274,7 +274,7 @@ class ActivityScoreEditor extends ActivityEditorMixin(LocalizeActivityEditorMixi
 							showing
 							align="start"
 						>
-							${scoreOutOfError ? html`<span>${this.localize(scoreOutOfError)}</span>` : null}
+							${scoreOutOfError ? html`<span>${this.localize(`editor.${scoreOutOfError}`)}</span>` : null}
 						</d2l-tooltip>
 					` : null}
 					<div class="d2l-body-compact grade-type-text">${gradeType}</div>

--- a/components/d2l-activity-editor/state/activity-dates.js
+++ b/components/d2l-activity-editor/state/activity-dates.js
@@ -32,44 +32,44 @@ export class ActivityDates {
 
 	setErrorLangTerms(errorType) {
 		if (errorType && errorType.includes('end-due-start-date-error')) {
-			this.dueDateErrorTerm = 'dueBetweenStartEndDate';
-			this.startDateErrorTerm = 'dueBetweenStartEndDate';
-			this.endDateErrorTerm = 'dueBetweenStartEndDate';
+			this.dueDateErrorTerm = 'editor.dueBetweenStartEndDate';
+			this.startDateErrorTerm = 'editor.dueBetweenStartEndDate';
+			this.endDateErrorTerm = 'editor.dueBetweenStartEndDate';
 			return;
 		}
 
 		if (errorType && errorType.includes('start-after-due-end-date-error')) {
-			this.dueDateErrorTerm = 'dueAfterStartDate';
-			this.startDateErrorTerm = 'dueAfterStartDate';
-			this.endDateErrorTerm = 'startBeforeEndDate';
+			this.dueDateErrorTerm = 'editor.dueAfterStartDate';
+			this.startDateErrorTerm = 'editor.dueAfterStartDate';
+			this.endDateErrorTerm = 'editor.startBeforeEndDate';
 			return;
 		}
 
 		if (errorType && errorType.includes('start-after-due-date-error')) {
-			this.dueDateErrorTerm = 'dueAfterStartDate';
-			this.startDateErrorTerm = 'dueAfterStartDate';
+			this.dueDateErrorTerm = 'editor.dueAfterStartDate';
+			this.startDateErrorTerm = 'editor.dueAfterStartDate';
 			this.endDateErrorTerm = null;
 			return;
 		}
 
 		if (errorType && errorType.includes('end-before-start-due-date-error')) {
-			this.dueDateErrorTerm = 'dueBeforeEndDate';
-			this.startDateErrorTerm = 'startBeforeEndDate';
-			this.endDateErrorTerm = 'dueBeforeEndDate';
+			this.dueDateErrorTerm = 'editor.dueBeforeEndDate';
+			this.startDateErrorTerm = 'editor.startBeforeEndDate';
+			this.endDateErrorTerm = 'editor.dueBeforeEndDate';
 			return;
 		}
 
 		if (errorType && errorType.includes('end-before-due-date-error')) {
-			this.dueDateErrorTerm = 'dueBeforeEndDate';
+			this.dueDateErrorTerm = 'editor.dueBeforeEndDate';
 			this.startDateErrorTerm = null;
-			this.endDateErrorTerm = 'dueBeforeEndDate';
+			this.endDateErrorTerm = 'editor.dueBeforeEndDate';
 			return;
 		}
 
 		if (errorType && errorType.includes('end-before-start-date-error')) {
 			this.dueDateErrorTerm = null;
-			this.startDateErrorTerm = 'startBeforeEndDate';
-			this.endDateErrorTerm = 'startBeforeEndDate';
+			this.startDateErrorTerm = 'editor.startBeforeEndDate';
+			this.endDateErrorTerm = 'editor.startBeforeEndDate';
 			return;
 		}
 


### PR DESCRIPTION
With the new lang term loading, terms in files that are using the `d2l-activity-editor-lang-mixin.js` for i18n are referencing [this lang file](https://github.com/BrightspaceHypermediaComponents/activities/blob/master/components/d2l-activity-editor/lang/en.js) (or a respective translation). The terms in that file are prefixed, and some prefixes were missed in the original conversion.