### PR TITLE
US111737 remove warning text indicating folder type cannot change whe…

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
@@ -91,10 +91,6 @@ class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 
 		const isIndividualAssignmentType = assignment.isIndividualAssignmentType;
 
-		if (assignment.assignmentHasSubmissions) {
-			return this.localize('folderTypeCannotChange');
-		}
-
 		if (isIndividualAssignmentType && assignment.groupCategories.length === 0) {
 			return this.localize('folderTypeNoGroups');
 		}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ar.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ar.js
@@ -35,7 +35,6 @@ export default {
 	"txtGroupAssignmentSummary": "فرض المجموعات", // Summary message for accordion when assignment type is set to group
 	"submissionCompletionAndCategorization": "الإرسال والإكمال", // Label for the availability and dates summarizer
 	"assignmentSaveError": "لم يتم حفظ الفرض. يُرجى تصحيح الحقول الموضّحة باللون الأحمر.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
-	"folderTypeCannotChange": "يتعذر تغيير نوع الفرض بعد إرساله", // Folder type cannot change
 	"folderTypeNoGroups": "لا تتوفر أي مجموعة. أنشئ مجموعات جديدة باستخدام أداة المجموعات.", // Folder type no groups
 	"folderTypeCreateGroups": "أنشئ مجموعات جديدة باستخدام أداة المجموعات.", // Folder type create groups
 	"discardChangesTitle": "هل تريد تجاهل التغييرات؟", // Discard Changes User Prompt

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/da-dk.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/da-dk.js
@@ -35,7 +35,6 @@ export default {
 	"txtGroupAssignmentSummary": "Gruppeopgave", // Summary message for accordion when assignment type is set to group
 	"submissionCompletionAndCategorization": "Aflevering og færdiggørelse", // Label for the availability and dates summarizer
 	"assignmentSaveError": "Din opgave blev ikke gemt. Ret de felter, der er markeret med rødt.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
-	"folderTypeCannotChange": "Opgavetype kan ikke ændres, når opgaverne er afleveret", // Folder type cannot change
 	"folderTypeNoGroups": "Der eksisterer ingen grupper. Opret nye grupper i værktøjet Grupper.", // Folder type no groups
 	"folderTypeCreateGroups": "Opret nye grupper i værktøjet Grupper.", // Folder type create groups
 	"discardChangesTitle": "Slet ændringer?", // Discard Changes User Prompt

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/de.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/de.js
@@ -35,7 +35,6 @@ export default {
 	"txtGroupAssignmentSummary": "Gruppenübung", // Summary message for accordion when assignment type is set to group
 	"submissionCompletionAndCategorization": "Abgabe und Abschluss", // Label for the availability and dates summarizer
 	"assignmentSaveError": "Ihre Übung wurde nicht gespeichert. Korrigieren Sie die rot umrandeten Felder.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
-	"folderTypeCannotChange": "Übungstyp kann nicht mehr geändert werden, sobald Abgaben vorhanden sind", // Folder type cannot change
 	"folderTypeNoGroups": "Es sind keine Gruppen vorhanden. Erstellen Sie neue Gruppen im Gruppen-Tool.", // Folder type no groups
 	"folderTypeCreateGroups": "Erstellen Sie neue Gruppen im Gruppen-Tool.", // Folder type create groups
 	"discardChangesTitle": "Änderungen verwerfen?", // Discard Changes User Prompt

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
@@ -35,7 +35,6 @@ export default {
 	"txtGroupAssignmentSummary": "Group assignment", // Summary message for accordion when assignment type is set to group
 	"submissionCompletionAndCategorization": "Submission & Completion", // Label for the availability and dates summarizer
 	"assignmentSaveError": "Your assignment wasn't saved. Please correct the fields outlined in red.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
-	"folderTypeCannotChange": "Assignment type cannot be changed once submissions are present", // Folder type cannot change
 	"folderTypeNoGroups": "No groups exist. Create new groups in the Groups tool.", // Folder type no groups
 	"folderTypeCreateGroups": "Create new groups in the Groups tool.", // Folder type create groups
 	"discardChangesTitle": "Discard changes?", // Discard Changes User Prompt

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/es.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/es.js
@@ -35,7 +35,6 @@ export default {
 	"txtGroupAssignmentSummary": "Asignación grupal", // Summary message for accordion when assignment type is set to group
 	"submissionCompletionAndCategorization": "Envío y finalización", // Label for the availability and dates summarizer
 	"assignmentSaveError": "No se guardó la asignación. Corrija los campos marcados en color rojo.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
-	"folderTypeCannotChange": "El tipo de asignación no se puede cambiar una vez que hay envíos presentes", // Folder type cannot change
 	"folderTypeNoGroups": "No existen grupos. Cree nuevos grupos en la herramienta Grupos.", // Folder type no groups
 	"folderTypeCreateGroups": "Cree nuevos grupos en la herramienta Grupos.", // Folder type create groups
 	"discardChangesTitle": "¿Desea descartar los cambios?", // Discard Changes User Prompt

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/fr.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/fr.js
@@ -35,7 +35,6 @@ export default {
 	"txtGroupAssignmentSummary": "Travail de groupe", // Summary message for accordion when assignment type is set to group
 	"submissionCompletionAndCategorization": "Soumission et achèvement", // Label for the availability and dates summarizer
 	"assignmentSaveError": "Votre travail n\'était pas enregistré. Veuillez corriger les champs indiqués en rouge.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
-	"folderTypeCannotChange": "Le type de travail ne peut pas être changé lorsque des soumissions existent.", // Folder type cannot change
 	"folderTypeNoGroups": "Aucun groupe n\'existe. Créez des groupes dans l\'outil Groupes.", // Folder type no groups
 	"folderTypeCreateGroups": "Créez des groupes dans l\'outil Groupes.", // Folder type create groups
 	"discardChangesTitle": "Abandonner les modifications?", // Discard Changes User Prompt

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ja.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ja.js
@@ -35,7 +35,6 @@ export default {
 	"txtGroupAssignmentSummary": "グループでの課題", // Summary message for accordion when assignment type is set to group
 	"submissionCompletionAndCategorization": "送信して完了", // Label for the availability and dates summarizer
 	"assignmentSaveError": "課題は保存されませんでした。赤で囲まれたフィールドを修正してください。", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
-	"folderTypeCannotChange": "送信物が存在する場合は、課題タイプを変更できません", // Folder type cannot change
 	"folderTypeNoGroups": "グループが存在しません。グループツールで新規グループを作成します。", // Folder type no groups
 	"folderTypeCreateGroups": "グループツールで新規グループを作成します。", // Folder type create groups
 	"discardChangesTitle": "変更を破棄しますか？", // Discard Changes User Prompt

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ko.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ko.js
@@ -35,7 +35,6 @@ export default {
 	"txtGroupAssignmentSummary": "그룹 과제", // Summary message for accordion when assignment type is set to group
 	"submissionCompletionAndCategorization": "제출 및 완료", // Label for the availability and dates summarizer
 	"assignmentSaveError": "과제가 저장되지 않았습니다. 빨간색으로 표시된 필드를 수정하십시오.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
-	"folderTypeCannotChange": "제출 항목이 있으면 배정 유형을 변경할 수 없습니다.", // Folder type cannot change
 	"folderTypeNoGroups": "그룹이 없습니다. 그룹 도구에서 새 그룹을 만듭니다.", // Folder type no groups
 	"folderTypeCreateGroups": "그룹 도구에서 새 그룹을 만듭니다.", // Folder type create groups
 	"discardChangesTitle": "변경 사항을 제거하시겠습니까?", // Discard Changes User Prompt

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/nl.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/nl.js
@@ -35,7 +35,6 @@ export default {
 	"txtGroupAssignmentSummary": "Groepsopdracht", // Summary message for accordion when assignment type is set to group
 	"submissionCompletionAndCategorization": "Indiening & voltooiing", // Label for the availability and dates summarizer
 	"assignmentSaveError": "Uw opdracht is niet opgeslagen. Corrigeer de rood omlijnde velden.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
-	"folderTypeCannotChange": "Type opdracht kan niet worden gewijzigd zodra er indieningen aanwezig zijn", // Folder type cannot change
 	"folderTypeNoGroups": "Er bestaan geen groepen. Maak nieuwe groepen aan in de Groepen-tool.", // Folder type no groups
 	"folderTypeCreateGroups": "Maak nieuwe groepen aan in de Groepen-tool.", // Folder type create groups
 	"discardChangesTitle": "Wijzigingen verwijderen?", // Discard Changes User Prompt

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/pt.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/pt.js
@@ -35,7 +35,6 @@ export default {
 	"txtGroupAssignmentSummary": "Atividade em grupo", // Summary message for accordion when assignment type is set to group
 	"submissionCompletionAndCategorization": "Envio e Conclusão", // Label for the availability and dates summarizer
 	"assignmentSaveError": "Sua atividade não foi salva. Corrija os campos destacados em vermelho.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
-	"folderTypeCannotChange": "Não é possível alterar o tipo de atividade depois que já foram feitos envios", // Folder type cannot change
 	"folderTypeNoGroups": "Nenhum grupo. Crie grupos na ferramenta Grupos.", // Folder type no groups
 	"folderTypeCreateGroups": "Crie grupos na ferramenta Grupos.", // Folder type create groups
 	"discardChangesTitle": "Descartar alterações?", // Discard Changes User Prompt

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/sv.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/sv.js
@@ -35,7 +35,6 @@ export default {
 	"txtGroupAssignmentSummary": "Gruppuppgift", // Summary message for accordion when assignment type is set to group
 	"submissionCompletionAndCategorization": "Inlämning och slutförande", // Label for the availability and dates summarizer
 	"assignmentSaveError": "Ditt uppdrag sparades inte. Korrigera de fält som är markerade med rött.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
-	"folderTypeCannotChange": "Uppgiftstyp kan inte ändras när det finns inlämningsuppgifter", // Folder type cannot change
 	"folderTypeNoGroups": "Det finns inga grupper. Skapa nya grupper i gruppverktyget.", // Folder type no groups
 	"folderTypeCreateGroups": "Skapa nya grupper i gruppverktyget.", // Folder type create groups
 	"discardChangesTitle": "Vill du ignorera ändringarna?", // Discard Changes User Prompt

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/tr.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/tr.js
@@ -35,7 +35,6 @@ export default {
 	"txtGroupAssignmentSummary": "Grup ödevi", // Summary message for accordion when assignment type is set to group
 	"submissionCompletionAndCategorization": "Gönderme ve Tamamlama", // Label for the availability and dates summarizer
 	"assignmentSaveError": "Ödeviniz kaydedilmedi. Lütfen kırmızı ile gösterilen alanları düzeltin.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
-	"folderTypeCannotChange": "Gönderimler mevcut olduğunda ödev türü değiştirilemez", // Folder type cannot change
 	"folderTypeNoGroups": "Hiç grup yok. Gruplar aracında yeni gruplar oluşturun.", // Folder type no groups
 	"folderTypeCreateGroups": "Gruplar aracında yeni gruplar oluşturun.", // Folder type create groups
 	"discardChangesTitle": "Değişiklikler atılsın mı?", // Discard Changes User Prompt

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/zh-tw.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/zh-tw.js
@@ -35,7 +35,6 @@ export default {
 	"txtGroupAssignmentSummary": "群組作業", // Summary message for accordion when assignment type is set to group
 	"submissionCompletionAndCategorization": "提交與完成", // Label for the availability and dates summarizer
 	"assignmentSaveError": "您的作業未儲存。請修正以紅色顯示的欄位。", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
-	"folderTypeCannotChange": "一旦提交，便無法變更作業類型", // Folder type cannot change
 	"folderTypeNoGroups": "尚無群組。在「群組」工具中建立新群組。", // Folder type no groups
 	"folderTypeCreateGroups": "在「群組」工具中建立新群組。", // Folder type create groups
 	"discardChangesTitle": "捨棄變更？", // Discard Changes User Prompt

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/zh.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/zh.js
@@ -35,7 +35,6 @@ export default {
 	"txtGroupAssignmentSummary": "小组作业", // Summary message for accordion when assignment type is set to group
 	"submissionCompletionAndCategorization": "提交和完成", // Label for the availability and dates summarizer
 	"assignmentSaveError": "您的作业未保存。请更正以红色标出的字段。", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
-	"folderTypeCannotChange": "一旦已有提交，作业类型即无法更改", // Folder type cannot change
 	"folderTypeNoGroups": "没有任何组。在组工具中创建新组。", // Folder type no groups
 	"folderTypeCreateGroups": "在组工具中创建新组。", // Folder type create groups
 	"discardChangesTitle": "放弃更改？", // Discard Changes User Prompt

--- a/components/d2l-activity-editor/lang/da-dk.js
+++ b/components/d2l-activity-editor/lang/da-dk.js
@@ -71,7 +71,7 @@ export default {
 	"rubrics.txtDeleteRubric": "Slet rubrik", // Text for deleting rubric icon
 	"rubrics.btnClose": "Close", // X button for exiting the create new rubric overlay
 	"rubrics.txtRubricAdded": "Rubric added", // Text for notifying screenreader rubric was added
-	"rubrics.txtRubricRemoved": "Rubric removed", // Text for notifying screenreader rubric was removed 
+	"rubrics.txtRubricRemoved": "Rubric removed", // Text for notifying screenreader rubric was removed
 
 	"grades.points": "Point: {points}", // Text label for displaying points of a grade
 	"grades.weight": "Vægt: {weight}", // Text label for displaying weight of a grade
@@ -95,50 +95,4 @@ export default {
 	"attachments.addLinkMenu": "Weblink", // Attach menu item text
 	"attachments.addOneDriveLinkMenu": "OneDrive", // Attach menu item text
 	"attachments.addQuicklinkMenu": "Eksisterende aktivitet", // Attach menu item text
-
-	"assignment-editor.hdrReleaseConditions": "Release Conditions", // release conditions heading
-	"assignment-editor.hlpReleaseConditions": "Users are not able to access or view the assignment unless they meet the release conditions.", // release conditions help
-	"assignment-editor.completionType": "Marked as completed", // Label for the completion type field when creating/editing an assignment
-	"assignment-editor.lblAnonymousMarking": "Anonymous Marking", // Label for anonymous marking
-	"assignment-editor.chkAnonymousMarking": "Hide student names during assessment", // Checkbox for anonymous marking
-	"assignment-editor.dueDate": "Forfaldsdato", // ARIA label for the due date field when creating/editing an activity
-	"assignment-editor.txtAnnotationsOff": "Kommentarer slået fra", // annotations off text
-	"assignment-editor.emptyNameError": "Navn påkrævet", // Error message to inform user that the assignment name is a required field
-	"assignment-editor.instructions": "Instruktioner", // Label for the instruction field when creating/editing an assignment
-	"assignment-editor.hdrTurnitin": "Turnitin-integration", // turnitin heading
-	"assignment-editor.hlpTurnitin": "Turnitin® føjer ekstra funktionalitet til evaluering.", // turnitin help
-	"assignment-editor.btnEditTurnitin": "Administrer Turnitin", // edit turnitin button
-	"assignment-editor.btnCloseDialog": "Luk denne dialogboks", // close dialog button
-	"assignment-editor.txtOriginalityCheckOn": "Originality Check aktiveret", // originality check on text
-	"assignment-editor.txtGradeMarkOn": "GradeMark aktiveret", // grade mark on text
-	"assignment-editor.txtTurnitinOn": "Turnitin aktiveret", // turnitin on text
-	"assignment-editor.btnCancel": "Annuller", // cancel button
-	"assignment-editor.btnSave": "Gem", // save button
-	"assignment-editor.hdrAvailability": "Tilgængelighedsdatoer og betingelser", // availability header
-	"assignment-editor.name": "Navn", // Label for the name field when creating/editing an activity
-	"assignment-editor.submissionType": "Submission Type", // Label for the submission type field when creating/editing an assignment
-	"assignment-editor.annotationTools": "Annotation Tools", // Label for enabling/disabling Annotation Tools when creating/editing an assignment
-	"assignment-editor.annotationToolDescription": "Make annotation tools available for assessment", //Description next to the checkbox for annotation tools when creating/editing an assignment
-	"assignment-editor.scoreOutOf": "Score Out Of", // Label for the score-out-of field when creating/editing an activity
-	"assignment-editor.anonymousGradingEnabled": "Anonym markering", // Summary message for accordion when anonymous grading is enabled
-	"assignment-editor.evaluationAndFeedback": "Evaluering og feedback", // Header text for the evaluation and feedback summarizer
-	"assignment-editor.txtAssignmentType": "Opgavetype", // Label for assignment type
-	"assignment-editor.txtIndividual": "Individuel opgave", // Label for individual assignment type
-	"assignment-editor.txtGroup": "Gruppeopgave", // Label for group assignment type,
-	"assignment-editor.txtGroupCategoryWithName": "Gruppekategori: {groupCategory}", //Label for the group category {groupCategory} is the name of the group category
-	"assignment-editor.txtGroupCategory": "Gruppekategori", // Label for group category,
-	"assignment-editor.txtGroupAssignmentSummary": "Gruppeopgave", // Summary message for accordion when assignment type is set to group
-	"assignment-editor.submissionCompletionAndCategorization": "Aflevering og færdiggørelse", // Label for the availability and dates summarizer
-	"assignment-editor.assignmentSaveError": "Din opgave blev ikke gemt. Ret de felter, der er markeret med rødt.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
-	"assignment-editor.folderTypeCannotChange": "Opgavetype kan ikke ændres, når opgaverne er afleveret", // Folder type cannot change
-	"assignment-editor.folderTypeNoGroups": "Der eksisterer ingen grupper. Opret nye grupper i værktøjet Grupper.", // Folder type no groups
-	"assignment-editor.folderTypeCreateGroups": "Opret nye grupper i værktøjet Grupper.", // Folder type create groups
-	"assignment-editor.discardChangesTitle": "Slet ændringer?", // Discard Changes User Prompt
-	"assignment-editor.discardChangesQuestion": "Er du sikker på, at du vil slette dine ændringer?", // Discard Changes User Prompt
-	"assignment-editor.yesLabel": "Ja",
-	"assignment-editor.noLabel": "Nej",
-	"assignment-editor.filesSubmissionLimit": "Filer tilladt pr. aflevering",
-	"assignment-editor.UnlimitedFilesPerSubmission": "Ubegrænset",
-	"assignment-editor.OneFilePerSubmission": "En fil",
-	"assignment-editor.submissionsRule": "Afleveringer"
 };


### PR DESCRIPTION
…n assignemnt has submissions

I also removed extraneous entries from `d2l-activity-editor/lang/da-dk.js`, which didn't exist in other lang files (and are repeated from corresponding `d2l-activity-assignment-editor/lang` file.