### PR TITLE
US119006 Disable annotations editor if action is not available

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-editor.js
@@ -53,11 +53,6 @@ class ActivityAssignmentAnnotationsEditor
 			return html``;
 		}
 
-		const shouldRenderEditor = entity.canSeeAnnotations;
-		if (!shouldRenderEditor) {
-			return html``;
-		}
-
 		return html`
 			<label class="d2l-label-text">
 				${this.localize('annotationTools')}
@@ -65,7 +60,8 @@ class ActivityAssignmentAnnotationsEditor
 			<d2l-input-checkbox
 				@change="${this._toggleAnnotationToolsAvailability}"
 				?checked="${entity.annotationToolsAvailable}"
-				ariaLabel="${this.localize('annotationToolDescription')}">
+				ariaLabel="${this.localize('annotationToolDescription')}"
+				?disabled="${!entity.canSeeAnnotations}">
 				${this.localize('annotationToolDescription')}
 			</d2l-input-checkbox>
 		`;

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-editor.js
@@ -61,7 +61,7 @@ class ActivityAssignmentAnnotationsEditor
 				@change="${this._toggleAnnotationToolsAvailability}"
 				?checked="${entity.annotationToolsAvailable}"
 				ariaLabel="${this.localize('annotationToolDescription')}"
-				?disabled="${!entity.canSeeAnnotations}">
+				?disabled="${!entity.canEditAnnotations}">
 				${this.localize('annotationToolDescription')}
 			</d2l-input-checkbox>
 		`;

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-summary.js
@@ -20,7 +20,7 @@ class ActivityAssignmentAnnotationsSummary
 		}
 
 		const shouldRenderSummaryText =
-			entity.canSeeAnnotations &&
+			entity.canEditAnnotations &&
 			!entity.annotationToolsAvailable;
 		if (!shouldRenderSummaryText) {
 			return html``;

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -86,7 +86,7 @@ export class Assignment {
 		this.canEditInstructions = entity.canEditInstructions();
 		this.instructionsRichTextEditorConfig = entity.instructionsRichTextEditorConfig();
 		this.anonymousMarkingHelpText = entity.getAnonymousMarkingHelpText();
-		this.canSeeAnnotations = entity.canSeeAnnotations();
+		this.canEditAnnotations = entity.canEditAnnotations();
 		this.annotationToolsAvailable = entity.getAvailableAnnotationTools();
 		this.activityUsageHref = entity.activityUsageHref();
 		this.canEditTurnitin = entity.canEditTurnitin();
@@ -290,7 +290,7 @@ decorate(Assignment, {
 	isAnonymousMarkingEnabled: observable,
 	canEditAnonymousMarking: observable,
 	anonymousMarkingHelpText: observable,
-	canSeeAnnotations: observable,
+	canEditAnnotations: observable,
 	annotationToolsAvailable: observable,
 	activityUsageHref: observable,
 	completionTypeOptions: observable,

--- a/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
@@ -35,7 +35,7 @@ describe('Assignment ', function() {
 				isAnonymousMarkingEnabled: () => undefined,
 				canEditAnonymousMarking: () => undefined,
 				getAnonymousMarkingHelpText: () => undefined,
-				canSeeAnnotations: () => undefined,
+				canEditAnnotations: () => undefined,
 				getAvailableAnnotationTools: () => undefined,
 				activityUsageHref: () => 'http://activity/1',
 				submissionTypeOptions: () => [


### PR DESCRIPTION
Previously the annotations editor was being hidden completely if the edit actions is not available. With the new read-only design, this should change to show a disabled editor.