### PR TITLE
remove hint text about creating groups when submissions are present

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
@@ -90,12 +90,13 @@ class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 		}
 
 		const isIndividualAssignmentType = assignment.isIndividualAssignmentType;
+		const hasSubmissions = assignment.assignmentHasSubmissions;
 
-		if (isIndividualAssignmentType && assignment.groupCategories.length === 0) {
+		if (!hasSubmissions && isIndividualAssignmentType && assignment.groupCategories.length === 0) {
 			return this.localize('folderTypeNoGroups');
 		}
 
-		if (!isIndividualAssignmentType) {
+		if (!hasSubmissions && !isIndividualAssignmentType) {
 			return this.localize('folderTypeCreateGroups');
 		}
 


### PR DESCRIPTION
Fixes:
https://trello.com/c/46OKspKm/236-submission-state-individual-assignment-hide-help-text
https://trello.com/c/SxvAWIJW/237-submission-state-group-assignment-hide-help-text