### PR TITLE
DE39920 fix annotation summarizer text

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-summary.js
@@ -1,10 +1,11 @@
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { html } from 'lit-element/lit-element.js';
+import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { assignments as store } from './state/assignment-store.js';
 
 class ActivityAssignmentAnnotationsSummary
-	extends ActivityEditorMixin(MobxLitElement) {
+	extends ActivityEditorMixin(LocalizeActivityAssignmentEditorMixin(MobxLitElement)) {
 
 	constructor() {
 


### PR DESCRIPTION
Annotation summarizer text wasn't showing up because `localize` wasn't defined.