### PR TITLE
disable notificationEmail when no permission to edit (update action n…

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -237,6 +237,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends ActivityEditorFeat
 				label-hidden
 				value="${assignment.notificationEmail}"
 				maxlength="1024"
+				?disabled="${!assignment.canEditNotificationEmail}"
 				@change="${this._onNotificationEmailChanged}"
 				@blur="${this._onNotificationEmailChanged}"
 			></d2l-input-text>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -111,7 +111,8 @@ export class Assignment {
 		this.submissionsRule = entity.submissionsRule() || 'keepall';
 		this.submissionsRuleOptions = entity.getSubmissionsRuleOptions();
 
-		this.notificationEmail = entity.notificationEmail() || '';
+		this.notificationEmail = entity.notificationEmail();
+		this.canEditNotificationEmail = entity.canEditNotificationEmail();
 
 		this.canEditFilesSubmissionLimit = entity.canEditFilesSubmissionLimit();
 		this.filesSubmissionLimit = entity.filesSubmissionLimit() || 'unlimited';
@@ -270,7 +271,7 @@ export class Assignment {
 	}
 
 	get showNotificationEmail() {
-		return this.showSubmissionsRule;
+		return typeof this.notificationEmail !== 'undefined' && this.showSubmissionsRule;
 	}
 
 	setNotificationEmail(value) {
@@ -315,6 +316,7 @@ decorate(Assignment, {
 	showFilesSubmissionLimit: computed,
 	showSubmissionsRule: computed,
 	notificationEmail: observable,
+	canEditNotificationEmail: observable,
 	showNotificationEmail: computed,
 	// actions
 	load: action,

--- a/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
@@ -85,6 +85,7 @@ describe('Assignment ', function() {
 				canEditSubmissionsRule: () => true,
 				submissionsRule: () => 'keepall',
 				notificationEmail: () => '',
+				canEditNotificationEmail: () => true,
 				getSubmissionsRuleOptions: () => [
 					{
 						'type': 'radio',


### PR DESCRIPTION
…ot present), hide it altogether when config var is off (notification-email entity not present)
Fixes https://trello.com/c/GOrVBGUm/240-notification-email-respect-the-config-d2ltoolsdropboxallownotificationemail
and https://trello.com/c/M1CNW7Kc/241-notification-email-require-permission-assignmentsmanage-delivery

Corresponding changes to siren-sdk and lms