### PR TITLE
Kapatel/user/de39250 modify href

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -200,7 +200,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 				<div id="score-container">
 					<label class="d2l-label-text">${this.localize('scoreOutOf')}</label>
 					<d2l-activity-score-editor
-						href="${activityUsageHref}"
+						.href="${activityUsageHref}"
 						.token="${this.token}"
 						.activityName="${name}">
 					</d2l-activity-score-editor>
@@ -208,7 +208,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 
 				<div id="duedate-container">
 					<d2l-activity-due-date-editor
-						href="${activityUsageHref}"
+						.href="${activityUsageHref}"
 						.token="${this.token}">
 					</d2l-activity-due-date-editor>
 				</div>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-footer.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-footer.js
@@ -70,7 +70,7 @@ class AssignmentEditorFooter extends SaveStatusMixin(EntityMixinLit(RtlMixin(Loc
 		return html`
 			<div class="d2l-activity-assignment-editor-footer-left">
 				<d2l-activity-visibility-editor
-					href="${this._activityUsageHref}"
+					.href="${this._activityUsageHref}"
 					.token="${this.token}">
 				</d2l-activity-visibility-editor>
 				<d2l-activity-editor-buttons></d2l-activity-editor-buttons>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-secondary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-secondary.js
@@ -69,7 +69,7 @@ class AssignmentEditorSecondary extends ActivityEditorFeaturesMixin(RtlMixin(Ent
 
 		const availabilityAccordian = html`
 			<d2l-activity-assignment-availability-editor
-				href="${this._activityUsageHref}"
+				.href="${this._activityUsageHref}"
 				.token="${this.token}">
 			</d2l-activity-assignment-availability-editor>
 		`;

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -240,19 +240,19 @@ class AssignmentEditor extends ActivityEditorContainerMixin(LocalizeActivityAssi
 				<div slot="primary" class="d2l-activity-assignment-editor-primary-panel">
 					<d2l-alert type="error" ?hidden=${!this.isError}>${this.localize('assignmentSaveError')}</d2l-alert>
 					<d2l-activity-assignment-editor-detail
-						href="${assignmentHref}"
+						.href="${assignmentHref}"
 						.token="${this.token}">
 					</d2l-activity-assignment-editor-detail>
 				</div>
 				<div slot="secondary">
 					<d2l-activity-assignment-editor-secondary
-						href="${assignmentHref}"
+						.href="${assignmentHref}"
 						.token="${this.token}"
 						class="d2l-activity-assignment-editor-secondary-panel">
 					</d2l-activity-assignment-editor-secondary>
 				</div>
 				<d2l-activity-assignment-editor-footer
-					href="${assignmentHref}"
+					.href="${assignmentHref}"
 					.token="${this.token}"
 					slot="footer"
 					class="d2l-activity-assignment-editor-footer">

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
@@ -122,7 +122,7 @@ class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(Loc
 	_renderRubricsSummary() {
 		return html`
 			<d2l-activity-rubrics-summary-wrapper
-				href="${this.activityUsageHref}"
+				.href="${this.activityUsageHref}"
 				.token="${this.token}">
 			</d2l-activity-rubrics-summary-wrapper>
 		`;
@@ -131,7 +131,7 @@ class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(Loc
 	_renderCompetenciesSummary() {
 		return html`
 			<d2l-activity-competencies-summary
-				href="${this.activityUsageHref}"
+				.href="${this.activityUsageHref}"
 				.token="${this.token}">
 			</d2l-activity-competencies-summary>
 		`;
@@ -150,7 +150,7 @@ class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(Loc
 	_renderCompetenciesOpener() {
 		return html`
 			<d2l-activity-competencies
-				href="${this.activityUsageHref}"
+				.href="${this.activityUsageHref}"
 				.token="${this.token}">
 			</d2l-activity-competencies>
 		`;

--- a/components/d2l-activity-editor/d2l-activity-grades-dialog.js
+++ b/components/d2l-activity-editor/d2l-activity-grades-dialog.js
@@ -149,7 +149,7 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeActivityEditorMix
 								</div>
 							</div>
 						</div>
-						<d2l-activity-grade-category-selector href="${this.href}" .token="${this.token}"></d2l-activity-grade-category-selector>
+						<d2l-activity-grade-category-selector .href="${this.href}" .token="${this.token}"></d2l-activity-grade-category-selector>
 					` : html`
 						<div class="d2l-body-small">
 							${this.localize('editor.noGradeCreatePermission')}
@@ -168,7 +168,7 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeActivityEditorMix
 				</label>
 				<d2l-input-radio-spacer ?hidden="${this._createNewRadioChecked && this._hasGradeCandidates}" ?disabled="${!this._hasGradeCandidates}">
 					${this._hasGradeCandidates ? html`<d2l-activity-grade-candidate-selector
-						href="${this.href}"
+						.href="${this.href}"
 						.token="${this.token}">
 					</d2l-activity-grade-candidate-selector>` : html`<div class="d2l-body-small">
 						${this.localize('editor.noGradeItems')}

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -164,7 +164,7 @@ class ActivityRubricsListContainer extends ActivityEditorFeaturesMixin(ActivityE
 		if (this._newlyCreatedPotentialAssociationHref !== '') {
 			return html`
 				<d2l-rubric-editor
-					href="${this._newlyCreatedPotentialAssociationHref}"
+					.href="${this._newlyCreatedPotentialAssociationHref}"
 					.token="${this.token}"
 					title-dropdown-hidden>
 				</d2l-rubric-editor>`;
@@ -269,7 +269,7 @@ class ActivityRubricsListContainer extends ActivityEditorFeaturesMixin(ActivityE
 			</div>
 			<d2l-activity-rubrics-list-editor
 				href="${this.href}"
-				activityUsageHref=${this.activityUsageHref}
+				.activityUsageHref=${this.activityUsageHref}
 				.token=${this.token}
 				.assignmentHref=${this.assignmentHref}
 			></d2l-activity-rubrics-list-editor>

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
@@ -88,7 +88,7 @@ class ActivityRubricsListEditor extends ActivityEditorFeaturesMixin(ActivityEdit
 				<d2l-rubric
 					class="association-box"
 					force-compact
-					href="${association.rubricHref}"
+					.href="${association.rubricHref}"
 					.token="${this.token}">
 				</d2l-rubric>
 				<d2l-button-icon

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-wrapper.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-wrapper.js
@@ -18,7 +18,7 @@ class ActivityRubricsListWrapper
 		}
 		return html`
 			<d2l-activity-rubrics-list-container
-				href="${entity.associationsHref}"
+				.href="${entity.associationsHref}"
 				.token="${this.token}"
 				.activityUsageHref=${this.href}
 				.assignmentHref=${this.assignmentHref}>

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-summary-wrapper.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-summary-wrapper.js
@@ -19,7 +19,7 @@ class ActivityRubricsSummaryWrapper
 
 		return html`
 			<d2l-activity-rubrics-summary
-				href="${entity.associationsHref}"
+				.href="${entity.associationsHref}"
 				.token="${this.token}">
 			</d2l-activity-rubrics-summary>
 		`;


### PR DESCRIPTION
[DE28769](https://git.dev.d2l/projects/CORE/repos/lms/pull-requests/13680/overview)
Updated some instances of `href` to `.href` to prevent undefined href from being coerced into a string and hopefully stop some chatty logging of the following error:

`The input is not a valid Base-64 string as it contains a non-base 64 character, more than two padding characters, or an illegal character among the padding characters.`

I updated the href's related to dialog's and all href's that are set using the following:
	- assignmentHRef
	- activityUsageHref
	- entity.associationsHref
	- this._newlyCreatedPotentialAssociationHref
	- rubricHref

I tested these things on Edge and Chrome to make sure nothing breaks:
- the main editor area and opening/editing the grades dialog
- all links on the side bar that open external dialog's (focusing on adding dates, adding a rubric and managing learning objectives)