### PR TITLE
US117892 - Part 2 - Fixing assignment read-only view (Instructions, hide competencies, hide outcomes, hide turnitin)

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -191,10 +191,17 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 				${this._getNameTooltip()}
 			</div>
 
-			<d2l-activity-outcomes
-				href="${activityUsageHref}"
-				.token="${this.token}">
-			</d2l-activity-outcomes>
+			${canEditName ?
+				/** This is a hack. US117892. Learning outcomes shouldn't show if the user lacks the Assignment Add/Edit Submission Folders permission.
+					We are using `canEditName` instead of relying on something in outcomes,
+					because the outcomes Manage Alignments permission is currently not truly pluggable,
+					and so it cannot be plugged into Dropbox to check Assignment permissions.
+				*/
+				html`<d2l-activity-outcomes
+					href="${activityUsageHref}"
+					.token="${this.token}">
+				</d2l-activity-outcomes>` : null
+			}
 
 			<div id="score-and-duedate-container">
 				<div id="score-container">

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -191,17 +191,16 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 				${this._getNameTooltip()}
 			</div>
 
-			${canEditName ?
-				/** This is a hack. US117892. Learning outcomes shouldn't show if the user lacks the Assignment Add/Edit Submission Folders permission.
-					We are using `canEditName` instead of relying on something in outcomes,
-					because the outcomes Manage Alignments permission is currently not truly pluggable,
-					and so it cannot be plugged into Dropbox to check Assignment permissions.
-				*/
-				html`<d2l-activity-outcomes
-					href="${activityUsageHref}"
-					.token="${this.token}">
-				</d2l-activity-outcomes>` : null
-			}
+			${canEditName ? /** This is a hack. US117892. Learning outcomes shouldn't show if the user lacks the Assignment Add/Edit Submission Folders permission.
+								We are using `canEditName` instead of relying on something in outcomes,
+								because the outcomes Manage Alignments permission is currently not truly pluggable,
+								and so it cannot be plugged into Dropbox to check Assignment permissions.
+				*/ html`
+					<d2l-activity-outcomes
+						href="${activityUsageHref}"
+						.token="${this.token}">
+					</d2l-activity-outcomes>
+				` : null }
 
 			<div id="score-and-duedate-container">
 				<div id="score-container">

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
@@ -9,14 +9,14 @@ import '../d2l-activity-rubrics/d2l-activity-rubrics-summary-wrapper.js';
 import './d2l-assignment-turnitin-editor.js';
 import './d2l-assignment-turnitin-summary.js';
 import { ActivityEditorFeaturesMixin, Milestones } from '../mixins/d2l-activity-editor-features-mixin.js';
