### PR TITLE
DE39814 - Make sure new grade candidates are fetched when doing an A…

### DIFF
--- a/components/d2l-activity-editor/state/activity-score-grade.js
+++ b/components/d2l-activity-editor/state/activity-score-grade.js
@@ -124,6 +124,12 @@ export class ActivityScoreGrade {
 
 		return newGradeCandidateEntity.getSaveAction();
 	}
+
+	async save() {
+		if (this.inGrades && this.createNewGrade) {
+			await this.fetchNewGradeCandidates();
+		}
+	}
 }
 
 decorate(ActivityScoreGrade, {

--- a/components/d2l-activity-editor/state/activity-score-grade.js
+++ b/components/d2l-activity-editor/state/activity-score-grade.js
@@ -125,7 +125,7 @@ export class ActivityScoreGrade {
 		return newGradeCandidateEntity.getSaveAction();
 	}
 
-	async save() {
+	async primeGradeSave() {
 		if (this.inGrades && this.createNewGrade) {
 			await this.fetchNewGradeCandidates();
 		}
@@ -159,5 +159,6 @@ decorate(ActivityScoreGrade, {
 	fetchGradeCandidates: action,
 	fetchNewGradeCandidates: action,
 	linkToNewGrade: action,
-	setNewGradeName: action
+	setNewGradeName: action,
+	primeGradeSave: action
 });

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -197,7 +197,7 @@ export class ActivityUsage {
 
 		await this.saveAlignments();
 
-		await this.scoreAndGrade.save();
+		await this.scoreAndGrade.primeGradeSave();
 
 		await this._entity.save(this._makeUsageData());
 

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -197,6 +197,8 @@ export class ActivityUsage {
 
 		await this.saveAlignments();
 
+		await this.scoreAndGrade.save();
+
 		await this._entity.save(this._makeUsageData());
 
 		await this.fetch();

--- a/test/d2l-activity-editor/state/activity-usage.spec.js
+++ b/test/d2l-activity-editor/state/activity-usage.spec.js
@@ -5,6 +5,7 @@ import { AlignmentsCollectionEntity } from 'siren-sdk/src/alignments/AlignmentsC
 import { CompetenciesEntity } from 'siren-sdk/src/competencies/CompetenciesEntity.js';
 import { expect } from 'chai';
 import { fetchEntity } from '../../../components/d2l-activity-editor/state/fetch-entity.js';
+import { GradeCandidateCollectionEntity } from 'siren-sdk/src/activities/GradeCandidateCollectionEntity';
 import sinon from 'sinon';
 import { when } from 'mobx';
 
@@ -12,6 +13,7 @@ jest.mock('siren-sdk/src/activities/ActivitySpecialAccessEntity.js');
 jest.mock('siren-sdk/src/activities/ActivityUsageEntity.js');
 jest.mock('siren-sdk/src/alignments/AlignmentsCollectionEntity.js');
 jest.mock('siren-sdk/src/competencies/CompetenciesEntity.js');
+jest.mock('siren-sdk/src/activities/GradeCandidateCollectionEntity.js');
 jest.mock('../../../components/d2l-activity-editor/state/fetch-entity.js');
 
 describe('Activity Usage', function() {
@@ -57,6 +59,7 @@ describe('Activity Usage', function() {
 		ActivitySpecialAccessEntity.mockClear();
 		ActivityUsageEntity.mockClear();
 		AlignmentsCollectionEntity.mockClear();
+		GradeCandidateCollectionEntity.mockClear();
 		fetchEntity.mockClear();
 	});
 
@@ -260,6 +263,13 @@ describe('Activity Usage', function() {
 			}));
 
 			fetchEntity.mockImplementation(() => sirenEntity);
+
+			const gradeCandidateCollectionEntityMock = {
+				href: () => 'http://grade-candidate-collection-href',
+				getGradeCandidates: () => [],
+				getAssociateNewGradeAction: () => {}
+			};
+			GradeCandidateCollectionEntity.mockImplementation(() => gradeCandidateCollectionEntityMock);
 		});
 
 		it('saves', async() => {


### PR DESCRIPTION
…ctivity-Usage PATCH for all create new grade scenarios

The `fetchNewGradeCandidates()` was only being called if the Choose From Grades dialog was opened once. But now, if "In Grades" is selected and it was previously ungraded or not in grades, we should still be fetching the new grade candidates in order to use its fields as part of the activity-usage PATCH.

https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fdefect%2F405157847512

**Associated PRs**
https://git.dev.d2l/projects/CORE/repos/lms/pull-requests/14588/overview
https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/211