### PR TITLE
hide the RC header when the user doesn't have manage delivery permission

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
@@ -112,7 +112,7 @@ class ActivityAssignmentAvailabilityEditor extends ActivityEditorFeaturesMixin(L
 
 	_renderReleaseConditionEditor() {
 		const activity = store.get(this.href);
-		if (!this._m3ReleaseConditionsEnabled || !activity || !activity.conditionsHref) {
+		if (!this._m3ReleaseConditionsEnabled || !activity || !activity.canEditReleaseConditions) {
 			return html``;
 		}
 

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
@@ -111,7 +111,8 @@ class ActivityAssignmentAvailabilityEditor extends ActivityEditorFeaturesMixin(L
 	}
 
 	_renderReleaseConditionEditor() {
-		if (!this._m3ReleaseConditionsEnabled) {
+		const activity = store.get(this.href);
+		if (!this._m3ReleaseConditionsEnabled || !activity || !activity.conditionsHref) {
 			return html``;
 		}
 

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -28,6 +28,7 @@ export class ActivityUsage {
 	async load(entity) {
 		this._entity = entity;
 		this.conditionsHref = entity.conditionsHref();
+		this.canEditReleaseConditions = entity.canEditReleaseConditions();
 		this.isDraft = entity.isDraft();
 		this.canEditDraft = entity.canEditDraft();
 		this.isError = false;

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -221,6 +221,7 @@ decorate(ActivityUsage, {
 	// props
 	dueDate: observable,
 	conditionsHref: observable,
+	canEditReleaseConditions: observable,
 	isDraft: observable,
 	canEditDraft: observable,
 	isError: observable,

--- a/test/d2l-activity-editor/state/activity-usage.spec.js
+++ b/test/d2l-activity-editor/state/activity-usage.spec.js
@@ -40,6 +40,7 @@ describe('Activity Usage', function() {
 			associatedGrade: () => undefined,
 			gradeCandidatesHref: () => '',
 			conditionsHref: () => undefined,
+			canEditReleaseConditions: () => true,
 			getDirectRubricAssociationsHref: () => undefined,
 			newGradeCandidatesHref: () => undefined,
 			isNewGradeCandidate: () => false,


### PR DESCRIPTION
[DE339958](https://rally1.rallydev.com/#/110294864140d/custom/110851118712?detail=%2Fdefect%2F408302156092&fdp=true)

Hide the RC header when the user doesn't have manage delivery permissions

Testing:
- remove manage delivery permissions and see that the RC header doesn't show under Availability on FACE
- give manage delivery permission and see that the RC header does show under Availability on FACE