-import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { bodySmallStyles, heading3Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { summarizerHeaderStyles, summarizerSummaryStyles } from './activity-summarizer-styles.js';
+import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
-import { shared as store } from './state/assignment-store.js';
 import { shared as activityStore } from '../state/activity-store.js';
+import { shared as store } from './state/assignment-store.js';
 
 class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(LocalizeActivityAssignmentEditorMixin(ActivityEditorMixin(MobxLitElement))) {
 
@@ -165,7 +165,7 @@ class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(Loc
 		}
 
 		const activity = activityStore.get(this.activityUsageHref);
-		if(!activity) {
+		if (!activity) {
 			return html``;
 		}
 

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
@@ -13,9 +13,9 @@ import { bodySmallStyles, heading3Styles } from '@brightspace-ui/core/components
 import { css, html } from 'lit-element/lit-element.js';
 import { summarizerHeaderStyles, summarizerSummaryStyles } from './activity-summarizer-styles.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
+import { shared as activityStore } from '../state/activity-store.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
-import { shared as activityStore } from '../state/activity-store.js';
 import { shared as store } from './state/assignment-store.js';
 
 class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(LocalizeActivityAssignmentEditorMixin(ActivityEditorMixin(MobxLitElement))) {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
@@ -9,14 +9,16 @@ import '../d2l-activity-rubrics/d2l-activity-rubrics-summary-wrapper.js';
 import './d2l-assignment-turnitin-editor.js';
 import './d2l-assignment-turnitin-summary.js';
 import { ActivityEditorFeaturesMixin, Milestones } from '../mixins/d2l-activity-editor-features-mixin.js';
+import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { bodySmallStyles, heading3Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { summarizerHeaderStyles, summarizerSummaryStyles } from './activity-summarizer-styles.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { shared as store } from './state/assignment-store.js';
+import { shared as activityStore } from '../state/activity-store.js';
 
-class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(LocalizeActivityAssignmentEditorMixin(MobxLitElement)) {
+class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(LocalizeActivityAssignmentEditorMixin(ActivityEditorMixin(MobxLitElement))) {
 
 	static get properties() {
 
@@ -162,6 +164,11 @@ class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(Loc
 			return html``;
 		}
 
+		const activity = activityStore.get(this.activityUsageHref);
+		if(!activity) {
+			return html``;
+		}
+
 		return html`
 			<d2l-labs-accordion-collapse flex header-border>
 				<h3 class="d2l-heading-3 activity-summarizer-header" slot="header">
@@ -169,14 +176,14 @@ class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(Loc
 				</h3>
 				<ul class="d2l-body-small activity-summarizer-summary" slot="summary">
 					${this._m2Enabled ? html`<li>${this._renderRubricsSummary()}</li>` : null}
-					${this._m3CompetenciesEnabled ? html`<li>${this._renderCompetenciesSummary()}</li>` : null}
+					${this._m3CompetenciesEnabled && activity.canEditCompetencies ? html`<li>${this._renderCompetenciesSummary()}</li>` : null}
 					${this._m2Enabled ? html`<li>${this._renderAnnotationsSummary()}</li>` : null}
 					${this._m2Enabled ? html`<li>${this._renderAnonymousMarkingSummary()}</li>` : null}
 					${this._m2Enabled ? html`<li>${this._renderTurnitinSummary()}</li>` : null}
 				</ul>
 				<div class="editors">
 					${this._m2Enabled ? html`${this._renderRubricsCollectionEditor()}` : null}
-					${this._m3CompetenciesEnabled ? this._renderCompetenciesOpener() : null}
+					${this._m3CompetenciesEnabled && activity.canEditCompetencies ? this._renderCompetenciesOpener() : null}
 					${this._m2Enabled ? html`${this._renderAnnotationsEditor()}` : null}
 					${this._m2Enabled ? html`${this._renderAnonymousMarkingEditor()}` : null}
 					${this._m2Enabled ? html`${this._renderTurnitinEditor()}` : null}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
@@ -179,14 +179,14 @@ class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(Loc
 					${this._m3CompetenciesEnabled && activity.canEditCompetencies ? html`<li>${this._renderCompetenciesSummary()}</li>` : null}
 					${this._m2Enabled ? html`<li>${this._renderAnnotationsSummary()}</li>` : null}
 					${this._m2Enabled ? html`<li>${this._renderAnonymousMarkingSummary()}</li>` : null}
-					${this._m2Enabled ? html`<li>${this._renderTurnitinSummary()}</li>` : null}
+					${this._m2Enabled && assignment.canEditTurnitin ? html`<li>${this._renderTurnitinSummary()}</li>` : null}
 				</ul>
 				<div class="editors">
 					${this._m2Enabled ? html`${this._renderRubricsCollectionEditor()}` : null}
 					${this._m3CompetenciesEnabled && activity.canEditCompetencies ? this._renderCompetenciesOpener() : null}
 					${this._m2Enabled ? html`${this._renderAnnotationsEditor()}` : null}
 					${this._m2Enabled ? html`${this._renderAnonymousMarkingEditor()}` : null}
-					${this._m2Enabled ? html`${this._renderTurnitinEditor()}` : null}
+					${this._m2Enabled && assignment.canEditTurnitin ? html`${this._renderTurnitinEditor()}` : null}
 				</div>
 			</d2l-labs-accordion-collapse>
 		`;

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-assignment-turnitin-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-assignment-turnitin-editor.js
@@ -159,8 +159,7 @@ class AssignmentTurnitinEditor
 				${featureSummary}
 				<d2l-button-subtle
 					text="${this.localize('btnEditTurnitin')}"
-					@click="${this._onClickEdit}"
-					?hidden="${!canEditTurnitin}">
+					@click="${this._onClickEdit}">
 				</d2l-button-subtle>
 			</div>
 		`;

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-assignment-turnitin-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-assignment-turnitin-editor.js
@@ -120,7 +120,6 @@ class AssignmentTurnitinEditor
 		} = entity;
 
 		const isTurnitinEnabled = isOriginalityCheckEnabled || isGradeMarkEnabled;
-		const isEditorDisplayed = canEditTurnitin || isTurnitinEnabled;
 
 		let featureSummary;
 		if (isTurnitinEnabled) {
@@ -154,7 +153,7 @@ class AssignmentTurnitinEditor
 		}
 
 		return html`
-			<div id="assignment-turnitin-container" ?hidden="${!isEditorDisplayed}">
+			<div id="assignment-turnitin-container" ?hidden="${!canEditTurnitin}">
 				<h4 class="d2l-heading-4">${this.localize('hdrTurnitin')}</h4>
 				<p class="help-text d2l-body-small">${this.localize('hlpTurnitin')}</p>
 				${featureSummary}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -73,7 +73,7 @@ export class Assignment {
 		this._entity = entity;
 		this.name = entity.name();
 		this.canEditName = entity.canEditName();
-		this.instructions = entity.instructionsEditorHtml();
+		this.instructions = entity.canEditInstructions() ? entity.instructionsEditorHtml() : entity.instructionsHtml();
 		this.canEditInstructions = entity.canEditInstructions();
 		this.instructionsRichTextEditorConfig = entity.instructionsRichTextEditorConfig();
 		this.isAnonymousMarkingAvailable = entity.isAnonymousMarkingAvailable();

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -200,7 +200,6 @@ export class Assignment {
 		*/
 		const data = {
 			name: this.name,
-			instructions: this.instructions,
 			isAnonymous: this.isAnonymousMarkingEnabled,
 			annotationToolsAvailable: this.annotationToolsAvailable,
 			submissionType: this.submissionType,
@@ -208,6 +207,9 @@ export class Assignment {
 			groupTypeId: this.selectedGroupCategoryId,
 			defaultScoringRubricId: this.defaultScoringRubricId
 		};
+		if (this.canEditInstructions) {
+			data.instructions = this.instructions;
+		}
 		if (this.canEditCompletionType) {
 			data.completionType = this.completionType;
 		}

--- a/components/d2l-activity-editor/d2l-activity-html-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-editor.js
@@ -164,9 +164,11 @@ class ActivityHtmlEditor extends LocalizeActivityEditorMixin(LitElement) {
 		super.updated(changedProperties);
 		// This is acknowledged to be non-idiomatic (manipulating DOM outside render), but this
 		// is unforunately a necessary evil of using the tinymce/HTML editor.
-		const editor = this.shadowRoot.querySelector('d2l-html-editor');
-		if (editor) {
-			editor.d2lPluginSettings = (this.richtextEditorConfig || {}).properties || {};
+		if (changedProperties.has('richtextEditorConfig')) {
+			const editor = this.shadowRoot.querySelector('d2l-html-editor');
+			if (editor) {
+				editor.d2lPluginSettings = this.richtextEditorConfig.properties || {};
+			}
 		}
 
 		if (changedProperties.has('value') && typeof changedProperties.get('value') === 'undefined') {

--- a/components/d2l-activity-editor/d2l-activity-html-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-editor.js
@@ -101,11 +101,11 @@ class ActivityHtmlEditor extends LocalizeActivityEditorMixin(LitElement) {
 				/* d2l-input-invalid */
 				border-color: var(--d2l-color-cinnabar);
 			}
-			d2l-html-editor > .d2l-html-editor-container:disabled {
+			d2l-html-editor[disabled] > .d2l-html-editor-container {
 				/* d2l-input-disabled */
 				opacity: 0.5;
 			}
-			d2l-html-editor > .d2l-html-editor-container:hover:disabled {
+			d2l-html-editor[disabled] > .d2l-html-editor-container:hover {
 				/* d2l-input-hover-disabled */
 				background-color: var(--d2l-input-background-color);
 				border-color: var(--d2l-input-border-color);

--- a/components/d2l-activity-editor/d2l-activity-html-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-editor.js
@@ -145,7 +145,8 @@ class ActivityHtmlEditor extends LocalizeActivityEditorMixin(LitElement) {
 				max-rows="1000"
 				fullpage-enabled="0"
 				toolbar="bold italic underline numlist bullist d2l_isf"
-				plugins="lists paste d2l_isf d2l_replacestring">
+				plugins="lists paste d2l_isf d2l_replacestring"
+				?disabled="${this.disabled}">
 
 				<div id="toolbar-shortcut-${this._htmlEditorUniqueId}" hidden="">${this.localize('editor.ariaToolbarShortcutInstructions')}</div>
 				<div
@@ -153,7 +154,6 @@ class ActivityHtmlEditor extends LocalizeActivityEditorMixin(LitElement) {
 					id="${this._htmlEditorUniqueId}"
 					aria-label="${this.ariaLabel}"
 					aria-describedby="toolbar-shortcut-${this._htmlEditorUniqueId}"
-					?disabled="${this.disabled}"
 					role="textbox"
 					prevent-submit>
 				</div>
@@ -164,11 +164,9 @@ class ActivityHtmlEditor extends LocalizeActivityEditorMixin(LitElement) {
 		super.updated(changedProperties);
 		// This is acknowledged to be non-idiomatic (manipulating DOM outside render), but this
 		// is unforunately a necessary evil of using the tinymce/HTML editor.
-		if (changedProperties.has('richtextEditorConfig')) {
-			const editor = this.shadowRoot.querySelector('d2l-html-editor');
-			if (editor) {
-				editor.d2lPluginSettings = this.richtextEditorConfig.properties || {};
-			}
+		const editor = this.shadowRoot.querySelector('d2l-html-editor');
+		if (editor) {
+			editor.d2lPluginSettings = (this.richtextEditorConfig || {}).properties || {};
 		}
 
 		if (changedProperties.has('value') && typeof changedProperties.get('value') === 'undefined') {

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -50,6 +50,7 @@ export class ActivityUsage {
 		this.associatedCompetenciesCount = null;
 		this.unevaluatedCompetenciesCount = null;
 		this.competenciesDialogUrl = null;
+		this.canEditCompetencies = false;
 
 		/**
 		 * Learning Outcomes
@@ -75,6 +76,7 @@ export class ActivityUsage {
 		runInAction(() => {
 			const entity = new CompetenciesEntity(sirenEntity);
 			this.competenciesDialogUrl = entity.dialogUrl();
+			this.canEditCompetencies = !!this.competenciesDialogUrl;
 			this.associatedCompetenciesCount = entity.associatedCount() || 0;
 			this.unevaluatedCompetenciesCount = entity.unevaluatedCount() || 0;
 		});
@@ -229,6 +231,7 @@ decorate(ActivityUsage, {
 	competenciesHref: observable,
 	associatedCompetenciesCount: observable,
 	unevaluatedCompetenciesCount: observable,
+	canEditCompetencies: observable,
 	competenciesDialogUrl: observable,
 	specialAccess: observable,
 	// actions

--- a/test/d2l-activity-editor/state/activity-usage.spec.js
+++ b/test/d2l-activity-editor/state/activity-usage.spec.js
@@ -110,6 +110,7 @@ describe('Activity Usage', function() {
 			expect(activity.associatedCompetenciesCount).to.be.null;
 			expect(activity.unevaluatedCompetenciesCount).to.be.null;
 			expect(activity.competenciesDialogUrl).to.be.null;
+			expect(activity.canEditCompetencies).to.be.false;
 
 			expect(fetchEntity.mock.calls.length).to.equal(2);
 			expect(fetchEntity.mock.calls[0][0]).to.equal('http://1');
@@ -134,6 +135,7 @@ describe('Activity Usage', function() {
 			expect(activity.associatedCompetenciesCount).to.equal(13);
 			expect(activity.unevaluatedCompetenciesCount).to.equal(10);
 			expect(activity.competenciesDialogUrl).to.equal('http://competencies-dialog-href/');
+			expect(activity.canEditCompetencies).to.be.true;
 
 			expect(fetchEntity.mock.calls.length).to.equal(2);
 			expect(fetchEntity.mock.calls[0][0]).to.equal('http://1');
@@ -156,6 +158,7 @@ describe('Activity Usage', function() {
 			expect(activity.associatedCompetenciesCount).to.equal(13);
 			expect(activity.unevaluatedCompetenciesCount).to.equal(10);
 			expect(activity.competenciesDialogUrl).to.equal('http://competencies-dialog-href/');
+			expect(activity.canEditCompetencies).to.be.true;
 
 			// Override competencies with new values
 			CompetenciesEntity.mockImplementation(() => {
@@ -173,6 +176,7 @@ describe('Activity Usage', function() {
 			expect(activity.associatedCompetenciesCount).to.equal(22);
 			expect(activity.unevaluatedCompetenciesCount).to.equal(11);
 			expect(activity.competenciesDialogUrl).to.equal('http://competencies-dialog-href-2/');
+			expect(activity.canEditCompetencies).to.be.true;
 
 			expect(fetchEntity.mock.calls.length).to.equal(3);
 			expect(fetchEntity.mock.calls[0][0]).to.equal('http://1');
@@ -191,6 +195,7 @@ describe('Activity Usage', function() {
 				expect(activity.associatedCompetenciesCount).to.be.null;
 				expect(activity.unevaluatedCompetenciesCount).to.be.null;
 				expect(activity.competenciesDialogUrl).to.be.null;
+				expect(activity.canEditCompetencies).to.be.false;
 
 				expect(fetchEntity.mock.calls.length).to.equal(2);
 				expect(fetchEntity.mock.calls[0][0]).to.equal('http://1');


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F399772334476

This PR implements a view when "Add/Edit Assignment Submission Folders" permission is missing.
- Read-only rich-text and non rich-text instructions
- Hide Competencies
- Hide Outcomes (hack)
- Hide Turn it in