### PR TITLE
US114853 - Use the new d2l-hm-filter in Quick Eval

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -128,7 +128,7 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 				<d2l-hm-filter
 					href="[[filterHref]]"
 					token="[[token]]"
-					category-whitelist="[[filterIds]]"
+					category-include-list="[[filterIds]]"
 					lazy-load-options>
 				</d2l-hm-filter>
 				<d2l-hm-search

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -98,7 +98,7 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 				<d2l-hm-filter
 					href="[[filterHref]]"
 					token="[[token]]"
-					category-whitelist="[[filterIds]]"
+					category-include-list="[[filterIds]]"
 					result-size="[[_numberOfActivitiesToShow]]"
 					lazy-load-options>
 				</d2l-hm-filter>

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "d2l-button": "BrightspaceUI/button#semver:^5",
     "d2l-card": "BrightspaceUI/card#semver:^6",
     "d2l-colors": "BrightspaceUI/colors#semver:^4",
-    "d2l-common": "BrightspaceHypermediaComponents/common#semver:^2",
+    "d2l-common": "BrightspaceHypermediaComponents/common#semver:^3",
     "d2l-datetime-picker": "BrightspaceUI/datetime-picker#semver:^4",
     "d2l-dropdown": "BrightspaceUI/dropdown#semver:^7",
     "d2l-fetch": "Brightspace/d2l-fetch.git#semver:^2",


### PR DESCRIPTION
This will fail until https://github.com/BrightspaceHypermediaComponents/common/pull/36 is merged and the major version bump is done - just getting the PR ready.