### PR TITLE
Kapatel/user/de39269 hide rubrics label when the 

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -177,7 +177,7 @@ class ActivityRubricsListContainer extends ActivityEditorFeaturesMixin(ActivityE
 	_renderRubricsList(entity) {
 		const canCreatePotentialAssociation = entity.canCreatePotentialAssociation();
 		const canCreateAssociation = entity.canCreateAssociation();
-		const totalAssociations = entity.fetchAssociations().length;
+		const totalAssociations = entity.fetchAttachedAssociationsCount();
 
 		if (!canCreatePotentialAssociation && !canCreateAssociation && totalAssociations === 0) {
 			return html``;

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -177,9 +177,9 @@ class ActivityRubricsListContainer extends ActivityEditorFeaturesMixin(ActivityE
 	_renderRubricsList(entity) {
 		const canCreatePotentialAssociation = entity.canCreatePotentialAssociation();
 		const canCreateAssociation = entity.canCreateAssociation();
-		const totalAssociations = entity.fetchAttachedAssociationsCount();
+		const associationsCount = entity.fetchAttachedAssociationsCount();
 
-		if (!canCreatePotentialAssociation && !canCreateAssociation && totalAssociations === 0) {
+		if (!canCreatePotentialAssociation && !canCreateAssociation && associationsCount === 0) {
 			return html``;
 		}
 

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -174,12 +174,12 @@ class ActivityRubricsListContainer extends ActivityEditorFeaturesMixin(ActivityE
 		this._newlyCreatedPotentialAssociationHref = '';
 	}
 
-	_renderRubricsList(entity){
+	_renderRubricsList(entity) {
 		const canCreatePotentialAssociation = entity.canCreatePotentialAssociation();
 		const canCreateAssociation = entity.canCreateAssociation();
 		const totalAssociations = entity.fetchAssociations().length;
-		
-		if (!canCreatePotentialAssociation && !canCreateAssociation && totalAssociations == 0) {
+
+		if (!canCreatePotentialAssociation && !canCreateAssociation && totalAssociations === 0) {
 			return html``;
 		}
 

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -174,6 +174,30 @@ class ActivityRubricsListContainer extends ActivityEditorFeaturesMixin(ActivityE
 		this._newlyCreatedPotentialAssociationHref = '';
 	}
 
+	_renderRubricsList(entity){
+		const canCreatePotentialAssociation = entity.canCreatePotentialAssociation();
+		const canCreateAssociation = entity.canCreateAssociation();
+		const totalAssociations = entity.fetchAssociations().length;
+		
+		if (!canCreatePotentialAssociation && !canCreateAssociation && totalAssociations == 0) {
+			return html``;
+		}
+
+		return html`
+			<div class="d2l-rubric-heading-container">
+				<h3 class="d2l-heading-4 d2l-rubric-heading-title">
+					${this.localize('rubrics.hdrRubrics')}
+				</h3>
+			</div>
+			<d2l-activity-rubrics-list-editor
+				href="${this.href}"
+				.activityUsageHref=${this.activityUsageHref}
+				.token=${this.token}
+				.assignmentHref=${this.assignmentHref}
+			></d2l-activity-rubrics-list-editor>
+			`;
+	}
+
 	_renderAddRubricDropdown(entity) {
 
 		const canCreatePotentialAssociation = entity.canCreatePotentialAssociation();
@@ -250,7 +274,6 @@ class ActivityRubricsListContainer extends ActivityEditorFeaturesMixin(ActivityE
 	}
 
 	render() {
-
 		const entity = associationStore.get(this.href);
 
 		if (!entity) {
@@ -258,17 +281,7 @@ class ActivityRubricsListContainer extends ActivityEditorFeaturesMixin(ActivityE
 		}
 
 		return html`
-			<div class="d2l-rubric-heading-container">
-				<h3 class="d2l-heading-4 d2l-rubric-heading-title">
-					${this.localize('rubrics.hdrRubrics')}
-				</h3>
-			</div>
-			<d2l-activity-rubrics-list-editor
-				href="${this.href}"
-				.activityUsageHref=${this.activityUsageHref}
-				.token=${this.token}
-				.assignmentHref=${this.assignmentHref}
-			></d2l-activity-rubrics-list-editor>
+			${this._renderRubricsList(entity)}
 
 			${this._renderAddRubricDropdown(entity)}
 


### PR DESCRIPTION
[DE39269](https://rally1.rallydev.com/#/110294864140d/custom/110851118712?detail=%2Fdefect%2F394449702920&fdp=true)

Hide the rubrics label when the user doesn't have any permissions for rubrics and there is no existing association

Tested:
- edited an assignment with an instructor that only has "See Rubrics" permission and there is no existing rubric association, the rubrics header is correctly hidden
- edited an assignment with an instructor that only has "See Rubrics" permission but there is an existing rubric association, the rubrics header is correctly shown
- edited an assignment with an instructor that has no permissions, the rubrics header is correctly hidden
- edited an assignment with an instructor that has all permission, the rubrics header is correctly shown


