### PR TITLE
DE39814 - Allow a `saveOrder` property to be set for each editor

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -114,7 +114,7 @@ class AssignmentEditor extends ActivityEditorContainerMixin(RtlMixin(LocalizeAct
 
 		this.type = 'assignment';
 		this.telemetryId = 'assignments';
-		this.order = 2000;
+		this.saveOrder = 2000;
 	}
 
 	_onRequestProvider(e) {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -114,6 +114,7 @@ class AssignmentEditor extends ActivityEditorContainerMixin(RtlMixin(LocalizeAct
 
 		this.type = 'assignment';
 		this.telemetryId = 'assignments';
+		this.order = 2000;
 	}
 
 	_onRequestProvider(e) {

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
@@ -75,7 +75,7 @@ export const ActivityEditorContainerMixin = superclass => class extends Activity
 		this.isSaving = true;
 		this.markSaveStart(this.type, this.telemetryId);
 
-		const orderedEditors = Array.from(this._editors).sort((a, b) => a.order - b.order);
+		const orderedEditors = Array.from(this._editors).sort((a, b) => a.saveOrder - b.saveOrder);
 
 		const validations = [];
 		for (const editor of orderedEditors) {

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
@@ -75,8 +75,10 @@ export const ActivityEditorContainerMixin = superclass => class extends Activity
 		this.isSaving = true;
 		this.markSaveStart(this.type, this.telemetryId);
 
+		const orderedEditors = Array.from(this._editors).sort((a, b) => a.order - b.order);
+
 		const validations = [];
-		for (const editor of this._editors) {
+		for (const editor of orderedEditors) {
 			validations.push(editor.validate());
 		}
 
@@ -93,7 +95,7 @@ export const ActivityEditorContainerMixin = superclass => class extends Activity
 			return;
 		}
 
-		for (const editor of this._editors) {
+		for (const editor of orderedEditors) {
 			// TODO - Once we decide how we want to handle errors we may want to add error handling logic
 			// to the save
 			try {

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
@@ -30,7 +30,7 @@ export const ActivityEditorMixin = superclass => class extends superclass {
 			/**
 			 * Order in which the editor validation and saving occurs (lowest first)
 			 */
-			order: { type: Number },
+			saveOrder: { type: Number },
 		};
 	}
 
@@ -38,7 +38,7 @@ export const ActivityEditorMixin = superclass => class extends superclass {
 		super();
 		this._container = null;
 		this.store = store;
-		this.order = 1000;
+		this.saveOrder = 1000;
 	}
 
 	async validate() {}

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
@@ -30,7 +30,7 @@ export const ActivityEditorMixin = superclass => class extends superclass {
 			/**
 			 * Order in which the editor validation and saving occurs (lowest first)
 			 */
-			saveOrder: { type: Number },
+			saveOrder: { attribute: 'save-order', reflect: true, type: Number },
 		};
 	}
 

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
@@ -27,6 +27,10 @@ export const ActivityEditorMixin = superclass => class extends superclass {
 			 * Token JWT Token for brightspace | a function that returns a JWT token for brightspace | null (defaults to cookie authentication in a browser)
 			 */
 			token: { type: String },
+			/**
+			 * Order in which the editor validation and saving occurs (lowest first)
+			 */
+			order: { type: Number },
 		};
 	}
 
@@ -34,6 +38,7 @@ export const ActivityEditorMixin = superclass => class extends superclass {
 		super();
 		this._container = null;
 		this.store = store;
+		this.order = 1000;
 	}
 
 	async validate() {}


### PR DESCRIPTION
This `saveOrder` property will be used to determine the order of validation and saving when the save event is triggered.
The default order will be 1000.
This PR sets the activity-assignment-editor to have a `saveOrder` of 2000 and so the assignment PATCH/save will occur after the other activity-editors.

https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fdefect%2F405157847512

The problem we were having was that there was a corrupted assignment that was associated to a grade, but had no `score-out-of` value. Even when we fixed the `score-out-of` value, the assignment failed to save, because the assignment PATCH request occurred before the `score-out-of` POST, and would throw up because it saw that the assignment was associated to a grade but had no score. So this ordering fix allows us to call the `score-out-of` API to update the assignment score with a value before sending the assignment PATCH request. And so now when the assignment saves, it won't throw up because there is a valid out of score on the assignment.

The `Array.sort` function will be a stable sort (except for IE) according to mdn web docs.