### PR TITLE
US118882 Hide anonymous marking options when submission type is in-person or on-paper

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-summary.js
@@ -32,7 +32,7 @@ class ActivityAssignmentAnonymousMarkingSummary
 			return html``;
 		}
 
-		const shouldRenderSummaryText = entity.isAnonymousMarkingEnabled;
+		const shouldRenderSummaryText = entity.isAnonymousMarkingAvailable && entity.isAnonymousMarkingEnabled;
 		if (!shouldRenderSummaryText) {
 			return html``;
 		}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -69,6 +69,13 @@ export class Assignment {
 		}
 	}
 
+	_getIsAnonymousMarkingAvailable() {
+		// only file (0) and text (1) submissions can have anonymous marking, see https://docs.valence.desire2learn.com/res/dropbox.html#attributes
+		const submissionTypesWithAnonMarking = ['0', '1'];
+
+		return this._entity.isAnonymousMarkingAvailable() && submissionTypesWithAnonMarking.includes(this.submissionType);
+	}
+
 	load(entity) {
 		this._entity = entity;
 		this.name = entity.name();
@@ -76,9 +83,6 @@ export class Assignment {
 		this.instructions = entity.instructionsEditorHtml();
 		this.canEditInstructions = entity.canEditInstructions();
 		this.instructionsRichTextEditorConfig = entity.instructionsRichTextEditorConfig();
-		this.isAnonymousMarkingAvailable = entity.isAnonymousMarkingAvailable();
-		this.isAnonymousMarkingEnabled = entity.isAnonymousMarkingEnabled();
-		this.canEditAnonymousMarking = entity.canEditAnonymousMarking();
 		this.anonymousMarkingHelpText = entity.getAnonymousMarkingHelpText();
 		this.canSeeAnnotations = entity.canSeeAnnotations();
 		this.annotationToolsAvailable = entity.getAvailableAnnotationTools();
@@ -95,6 +99,11 @@ export class Assignment {
 		this.canEditCompletionType = entity.canEditCompletionType();
 		this.submissionType = String(entity.submissionType().value);
 		this.completionType = entity.completionTypeValue();
+
+		// set up anonymous marking _after_ submission type
+		this.isAnonymousMarkingEnabled = entity.isAnonymousMarkingEnabled();
+		this.canEditAnonymousMarking = entity.canEditAnonymousMarking();
+		this.isAnonymousMarkingAvailable = this._getIsAnonymousMarkingAvailable();
 
 		this.canEditSubmissionsRule = entity.canEditSubmissionsRule();
 		this.submissionsRule = entity.submissionsRule() || 'keepall';
@@ -131,6 +140,8 @@ export class Assignment {
 	setSubmissionType(value) {
 		this.submissionType = value;
 		this._setValidCompletionTypeForSubmissionType();
+
+		this.isAnonymousMarkingAvailable = this._getIsAnonymousMarkingAvailable();
 	}
 
 	setFilesSubmissionLimit(value) {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -69,11 +69,13 @@ export class Assignment {
 		}
 	}
 
-	_getIsAnonymousMarkingAvailable() {
+	_isSubmissionTypeWithAnonMarking() {
 		// only file (0) and text (1) submissions can have anonymous marking, see https://docs.valence.desire2learn.com/res/dropbox.html#attributes
-		const submissionTypesWithAnonMarking = ['0', '1'];
+		return ['0', '1'].includes(this.submissionType);
+	}
 
-		return this._entity.isAnonymousMarkingAvailable() && submissionTypesWithAnonMarking.includes(this.submissionType);
+	_getIsAnonymousMarkingAvailable() {
+		return this._entity.isAnonymousMarkingAvailable() && this._isSubmissionTypeWithAnonMarking();
 	}
 
 	load(entity) {
@@ -210,13 +212,15 @@ export class Assignment {
 		const data = {
 			name: this.name,
 			instructions: this.instructions,
-			isAnonymous: this.isAnonymousMarkingEnabled,
 			annotationToolsAvailable: this.annotationToolsAvailable,
 			submissionType: this.submissionType,
 			isIndividualAssignmentType: this.isIndividualAssignmentType,
 			groupTypeId: this.selectedGroupCategoryId,
 			defaultScoringRubricId: this.defaultScoringRubricId
 		};
+		if (this._isSubmissionTypeWithAnonMarking()) {
+			data.isAnonymous = this.isAnonymousMarkingEnabled;
+		}
 		if (this.canEditCompletionType) {
 			data.completionType = this.completionType;
 		}

--- a/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
@@ -31,7 +31,7 @@ describe('Assignment ', function() {
 				isOriginalityCheckEnabled: () => undefined,
 				isGradeMarkEnabled: () => undefined,
 				instructionsRichTextEditorConfig: () => {},
-				isAnonymousMarkingAvailable: () => undefined,
+				isAnonymousMarkingAvailable: () => true,
 				isAnonymousMarkingEnabled: () => undefined,
 				canEditAnonymousMarking: () => undefined,
 				getAnonymousMarkingHelpText: () => undefined,
@@ -134,6 +134,7 @@ describe('Assignment ', function() {
 		expect(assignment.canEditCompletionType).to.equal(true);
 		expect(assignment.submissionType).to.equal('2');
 		expect(assignment.completionType).to.equal('2');
+		expect(assignment.isAnonymousMarkingAvailable).to.equal(false);
 
 		expect(fetchEntity.mock.calls.length).to.equal(1);
 		expect(AssignmentEntity.mock.calls[0][0]).to.equal(sirenEntity);
@@ -150,6 +151,7 @@ describe('Assignment ', function() {
 		expect(assignment.submissionType).to.equal('3');
 		expect(assignment.completionType).to.equal('3');
 		expect(assignment.canEditCompletionType).to.equal(true);
+		expect(assignment.isAnonymousMarkingAvailable).to.equal(false);
 	});
 
 	it('setSubmissionType when new submission type does not have completion types', async() => {
@@ -162,6 +164,7 @@ describe('Assignment ', function() {
 		expect(assignment.submissionType).to.equal('1');
 		expect(assignment.completionType).to.equal(null);
 		expect(assignment.canEditCompletionType).to.equal(true);
+		expect(assignment.isAnonymousMarkingAvailable).to.equal(true);
 	});
 
 	it('setSubmissionType when current completion type is valid', async() => {


### PR DESCRIPTION
Applies to the checkbox and the summary text.

https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F407977501928