### PR TITLE
Use numeric gradeType title if no gradeType is selected initially

### DIFF
--- a/components/d2l-activity-editor/state/activity-score-grade.js
+++ b/components/d2l-activity-editor/state/activity-score-grade.js
@@ -10,7 +10,7 @@ export class ActivityScoreGrade {
 		this.scoreOutOfError = null;
 		this.token = token;
 		this.inGrades = entity.inGrades();
-		this.gradeType = (entity.gradeType() || 'Points').toLowerCase();
+		this.gradeType = (entity.gradeType() || entity.numericGradeTypeTitle()).toLowerCase();
 		this.isUngraded = !this.inGrades && !this.scoreOutOf;
 		this.canEditScoreOutOf = entity.canEditScoreOutOf();
 		this.canSeeGrades = entity.canSeeGrades();


### PR DESCRIPTION
https://trello.com/c/ss2PQ5ho/232-points-string-not-translated-for-assignments-not-originally-in-grades

Defaults to the (translated) title of the numeric gradeType if the gradeType is not set initially. Previous default value was the hard-coded value `Points`.

siren-sdk PR: https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/208 