### PR TITLE
hide the rubrics summary if the user doesn't have any permissions for rubrics

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-summary.js
@@ -20,7 +20,7 @@ class ActivityRubricsSummary
 		const canCreatePotentialAssociation = entity.canCreatePotentialAssociation();
 		const canCreateAssociation = entity.canCreateAssociation();
 		const associationsCount = entity.fetchAttachedAssociationsCount();
-		if(!canCreatePotentialAssociation && !canCreateAssociation){
+		if (!canCreatePotentialAssociation && !canCreateAssociation) {
 			return html``;
 		} else if (associationsCount <= 0) {
 			return html`${this.localize('rubrics.txtNoRubricAdded')}`;

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-summary.js
@@ -17,8 +17,12 @@ class ActivityRubricsSummary
 			return html``;
 		}
 
+		const canCreatePotentialAssociation = entity.canCreatePotentialAssociation();
+		const canCreateAssociation = entity.canCreateAssociation();
 		const associationsCount = entity.fetchAttachedAssociationsCount();
-		if (associationsCount <= 0) {
+		if(!canCreatePotentialAssociation && !canCreateAssociation){
+			return html``;
+		} else if (associationsCount <= 0) {
 			return html`${this.localize('rubrics.txtNoRubricAdded')}`;
 		}
 


### PR DESCRIPTION
[DE39269](https://rally1.rallydev.com/#/110294864140d/custom/110851118712?detail=%2Fdefect%2F394449702920&fdp=true)

Hide the summary for rubrics if the user doesn't have any permission to see rubrics 

Testing:
- Try to edit an assignment with and without an existing rubric attached but with a user that has no permissions for rubrics. The rubrics summary is hidden
- Try to edit an assignment with and without an existing rubric but with a user with full permissions for rubrics, the rubrics summary is shown