### PR TITLE
Add stylelint integration

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@brightspace-ui/stylelint-config"
+}

--- a/components/d2l-activity-admin-list/d2l-activity-admin-list.js
+++ b/components/d2l-activity-admin-list/d2l-activity-admin-list.js
@@ -64,8 +64,8 @@ class AdminList extends EntityMixinLit(LitElement) {
 				}
 				.d2l-activity-admin-list-content {
 					box-sizing: border-box;
-					padding: 0 30px;
 					max-width: 1230px;
+					padding: 0 30px;
 					width: 100%;
 				}
 
@@ -85,8 +85,8 @@ class AdminList extends EntityMixinLit(LitElement) {
 					background-color: --var(--d2l-color-regolith);
 				}
 				.d2l-activity-admin-list-body {
-					padding-top: 72px;
 					padding-bottom: 72px;
+					padding-top: 72px;
 				}
 			`
 		];

--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -283,9 +283,9 @@ class CollectionEditor extends LocalizeActivityCollectionEditor(EntityMixinLit(L
 				padding: 0 0.35rem;
 			}
 			.d2l-activity-collection-activities {
+				margin: 0 -1.5rem;
 				max-width: 881px;
 				padding: 0 0.05rem;
-				margin: 0 -1.5rem;
 			}
 			.d2l-activity-collection-list-actions {
 				align-items: baseline;
@@ -315,7 +315,7 @@ class CollectionEditor extends LocalizeActivityCollectionEditor(EntityMixinLit(L
 				max-width: 600px;
 			}
 			.d2l-activity-collection-title-header {
-				margin: 9px 0px 6px 0;
+				margin: 9px 0 6px 0;
 				min-height: 52px;
 			}
 			.d2l-activity-collection-toggle-container {
@@ -405,9 +405,9 @@ class CollectionEditor extends LocalizeActivityCollectionEditor(EntityMixinLit(L
 
 			.d2l-activitiy-collection-list-item-illustration {
 				display: grid;
+				grid-template-areas: only-one;
 				grid-template-columns: 100%;
 				grid-template-rows: 100%;
-				grid-template-areas: only-one;
 				position: relative;
 			}
 
@@ -438,8 +438,8 @@ class CollectionEditor extends LocalizeActivityCollectionEditor(EntityMixinLit(L
 
 			.d2l-activity-collection-reorder-spinner {
 				left: 50%;
-				margin-left: -42.5px;
 				margin: auto;
+				margin-left: -42.5px;
 				position: absolute;
 				top: 0;
 			}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/activity-summarizer-styles.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/activity-summarizer-styles.js
@@ -2,26 +2,26 @@ import { css } from 'lit-element/lit-element.js';
 
 // !important is only needed for old Edge
 export const summarizerHeaderStyles = css`
-	.activity-summarizer-header {
-		margin-top: 20px !important;
+	.d2l-activity-summarizer-header {
 		margin-bottom: 12px !important;
+		margin-top: 20px !important;
 	}
 `;
 
 export const summarizerSummaryStyles = css`
-	.activity-summarizer-summary {
+	.d2l-activity-summarizer-summary {
+		color: var(--d2l-color-tungsten);
 		list-style: none;
-		padding: 0;
 		margin-top: 5px;
 		min-height: 20px;
-		color: var(--d2l-color-tungsten);
+		padding: 0;
 	}
 
-	ul.activity-summarizer-summary > li {
+	ul.d2l-activity-summarizer-summary > li {
 		margin-bottom: 8px;
 	}
 
-	ul.activity-summarizer-summary > li:last-child {
+	ul.d2l-activity-summarizer-summary > li:last-child {
 		margin-bottom: 0;
 	}
 `;

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-editor.js
@@ -23,13 +23,13 @@ class ActivityAssignmentAnnotationsEditor
 			}
 
 			d2l-input-checkbox {
-				padding-right: 1rem;
 				margin: 0;
+				padding-right: 1rem;
 			}
 
 			:host([dir="rtl"]) d2l-input-checkbox {
-				padding-right: 0;
 				padding-left: 1rem;
+				padding-right: 0;
 			}
 			`
 		];

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-editor.js
@@ -34,8 +34,8 @@ class ActivityAssignmentAnonymousMarkingEditor
 			}
 
 			:host([dir="rtl"]) d2l-input-checkbox {
-				padding-right: 0;
 				padding-left: 1rem;
+				padding-right: 0;
 			}
 
 			d2l-input-checkbox-spacer {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
@@ -42,11 +42,11 @@ class ActivityAssignmentAvailabilityEditor extends ActivityEditorFeaturesMixin(L
 					display: none;
 				}
 
-				.editor {
+				.d2l-editor {
 					margin: 1rem 0;
 				}
 
-				.editor:last-child {
+				.d2l-editor:last-child {
 					margin-bottom: 0;
 				}
 
@@ -88,7 +88,7 @@ class ActivityAssignmentAvailabilityEditor extends ActivityEditorFeaturesMixin(L
 	_renderAvailabilityDatesEditor() {
 
 		return html`
-			<div class="editor">
+			<div class="d2l-editor">
 				<d2l-activity-availability-dates-editor
 					href="${this.href}"
 					.token="${this.token}">
@@ -116,7 +116,7 @@ class ActivityAssignmentAvailabilityEditor extends ActivityEditorFeaturesMixin(L
 		}
 
 		return html`
-			<div class="editor">
+			<div class="d2l-editor">
 				<h3 class="d2l-heading-4">
 					${this.localize('hdrReleaseConditions')}
 				</h3>
@@ -150,7 +150,7 @@ class ActivityAssignmentAvailabilityEditor extends ActivityEditorFeaturesMixin(L
 		}
 
 		return html`
-			<div class="editor">
+			<div class="d2l-editor">
 				<h3 class="d2l-heading-4">
 					${this.localize('hdrSpecialAccess')}
 				</h3>
@@ -184,10 +184,10 @@ class ActivityAssignmentAvailabilityEditor extends ActivityEditorFeaturesMixin(L
 				header-border
 				?opened=${this._isOpened()}
 				@d2l-labs-accordion-collapse-state-changed=${this._onAccordionStateChange}>
-				<h3 class="d2l-heading-3 activity-summarizer-header" slot="header">
+				<h3 class="d2l-heading-3 d2l-activity-summarizer-header" slot="header">
 					${this.localize('hdrAvailability')}
 				</h3>
-				<ul class="d2l-body-small activity-summarizer-summary" slot="summary">
+				<ul class="d2l-body-small d2l-activity-summarizer-summary" slot="summary">
 					<li>${this._renderAvailabilityDatesSummary()}</li>
 					<li>${this._renderReleaseConditionSummary()}</li>
 					<li>${this._renderSpecialAccessSummary()}</li>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -53,14 +53,14 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 					display: flex;
 					flex-wrap: wrap;
 					min-height: 90px;  /* Hack to force a consistent the height for the old */
-					padding-bottom: 0; /* datetime picker. Can hopefully be removed when the new picker is used.*/
+					padding-bottom: 0; /* datetime picker. Can hopefully be removed when the new picker is used. */
 				}
 				#score-container {
 					margin-right: 40px;
 				}
 				:host([dir="rtl"]) #score-container {
-					margin-right: 0;
 					margin-left: 40px;
+					margin-right: 0;
 				}
 			`
 		];

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-footer.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-footer.js
@@ -28,8 +28,8 @@ class AssignmentEditorFooter extends SaveStatusMixin(EntityMixinLit(RtlMixin(Loc
 			}
 			.d2l-activity-assignment-editor-footer-left {
 				align-items: baseline;
-				flex: 1;
 				display: flex;
+				flex: 1;
 				flex-direction: row-reverse;
 				justify-content: flex-end;
 			}
@@ -39,7 +39,7 @@ class AssignmentEditorFooter extends SaveStatusMixin(EntityMixinLit(RtlMixin(Loc
 			@media only screen and (max-width: 615px) {
 				.d2l-activity-assignment-editor-footer-left {
 					justify-content: space-between;
-					}
+				}
 			}
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-secondary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-secondary.js
@@ -23,16 +23,16 @@ class AssignmentEditorSecondary extends ActivityEditorFeaturesMixin(RtlMixin(Ent
 			labelStyles,
 			css`
 				:host {
-					display: block;
 					background: var(--d2l-color-gypsum);
+					display: block;
 				}
 				:host([hidden]) {
 					display: none;
 				}
 				:host > * {
 					background: var(--d2l-color-white);
-					margin-bottom: 10px;
 					border-radius: 8px;
+					margin-bottom: 10px;
 					padding: 20px;
 					padding-top: 0;
 				}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -40,10 +40,10 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends ActivityEditorFeat
 					display: block;
 				}
 
-				.block-select {
-					width: 100%;
-					max-width: 300px;
+				.d2l-block-select {
 					display: block;
+					max-width: 300px;
+					width: 100%;
 				}
 
 				div[id*="container"] {
@@ -60,8 +60,8 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends ActivityEditorFeat
 				}
 
 				#notification-email {
-					margin-top: 10px;
 					margin-bottom: 2px;
+					margin-top: 10px;
 				}
 			`,
 			summarizerHeaderStyles,
@@ -273,7 +273,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends ActivityEditorFeat
 			submissionTypeContent = html`
 				<select
 					id="assignment-submission-type"
-					class="d2l-input-select block-select"
+					class="d2l-input-select d2l-block-select"
 					@change="${this._saveSubmissionTypeOnChange}">
 						${this._getSubmissionTypeOptions(assignment)}
 				</select>
@@ -327,7 +327,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends ActivityEditorFeat
 			completionTypeContent = html`
 				<select
 					id="assignment-completion-type"
-					class="d2l-input-select block-select"
+					class="d2l-input-select d2l-block-select"
 					@change="${this._saveCompletionTypeOnChange}">
 						${this._getCompletionTypeOptions(assignment)}
 				</select>
@@ -364,10 +364,10 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends ActivityEditorFeat
 		const assignment = store.getAssignment(this.href);
 		return html`
 			<d2l-labs-accordion-collapse class="accordion" flex header-border>
-				<h3 class="d2l-heading-3 activity-summarizer-header" slot="header">
+				<h3 class="d2l-heading-3 d2l-activity-summarizer-header" slot="header">
 					${this.localize('submissionCompletionAndCategorization')}
 				</h3>
-				<ul class="d2l-body-small activity-summarizer-summary" slot="summary">
+				<ul class="d2l-body-small d2l-activity-summarizer-summary" slot="summary">
 					<li>${this._renderAssignmentTypeSummary()}</li>
 					<li>${this._renderAssignmentSubmissionTypeSummary(assignment)}</li>
 					<li>${this._renderAssignmentCompletionTypeSummary()}</li>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -85,26 +85,26 @@ class AssignmentEditor extends ActivityEditorContainerMixin(RtlMixin(LocalizeAct
 				padding: 20px;
 			}
 			d2l-alert {
-				max-width: 100%;
 				margin-bottom: 10px;
+				max-width: 100%;
 			}
 			.d2l-activity-assignment-editor-secondary-panel {
 				padding: 10px;
 			}
 			div[slot="secondary"] {
-				height: 100%;
 				background: var(--d2l-color-gypsum);
+				height: 100%;
 			}
-			.locked-alert {
-				display: flex;
+			.d2l-locked-alert {
 				align-items: baseline;
+				display: flex;
 			}
 			d2l-icon {
 				padding-right: 1rem;
 			}
 			:host([dir="rtl"]) d2l-icon {
-				padding-right: 0;
 				padding-left: 1rem;
+				padding-right: 0;
 			}
 		`;
 	}
@@ -255,7 +255,7 @@ class AssignmentEditor extends ActivityEditorContainerMixin(RtlMixin(LocalizeAct
 				<div slot="primary" class="d2l-activity-assignment-editor-primary-panel">
 					<d2l-alert type="error" ?hidden=${!this.isError}>${this.localize('assignmentSaveError')}</d2l-alert>
 					<d2l-alert ?hidden=${!hasSubmissions}>
-						<div class="locked-alert">
+						<div class="d2l-locked-alert">
 							<d2l-icon icon="tier1:lock-locked"></d2l-icon>
 							<div>${this.localize('assignmentLocked')}</div>
 						</div>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
@@ -45,7 +45,7 @@ class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(Loc
 					display: none;
 				}
 
-				.editors > *:not(:first-child) {
+				.d2l-editors > *:not(:first-child) {
 					display: block;
 					margin-top: 1rem;
 				}
@@ -171,17 +171,17 @@ class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(Loc
 
 		return html`
 			<d2l-labs-accordion-collapse flex header-border>
-				<h3 class="d2l-heading-3 activity-summarizer-header" slot="header">
+				<h3 class="d2l-heading-3 d2l-activity-summarizer-header" slot="header">
 					${this.localize('evaluationAndFeedback')}
 				</h3>
-				<ul class="d2l-body-small activity-summarizer-summary" slot="summary">
+				<ul class="d2l-body-small d2l-activity-summarizer-summary" slot="summary">
 					${this._m2Enabled ? html`<li>${this._renderRubricsSummary()}</li>` : null}
 					${this._m3CompetenciesEnabled && activity.canEditCompetencies ? html`<li>${this._renderCompetenciesSummary()}</li>` : null}
 					${this._m2Enabled ? html`<li>${this._renderAnnotationsSummary()}</li>` : null}
 					${this._m2Enabled ? html`<li>${this._renderAnonymousMarkingSummary()}</li>` : null}
 					${this._m2Enabled && assignment.canEditTurnitin ? html`<li>${this._renderTurnitinSummary()}</li>` : null}
 				</ul>
-				<div class="editors">
+				<div class="d2l-editors">
 					${this._m2Enabled ? html`${this._renderRubricsCollectionEditor()}` : null}
 					${this._m3CompetenciesEnabled && activity.canEditCompetencies ? this._renderCompetenciesOpener() : null}
 					${this._m2Enabled ? html`${this._renderAnnotationsEditor()}` : null}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
@@ -25,10 +25,10 @@ class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 					display: none;
 				}
 
-				.block-select {
-					width: 100%;
-					max-width: 300px;
+				.d2l-help-text {
 					display: block;
+					max-width: 300px;
+					width: 100%;
 				}
 
 				.d2l-body-small {
@@ -39,16 +39,16 @@ class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 					margin: 0 0 0.3rem 0;
 				}
 
-				.group-info {
+				.d2l-group-info {
 					padding-left: 1.8rem;
 				}
 
-				.info-text {
-					padding-left: 1.7rem;
+				.d2l-info-text {
 					margin: 0.1rem 0 0 0;
+					padding-left: 1.7rem;
 				}
 
-				.individual-type {
+				.d2l-individual-type {
 					margin: 0 0 0.5rem 0;
 				}
 			`
@@ -126,7 +126,7 @@ class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 			</div>
 
 			<div ?hidden=${!canEditAssignmentType} id="editable-assignment-type-container">
-				<label class="individual-type d2l-input-radio-label">
+				<label class="d2l-individual-type d2l-input-radio-label">
 					<input
 						id="assignment-type-individual"
 						type="radio"
@@ -149,17 +149,17 @@ class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 					>
 					${this.localize('txtGroup')}
 				</label>
-				<div class="select-list group-info" ?hidden="${isIndividualType}">
+				<div class="select-list d2l-group-info" ?hidden="${isIndividualType}">
 					<label class="d2l-label-text">${this.localize('txtGroupCategory')}</label>
 					<select
-						class="d2l-input-select block-select"
+						class="d2l-input-select d2l-help-text"
 						id="assignemnt-group-categories"
 						@change="${this._changeGroupCategory}"
 						>
 						${this._getGroupCategoryOptions(assignment)}
 					</select>
 				</div>
-				<p class="info-text d2l-body-small">${infoText}</p>
+				<p class="d2l-info-text d2l-body-small">${infoText}</p>
 			</div>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-assignment-turnitin-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-assignment-turnitin-editor.js
@@ -20,7 +20,7 @@ class AssignmentTurnitinEditor
 				margin: 0 0 0.6rem 0;
 			}
 
-			.help-text {
+			.d2l-help-text {
 				margin: 0 0 0.3rem 0;
 			}
 
@@ -28,19 +28,19 @@ class AssignmentTurnitinEditor
 				margin-left: -0.6rem;
 			}
 
-			.feature-summary {
+			.d2l-feature-summary {
 				list-style: none;
 				margin: 0;
 				padding: 0;
 			}
 
-			.feature-summary-item {
+			.d2l-feature-summary-item {
 				display: inline-block;
-				margin-left: 0.5rem;
 				font-size: 0.7rem;
+				margin-left: 0.5rem;
 			}
 
-			.feature-summary-item:first-child {
+			.d2l-feature-summary-item:first-child {
 				margin-left: 0;
 			}
 			`
@@ -127,7 +127,7 @@ class AssignmentTurnitinEditor
 			let originalityCheckItem;
 			if (isOriginalityCheckEnabled) {
 				originalityCheckItem = html`
-					<li class="feature-summary-item">
+					<li class="d2l-feature-summary-item">
 						<d2l-icon icon="tier1:check"></d2l-icon>
 						${this.localize('txtOriginalityCheckOn')}
 					</li>
@@ -137,7 +137,7 @@ class AssignmentTurnitinEditor
 			let gradeMarkItem;
 			if (isGradeMarkEnabled) {
 				gradeMarkItem = html`
-					<li class="feature-summary-item">
+					<li class="d2l-feature-summary-item">
 						<d2l-icon icon="tier1:check"></d2l-icon>
 						${this.localize('txtGradeMarkOn')}
 					</li>
@@ -145,7 +145,7 @@ class AssignmentTurnitinEditor
 			}
 
 			featureSummary = html`
-				<ul class="feature-summary">
+				<ul class="d2l-feature-summary">
 					${originalityCheckItem}
 					${gradeMarkItem}
 				</ul>
@@ -155,7 +155,7 @@ class AssignmentTurnitinEditor
 		return html`
 			<div id="assignment-turnitin-container" ?hidden="${!canEditTurnitin}">
 				<h4 class="d2l-heading-4">${this.localize('hdrTurnitin')}</h4>
-				<p class="help-text d2l-body-small">${this.localize('hlpTurnitin')}</p>
+				<p class="d2l-help-text d2l-body-small">${this.localize('hlpTurnitin')}</p>
 				${featureSummary}
 				<d2l-button-subtle
 					text="${this.localize('btnEditTurnitin')}"

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -18,26 +18,26 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeActivityEdit
 	static get styles() {
 		return css`
 			:host {
+				align-items: center;
+				background: var(--d2l-color-regolith);
+				border: 1px solid var(--d2l-color-mica);
+				border-radius: 6px;
 				display: flex;
 				flex-direction: row;
 				justify-content: space-between;
-				align-items: center;
-				background: var(--d2l-color-regolith);
-				border-radius: 6px;
-				border: 1px solid var(--d2l-color-mica);
 				padding: 12px;
 			}
 
-			.button-container {
+			.d2l-button-container {
 				display: flex;
 				flex-direction: row;
 				width: 100%;
 			}
 
-			.button-container-right {
+			.d2l-button-container-right {
 				margin-left: auto;
 			}
-			:host([dir="rtl"]) .button-container-right {
+			:host([dir="rtl"]) .d2l-button-container-right {
 				margin-left: 0;
 				margin-right: auto;
 			}
@@ -47,8 +47,8 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeActivityEdit
 				display: inline-block;
 			}
 
-			.button-container-small {
-				display:none
+			.d2l-button-container-small {
+				display: none;
 			}
 
 			@media only screen and (max-width: 768px) {
@@ -56,10 +56,10 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeActivityEdit
 					padding: 2px;
 				}
 
-				.button-container {
+				.d2l-button-container {
 					display: none;
 				}
-				.button-container-small {
+				.d2l-button-container-small {
 					display: block;
 				}
 			}
@@ -256,7 +256,7 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeActivityEdit
 		} = collection;
 
 		return html`
-			<div class="button-container">
+			<div class="d2l-button-container">
 				<d2l-button-icon
 					id="add-file-button"
 					icon="d2l-tier1:upload"
@@ -317,7 +317,7 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeActivityEdit
 					aria-hidden="true"
 					disable-focus-lock>${this.localize('attachments.addOneDriveLink')}</d2l-tooltip>
 
-				<div class="button-container-right">
+				<div class="d2l-button-container-right">
 					<d2l-button-subtle
 						id="record-audio-button"
 						icon="tier1:mic"
@@ -334,7 +334,7 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeActivityEdit
 					</d2l-button-subtle>
 				</div>
 			</div>
-			<div class="button-container-small">
+			<div class="d2l-button-container-small">
 				<d2l-dropdown>
 					<d2l-button-icon
 						id="attach-dropdown"
@@ -375,7 +375,7 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeActivityEdit
 						</d2l-menu>
 					</d2l-dropdown-menu>
 				</d2l-dropdown>
-				<span class="button-container-right">
+				<span class="d2l-button-container-right">
 					<d2l-button-icon
 						id="record-audio-button-small"
 						icon="tier1:mic"

--- a/components/d2l-activity-editor/d2l-activity-competencies.js
+++ b/components/d2l-activity-editor/d2l-activity-competencies.js
@@ -28,23 +28,23 @@ class ActivityCompetencies extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 				:host([hidden]) {
 					display: none;
 				}
-				.competencies-icon {
+				.d2l-competencies-icon {
 					margin-right: 0.6rem;
 				}
-				:host([dir="rtl"]) .competencies-icon {
+				:host([dir="rtl"]) .d2l-competencies-icon {
 					margin-left: 0.6rem;
 					margin-right: 0;
 				}
-				.competencies-count-container {
-					display: flex;
+				.d2l-competencies-count-container {
 					align-items: center;
+					display: flex;
 					margin-bottom: 0.3rem;
 				}
-				.competencies-count-text {
+				.d2l-competencies-count-text {
 					font-size: 0.7rem;
 					line-height: 0.7rem;
 				}
-				.alert-icon {
+				.d2l-alert-icon {
 					color: red;
 				}
 				.d2l-body-small {
@@ -121,8 +121,8 @@ class ActivityCompetencies extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 		}
 
 		return html`
-			<d2l-icon class="competencies-icon" icon="tier1:user-competencies"></d2l-icon>
-			<div class="competencies-count-text">${langTerm}</div>
+			<d2l-icon class="d2l-competencies-icon" icon="tier1:user-competencies"></d2l-icon>
+			<div class="d2l-competencies-count-text">${langTerm}</div>
 		`;
 	}
 
@@ -132,9 +132,9 @@ class ActivityCompetencies extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 		}
 
 		return html`
-			<div class="competencies-count-container">
-				<d2l-icon class="competencies-icon alert-icon" icon="tier1:alert"></d2l-icon>
-				<div class="competencies-count-text">${this.localize('editor.unevaluatedCompetencies', { count })}</div>
+			<div class="d2l-competencies-count-container">
+				<d2l-icon class="d2l-competencies-icon d2l-alert-icon" icon="tier1:alert"></d2l-icon>
+				<div class="d2l-competencies-count-text">${this.localize('editor.unevaluatedCompetencies', { count })}</div>
 			</div>
 		`;
 	}
@@ -153,7 +153,7 @@ class ActivityCompetencies extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 
 		return html`
 			<label class="d2l-label-text">${this.localize('editor.competencies')}</label>
-			<div class="competencies-count-container">
+			<div class="d2l-competencies-count-container">
 				${this._renderCountText(count)}
 			</div>
 			${this._renderUnevalCountText(unevalCount)}

--- a/components/d2l-activity-editor/d2l-activity-conditions-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-conditions-editor.js
@@ -34,19 +34,19 @@ class ActivityConditionsEditor
 			}
 
 			.d2l-input-select {
-				width: 100%;
-				max-width: 300px;
 				display: block;
+				max-width: 300px;
+				width: 100%;
 			}
 
 			d2l-dropdown-button-subtle {
 				margin-left: -0.6rem;
 			}
 
-			.conditions {
+			.d2l-conditions {
+				list-style: none;
 				margin: 0;
 				padding: 0;
-				list-style: none;
 			}
 			`,
 			...this.listItemStyles
@@ -59,34 +59,34 @@ class ActivityConditionsEditor
 			bodyCompactStyles,
 			css`
 			.d2l-list-item {
-				display: flex;
-				margin-top: 0.5rem;
-				margin-bottom: 0.5rem;
 				align-items: center;
+				display: flex;
+				margin-bottom: 0.5rem;
+				margin-top: 0.5rem;
 			}
 
-			.d2l-list-item-body{
-				flex-grow: 1;
+			.d2l-list-item-body {
 				border: 1px solid var(--d2l-color-chromite);
 				border-radius: 6px;
+				flex-grow: 1;
 				padding: 12px;
 			}
 
 			.d2l-list-item-decoration {
-				flex: 0 0 auto;
 				display: flex;
-				margin-right: 12px;
+				flex: 0 0 auto;
+				float: left;
 				margin-bottom: 2px;
-				float: left;	
+				margin-right: 12px;
 			}
 
 			.d2l-list-item-content {
-				flex: 1 1 auto;
 				align-self: center;
+				flex: 1 1 auto;
 				float: left;
-				max-width: 80%;
-				margin-top: -6px;
 				margin-bottom: -5px;
+				margin-top: -6px;
+				max-width: 80%;
 			}
 
 			.d2l-list-item-deleter {
@@ -229,7 +229,7 @@ class ActivityConditionsEditor
 	_renderConditions({ conditions }) {
 
 		return html`
-			<ul class="conditions">
+			<ul class="d2l-conditions">
 				${conditions.map(this._renderCondition, this)}
 			</ul>
 		`;

--- a/components/d2l-activity-editor/d2l-activity-editor-buttons.js
+++ b/components/d2l-activity-editor/d2l-activity-editor-buttons.js
@@ -19,17 +19,17 @@ class ActivityEditorButtons extends RtlMixin(LocalizeActivityEditorMixin(LitElem
 				margin-left: 0.75rem;
 				margin-right: 0;
 			}
-			.mobile {
+			.d2l-mobile {
 				display: none;
 			}
 			@media only screen and (max-width: 615px) {
-				.desktop {
+				.d2l-desktop {
 					display: none;
 				}
-				.mobile {
+				.d2l-mobile {
 					display: inline-block;
 				}
-				.footerBtn {
+				.d2l-footerBtn {
 					margin: 0;
 				}
 			}
@@ -56,9 +56,9 @@ class ActivityEditorButtons extends RtlMixin(LocalizeActivityEditorMixin(LitElem
 
 	render() {
 		return html`
-			<d2l-button class="desktop" primary @click="${this._save}">${this.localize('editor.btnSave')}</d2l-button>
-			<d2l-button class="mobile footerBtn" primary @click="${this._save}">${this.localize('editor.btnSaveMobile')}</d2l-button>
-			<d2l-button class="footerBtn" @click="${this._cancel}">${this.localize('editor.btnCancel')}</d2l-button>
+			<d2l-button class="d2l-desktop" primary @click="${this._save}">${this.localize('editor.btnSave')}</d2l-button>
+			<d2l-button class="d2l-mobile d2l-footerBtn" primary @click="${this._save}">${this.localize('editor.btnSaveMobile')}</d2l-button>
+			<d2l-button class="d2l-footerBtn" @click="${this._cancel}">${this.localize('editor.btnCancel')}</d2l-button>
 		`;
 	}
 }

--- a/components/d2l-activity-editor/d2l-activity-grades-dialog.js
+++ b/components/d2l-activity-editor/d2l-activity-grades-dialog.js
@@ -41,19 +41,19 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeActivityEditorMix
 				margin-bottom: 18px;
 			}
 			.d2l-activity-grades-dialog-create-new-activity-name {
-				word-break: break-word;
 				overflow-wrap: anywhere; /* not supported by safari */
+				word-break: break-word;
 			}
 			.d2l-activity-grades-dialog-create-new-icon {
 				padding-right: 9px;
 			}
 			:host([dir="rtl"]) .d2l-activity-grades-dialog-create-new-icon {
-				padding-right: 0;
 				padding-left: 9px;
+				padding-right: 0;
 			}
 			.d2l-activity-grades-dialog-grade-icon {
-				padding-top: 6px;
 				padding-bottom: 6px;
+				padding-top: 6px;
 			}
 			.d2l-input-radio-label-disabled {
 				margin-bottom: 0;

--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grade-category-selector.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grade-category-selector.js
@@ -28,8 +28,8 @@ class ActivityGradeCategorySelector extends ActivityEditorMixin(LocalizeActivity
 				padding-bottom: 8px;
 			}
 			#d2l-activity-grade-category-selector {
-				margin-top: 16px;
 				margin-bottom: 32px;
+				margin-top: 16px;
 			}
 			`
 		];

--- a/components/d2l-activity-editor/d2l-activity-html-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-editor.js
@@ -2,6 +2,7 @@ import 'd2l-html-editor/d2l-html-editor.js';
 import 'd2l-html-editor/d2l-html-editor-client.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { getUniqueId } from '@brightspace-ui/core/helpers/uniqueId';
+import { inputStyles } from '@brightspace-ui/core/components/inputs/input-styles';
 import { LocalizeActivityEditorMixin } from './mixins/d2l-activity-editor-lang-mixin.js';
 import { resolveUrl } from '@polymer/polymer/lib/utils/resolve-url.js';
 
@@ -18,19 +19,19 @@ class ActivityHtmlEditor extends LocalizeActivityEditorMixin(LitElement) {
 	}
 
 	static get styles() {
-		return css`
+		return [ inputStyles, css`
 			:host {
 				display: flex;
-				width: 100%
+				width: 100%;
 			}
 			:host([hidden]) {
 				display: none;
 			}
 
 			d2l-html-editor {
-				word-wrap: break-word;
 				display: flex;
 				width: 100%;
+				word-wrap: break-word;
 			}
 			d2l-html-editor > .d2l-html-editor-container > p:first-of-type {
 				margin-top: 0;
@@ -41,79 +42,7 @@ class ActivityHtmlEditor extends LocalizeActivityEditorMixin(LitElement) {
 			d2l-html-editor > .d2l-html-editor-container * {
 				max-width: 100%;
 			}
-
-			/*
-			Styles copied from d2l-inputs-shared-styles; once BrightspaceUI/inputs
-			is converted to LitElement, we can import these directly.
-			*/
-			d2l-html-editor > .d2l-html-editor-container {
-				--d2l-input-border-radius: 0.3rem;
-				--d2l-input-height: auto;
-				--d2l-input-line-height: 1.2rem;
-				--d2l-input-width: 100%;
-				--d2l-input-background-color: #ffffff;
-				--d2l-input-border-color: var(--d2l-color-galena);
-				--d2l-input-boxshadow: inset 0 2px 0 0 rgba(181, 189, 194, .2); /* corundum */
-				--d2l-input-padding: 0.4rem 0.75rem;
-				--d2l-input-padding-focus: calc(0.4rem - 1px) calc(0.75rem - 1px);
-				--d2l-input-color: var(--d2l-color-ferrite);
-				--d2l-input-placeholder-color: var(--d2l-color-mica);
-
-				/* d2l-input-common */
-				border-radius: var(--d2l-input-border-radius);
-				border-style: solid;
-				border-color: var(--d2l-input-border-color);
-				box-sizing: border-box;
-				display: inline-block;
-				margin: 0;
-				min-width: calc(2rem + 1em);
-				vertical-align: middle;
-				width: var(--d2l-input-width);
-				transition: background-color 0.5s ease, border-color 0.001s ease;
-
-				/* d2l-input-text */
-				color: var(--d2l-input-color);
-				font-size: 0.8rem;
-				font-weight: 400;
-				letter-spacing: 0.02rem;
-				line-height: var(--d2l-input-line-height);
-				min-height: calc(2rem + 2px);
-
-				/* d2l-input-hover-disabled */
-				background-color: var(--d2l-input-background-color);
-				border-color: var(--d2l-input-border-color);
-				border-width: 1px;
-				box-shadow: var(--d2l-input-boxshadow);
-				padding: var(--d2l-input-padding);
-
-				height: var(--d2l-input-height)
-			}
-			d2l-html-editor > .d2l-html-editor-container:hover,
-			d2l-html-editor > .d2l-html-editor-container:focus {
-				/* d2l-input-hover-focus */
-				border-color: var(--d2l-color-celestine);
-				border-width: 2px;
-				outline-style: none;
-				outline-width: 0;
-				padding: var(--d2l-input-padding-focus);
-			}
-			d2l-html-editor.invalid > .d2l-html-editor-container {
-				/* d2l-input-invalid */
-				border-color: var(--d2l-color-cinnabar);
-			}
-			d2l-html-editor[disabled] > .d2l-html-editor-container {
-				/* d2l-input-disabled */
-				opacity: 0.5;
-			}
-			d2l-html-editor[disabled] > .d2l-html-editor-container:hover {
-				/* d2l-input-hover-disabled */
-				background-color: var(--d2l-input-background-color);
-				border-color: var(--d2l-input-border-color);
-				border-width: 1px;
-				box-shadow: var(--d2l-input-boxshadow);
-				padding: var(--d2l-input-padding);
-			}
-		`;
+		`];
 	}
 
 	constructor() {
@@ -150,7 +79,7 @@ class ActivityHtmlEditor extends LocalizeActivityEditorMixin(LitElement) {
 
 				<div id="toolbar-shortcut-${this._htmlEditorUniqueId}" hidden="">${this.localize('editor.ariaToolbarShortcutInstructions')}</div>
 				<div
-					class="d2l-html-editor-container"
+					class="d2l-html-editor-container d2l-input"
 					id="${this._htmlEditorUniqueId}"
 					aria-label="${this.ariaLabel}"
 					aria-describedby="toolbar-shortcut-${this._htmlEditorUniqueId}"

--- a/components/d2l-activity-editor/d2l-activity-html-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-editor.js
@@ -42,6 +42,16 @@ class ActivityHtmlEditor extends LocalizeActivityEditorMixin(LitElement) {
 			d2l-html-editor > .d2l-html-editor-container * {
 				max-width: 100%;
 			}
+
+			/* Disabled styles copied from input-styles */
+			d2l-html-editor[disabled] > .d2l-html-editor-container {
+				opacity: 0.5;
+			}
+			d2l-html-editor[disabled] > .d2l-html-editor-container:hover {
+				border-color: var(--d2l-color-galena);
+				border-width: 1px;
+				padding: var(--d2l-input-padding, 0.4rem 0.75rem);
+			}
 		`];
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -46,20 +46,17 @@ class ActivityRubricsListContainer extends ActivityEditorFeaturesMixin(ActivityE
 				d2l-dropdown-button-subtle {
 					margin-left: -0.6rem;
 				}
-				.rubric-heading-container {
-					display: flex;
+				.d2l-rubric-heading-container {
 					align-items: center;
+					display: flex;
 					margin: 0 0 0.6rem 0;
 				}
-				.default-scoring-rubric-heading-container {
-					display: flex;
+				.d2l-default-scoring-rubric-heading-container {
 					align-items: center;
+					display: flex;
 					margin: 0.6rem 0 0.6rem 0;
 				}
-				.preview-rubrics {
-					flex-shrink: 0;
-				}
-				.rubric-heading-title {
+				.d2l-rubric-heading-title {
 					flex-grow: 1;
 				}
 			`
@@ -236,7 +233,7 @@ class ActivityRubricsListContainer extends ActivityEditorFeaturesMixin(ActivityE
 		}
 
 		return html`
-			<div class="default-scoring-rubric-heading-container">
+			<div class="d2l-default-scoring-rubric-heading-container">
 				<label class="d2l-label-text" for="assignment-default-scoring-rubric">
 					${this.localize('rubrics.defaultScoringRubric')}
 				</label>
@@ -262,8 +259,8 @@ class ActivityRubricsListContainer extends ActivityEditorFeaturesMixin(ActivityE
 		}
 
 		return html`
-			<div class="rubric-heading-container">
-				<h3 class="d2l-heading-4 rubric-heading-title">
+			<div class="d2l-rubric-heading-container">
+				<h3 class="d2l-heading-4 d2l-rubric-heading-title">
 					${this.localize('rubrics.hdrRubrics')}
 				</h3>
 			</div>

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
@@ -26,16 +26,16 @@ class ActivityRubricsListEditor extends ActivityEditorFeaturesMixin(ActivityEdit
 				.d2l-heading-4 {
 					margin: 0 0 0.6rem 0;
 				}
-				.association-container {
-					margin: 0 0 1rem 0;
-					display: flex;
+				.d2l-association-container {
 					align-items: center;
+					display: flex;
+					margin: 0 0 1rem 0;
 				}
-				.delete-association-button {
+				.d2l-delete-association-button {
 					flex-shrink: 0;
 					margin-left: 0.2rem;
 				}
-				.association-box{
+				.d2l-association-box {
 					flex-grow: 1;
 				}
 			`
@@ -84,16 +84,16 @@ class ActivityRubricsListEditor extends ActivityEditorFeaturesMixin(ActivityEdit
 			const canDeleteAssociation = association.entity.canDeleteAssociation() || association.isAssociating;
 
 			return html`
-			<div class="association-container">
+			<div class="d2l-association-container">
 				<d2l-rubric
-					class="association-box"
+					class="d2l-association-box"
 					force-compact
 					.href="${association.rubricHref}"
 					.token="${this.token}">
 				</d2l-rubric>
 				<d2l-button-icon
 					?hidden="${!canDeleteAssociation}"
-					class="delete-association-button"
+					class="d2l-delete-association-button"
 					icon="tier1:close-default"
 					data-id="${association.rubricHref}"
 					@click="${this._deleteAssociation}"

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -45,9 +45,9 @@ class ActivityScoreEditor extends ActivityEditorMixin(LocalizeActivityEditorMixi
 				width: auto;
 			}
 			#ungraded {
-				cursor: pointer;
 				--d2l-input-padding: 0.4rem 1.65rem 0.4rem 0.75rem;
 				--d2l-input-padding-focus: calc(0.4rem - 1px) calc(1.65rem - 1px) calc(0.4rem - 1px) calc(0.75rem - 1px);
+				cursor: pointer;
 			}
 			:host([dir="rtl"]) #ungraded {
 				--d2l-input-padding: 0.4rem 0.75rem 0.4rem 1.65rem;
@@ -59,9 +59,9 @@ class ActivityScoreEditor extends ActivityEditorMixin(LocalizeActivityEditorMixi
 				display: flex;
 			}
 			#score-info-container {
-				flex-wrap: wrap;
 				-webkit-align-items: center;
 				align-items: center;
+				flex-wrap: wrap;
 			}
 			#score-out-of-container {
 				-webkit-align-items: baseline;
@@ -71,70 +71,70 @@ class ActivityScoreEditor extends ActivityEditorMixin(LocalizeActivityEditorMixi
 				-webkit-align-items: center;
 				align-items: center;
 			}
-			.grade-type-text {
+			.d2l-grade-type-text {
 				margin: 0 0.75rem 0 0.6rem;
 			}
-			:host([dir="rtl"]) .grade-type-text {
+			:host([dir="rtl"]) .d2l-grade-type-text {
 				margin: 0 0.6rem 0 0.75rem;
 			}
 			#divider {
-				height: 30px;
 				border-left: solid 1px var(--d2l-color-galena);
+				height: 30px;
 				margin-right: 0.3rem;
 			}
 			:host([dir="rtl"]) #divider {
-				margin-right: 0;
 				margin-left: 0.3rem;
+				margin-right: 0;
 			}
-			.grade-info {
-				height: 42px;
-				border: 2px solid transparent;
+			.d2l-grade-info {
 				background: none;
-				outline: none;
+				border: 2px solid transparent;
 				border-radius: 0.3rem;
-				padding: .5rem .6rem .4rem;
 				cursor: pointer;
 				display: flex;
 				flex-wrap: nowrap;
+				height: 42px;
+				outline: none;
+				padding: 0.5rem 0.6rem 0.4rem;
 			}
-			.grade-info div {
+			.d2l-grade-info div {
 				flex-shrink: 1;
 			}
-			.grade-info d2l-icon {
+			.d2l-grade-info d2l-icon {
 				flex-shrink: 0;
 			}
-			.grade-info > * {
+			.d2l-grade-info > * {
 				margin-right: 0.3rem;
 			}
-			.grade-info > *:last-child {
+			.d2l-grade-info > *:last-child {
 				margin-right: 0;
 			}
-			:host([dir="rtl"]) .grade-info > * {
-				margin-right: 0;
+			:host([dir="rtl"]) .d2l-grade-info > * {
 				margin-left: 0.5rem;
+				margin-right: 0;
 			}
-			:host([dir="rtl"]) .grade-info > *:last-child {
+			:host([dir="rtl"]) .d2l-grade-info > *:last-child {
 				margin-left: 0;
 			}
-			.grade-info:hover,
-			.grade-info[active] {
+			.d2l-grade-info:hover,
+			.d2l-grade-info[active] {
 				border-color: var(--d2l-color-mica);
 				border-width: 1px;
-				padding: calc(.5rem + 1px) calc(.6rem + 1px); /* 1px is difference in border width */
+				padding: calc(0.5rem + 1px) calc(0.6rem + 1px); /* 1px is difference in border width */
 			}
-			.grade-info:focus {
+			.d2l-grade-info:focus {
 				border-color: var(--d2l-color-celestine);
 				border-width: 2px;
-				padding: .5rem .6rem .4rem;
+				padding: 0.5rem 0.6rem 0.4rem;
 			}
-			.grade-info:hover > *,
-			.grade-info:focus > * {
+			.d2l-grade-info:hover > *,
+			.d2l-grade-info:focus > * {
 				color: var(--d2l-color-celestine-minus-1);
 			}
 			button {
 				/* needed otherwise user agent style overrides this */
-				font-family: inherit;
 				color: inherit;
+				font-family: inherit;
 			}
 			`
 		];
@@ -277,13 +277,13 @@ class ActivityScoreEditor extends ActivityEditorMixin(LocalizeActivityEditorMixi
 							${scoreOutOfError ? html`<span>${this.localize(`editor.${scoreOutOfError}`)}</span>` : null}
 						</d2l-tooltip>
 					` : null}
-					<div class="d2l-body-compact grade-type-text">${gradeType}</div>
+					<div class="d2l-body-compact d2l-grade-type-text">${gradeType}</div>
 				</div>
 				${canSeeGrades ? html`
 					<div id="grade-info-container">
 						<div id="divider"></div>
 						<d2l-dropdown>
-							<button class="d2l-label-text grade-info d2l-dropdown-opener">
+							<button class="d2l-label-text d2l-grade-info d2l-dropdown-opener">
 								${inGrades ? html`<d2l-icon icon="tier1:grade"></d2l-icon>` : null}
 								<div>${inGrades ? this.localize('editor.inGrades') : this.localize('editor.notInGrades')}</div>
 								<d2l-icon icon="tier1:chevron-down"></d2l-icon>

--- a/components/d2l-activity-editor/d2l-activity-special-access-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-special-access-editor.js
@@ -26,19 +26,19 @@ class ActivitySpecialAccessEditor extends ActivityEditorMixin(RtlMixin(LocalizeA
 			d2l-button-subtle {
 				margin-left: -0.6rem;
 			}
-			.special-access-user-count-icon {
+			.d2l-special-access-user-count-icon {
 				margin-right: 0.2rem;
 			}
-			:host([dir="rtl"]) .special-access-user-count-icon {
+			:host([dir="rtl"]) .d2l-special-access-user-count-icon {
 				margin-left: 0.2rem;
 				margin-right: 0;
 			}
-			.special-access-user-count-text {
+			.d2l-special-access-user-count-text {
 				display: inline-block;
 				font-size: 0.7rem;
 				line-height: 0.7rem;
 			}
-			.alert-icon {
+			.d2l-alert-icon {
 				color: red;
 			}
 			`
@@ -68,14 +68,14 @@ class ActivitySpecialAccessEditor extends ActivityEditorMixin(RtlMixin(LocalizeA
 
 		const userCountText = html`${this.localize('editor.specialAccessCount', { count: userCount })}`;
 		const icon = isRestricted && userCount === 0 ?
-			html`<d2l-icon class="special-access-user-count-icon alert-icon" icon="tier1:alert"></d2l-icon>` :
-			html`<d2l-icon class="special-access-user-count-icon" icon="tier1:access-special"></d2l-icon>`;
+			html`<d2l-icon class="d2l-special-access-user-count-icon d2l-alert-icon" icon="tier1:alert"></d2l-icon>` :
+			html`<d2l-icon class="d2l-special-access-user-count-icon" icon="tier1:access-special"></d2l-icon>`;
 
 		return html`
 			<label class="d2l-label-text">${specialAccessTypeDescription}</label>
 			<div class="special-access-user-count-container">
 				${icon}
-				<div class="special-access-user-count-text">${userCountText}</div>
+				<div class="d2l-special-access-user-count-text">${userCountText}</div>
 			</div>
 		`;
 	}

--- a/components/d2l-quick-eval/dismiss/d2l-quick-eval-action-dismiss-dialog.js
+++ b/components/d2l-quick-eval/dismiss/d2l-quick-eval-action-dismiss-dialog.js
@@ -39,10 +39,10 @@ class D2LQuickEvalActionDialog extends RtlMixin(LitQuickEvalLocalize(LitElement)
 
 	static get styles() {
 		return [ labelStyles, bodyStandardStyles, radioStyles, css`
-			.radio-container {
+			.d2l-radio-container {
 				margin-top: 0.5rem;
 			}
-			.datepicker-container {
+			.d2l-datepicker-container {
 				margin-bottom: 0.9rem;
 			}
 			` ];
@@ -56,7 +56,7 @@ class D2LQuickEvalActionDialog extends RtlMixin(LitQuickEvalLocalize(LitElement)
 				<div class="d2l-body-standard">${this.localize('dismissingAnActivityHides')}</div>
 				<br/>
 				<p class="d2l-label-text">${this.localize('dismissUntil')}</p>
-				<div class="radio-container">
+				<div class="d2l-radio-container">
 					<label class="d2l-input-radio-label">
 						<input
 						id="dismiss-action-dialog-radio-input-nextSubmission"
@@ -139,7 +139,7 @@ class D2LQuickEvalActionDialog extends RtlMixin(LitQuickEvalLocalize(LitElement)
 
 		if (selectedRadio === DISMISS_TYPES.date) {
 			return html`
-				<div class="datepicker-container">
+				<div class="d2l-datepicker-container">
 					<d2l-datetime-picker
 						@d2l-datetime-picker-datetime-changed="${this._onDatetimePickerDatetimeChanged}"
 						@d2l-datetime-picker-datetime-cleared="${this._onDatetimePickerDatetimeCleared}"

--- a/components/d2l-quick-eval/view-toggle/d2l-quick-eval-view-toggle-button.js
+++ b/components/d2l-quick-eval/view-toggle/d2l-quick-eval-view-toggle-button.js
@@ -7,21 +7,21 @@ class D2LQuickEvalViewToggleButton extends LitElement {
 		return css`
 		button.d2l-quick-eval-view-toggle-left,
 		:host([dir='rtl']) button.d2l-quick-eval-view-toggle-right {
-			border-top-left-radius: 0.3rem;
 			border-bottom-left-radius: 0.3rem;
-			border-right-color: transparent;
-			border-top-right-radius: 0rem;
 			border-bottom-right-radius: 0;
 			border-left-color: var(--d2l-color-mica);
+			border-right-color: transparent;
+			border-top-left-radius: 0.3rem;
+			border-top-right-radius: 0;
 		}
 		button.d2l-quick-eval-view-toggle-right,
 		:host([dir='rtl']) button.d2l-quick-eval-view-toggle-left {
-			border-top-right-radius: 0.3rem;
+			border-bottom-left-radius: 0;
 			border-bottom-right-radius: 0.3rem;
 			border-left-color: transparent;
-			border-top-left-radius: 0rem;
-			border-bottom-left-radius: 0rem;
 			border-right-color: var(--d2l-color-mica);
+			border-top-left-radius: 0;
+			border-top-right-radius: 0.3rem;
 		}
 		button {
 			background-color: var(--d2l-color-sylvite);
@@ -34,20 +34,20 @@ class D2LQuickEvalViewToggleButton extends LitElement {
 			display: inline;
 			flex: 1;
 			font-family: inherit;
-			font-size: .7rem;
+			font-size: 0.7rem;
 			font-weight: 700;
 			margin: 0;
 			min-height: calc(2rem + 2px);
 			outline: none;
 			padding: 0.5rem 1.5rem;
 			text-align: center;
+			-webkit-user-select: none;
+			-moz-user-select: none;
+			-ms-user-select: none;
 			user-select: none;
 			vertical-align: middle;
 			white-space: nowrap;
 			width: auto;
-			-webkit-user-select: none;
-			-moz-user-select: none;
-			-ms-user-select: none;
 		}
 		button:hover, button:focus {
 			border: 1px solid var(--d2l-color-celestine) !important;
@@ -64,7 +64,7 @@ class D2LQuickEvalViewToggleButton extends LitElement {
 	}
 
 	render() {
-		return html`<button 
+		return html`<button
 				class="d2l-quick-eval-view-toggle-${this.side}"
 				aria-pressed="${this.selected.toString()}"
 				?selected="${this.selected}"

--- a/components/d2l-subtitle/d2l-subtitle.js
+++ b/components/d2l-subtitle/d2l-subtitle.js
@@ -4,11 +4,11 @@ class D2LSubtitle extends LitElement {
 	static get styles() {
 		return css`
 			span {
-				font-size: .6rem;
+				font-size: 0.6rem;
 			}
 			span::before {
 				content: "\u2022";
-				margin: .2rem;
+				margin: 0.2rem;
 			}
 			:host span:first-of-type::before {
 				content: "";
@@ -16,11 +16,11 @@ class D2LSubtitle extends LitElement {
 			}
 			@media (min-width: 900px) {
 				span {
-					font-size: .7rem;
-					line-height: .9rem;
+					font-size: 0.7rem;
+					line-height: 0.9rem;
 				}
 				:host {
-					line-height: .9rem;
+					line-height: 0.9rem;
 				}
 			}
 		`;

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "name": "d2l-activities",
   "scripts": {
     "build": "gulp build",
-    "lint": "npm run lint:wc && npm run lint:js",
+    "lint": "npm run lint:style && npm run lint:wc && npm run lint:js",
     "lint:js": "eslint . --ext .js,.html test/**/*.js test/**/*.html demo/**/*.html",
+    "lint:style": "stylelint \"**/*.js\"",
     "lint:wc": "polymer lint -i \"./*\" \"components\" \"demo\" \"test\"",
     "test:diff": "mocha test/**/*.visual-diff.js -t 40000",
     "test:diff:golden": "mocha test/**/*.visual-diff.js -t 40000 --golden",
@@ -75,6 +76,7 @@
     "@brightspace-ui-labs/list-item-accumulator": "^1.0.0",
     "@brightspace-ui/core": "^1.55.0",
     "@brightspace-ui/intl": "^3.0.1",
+    "@brightspace-ui/stylelint-config": "^0.0.1",
     "@d2l/d2l-attachment": "Brightspace/attachment#semver:^1",
     "@polymer/iron-resizable-behavior": "^3.0.0",
     "@polymer/polymer": "^3.0.0",
@@ -112,6 +114,7 @@
     "merge-stream": "^1.0.1",
     "mobx": "^5.15.2",
     "require-dir": "^1.2.0",
-    "siren-sdk": "BrightspaceHypermediaComponents/siren-sdk#semver:^1"
+    "siren-sdk": "BrightspaceHypermediaComponents/siren-sdk#semver:^1",
+    "stylelint": "^13.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@babel/core": "^7.8.3",
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.8.3",
+    "@brightspace-ui/stylelint-config": "^0.0.1",
     "@brightspace-ui/visual-diff": "^1.0.1",
     "@open-wc/testing": "^2.5.1",
     "@polymer/iron-component-page": "^3.0.0-pre.18",
@@ -56,6 +57,7 @@
     "polymer-cli": "^1.9.2",
     "puppeteer": "^1",
     "sinon": "^9.0.1",
+    "stylelint": "^13.6.1",
     "url-polyfill": "^1.1.3",
     "wct-browser-legacy": "^1.0.1",
     "wct-mocha": "^1.0.1",
@@ -76,7 +78,6 @@
     "@brightspace-ui-labs/list-item-accumulator": "^1.0.0",
     "@brightspace-ui/core": "^1.55.0",
     "@brightspace-ui/intl": "^3.0.1",
-    "@brightspace-ui/stylelint-config": "^0.0.1",
     "@d2l/d2l-attachment": "Brightspace/attachment#semver:^1",
     "@polymer/iron-resizable-behavior": "^3.0.0",
     "@polymer/polymer": "^3.0.0",
@@ -114,7 +115,6 @@
     "merge-stream": "^1.0.1",
     "mobx": "^5.15.2",
     "require-dir": "^1.2.0",
-    "siren-sdk": "BrightspaceHypermediaComponents/siren-sdk#semver:^1",
-    "stylelint": "^13.6.1"
+    "siren-sdk": "BrightspaceHypermediaComponents/siren-sdk#semver:^1"
   }
 }


### PR DESCRIPTION
Adds the new [`@brightspaceUI/stylelint-config`](https://github.com/BrightspaceUI/stylelint-config) integration and makes the existing files compliant. More info in the [blog post](https://blog.d2l.dev/2020/08/04/style-linting/).

Most of the changes are reordering styles to be in alphabetical order, and renaming classes to have the required `d2l-` prefix.

One other change is to use the shared core styles for the html editor. We were previously using a copy of them from before their conversion to Lit.

There are a couple of files with the eol char has changed, so ignoring white space might make the diff more manageable.