### PR TITLE
Adding greyscale filter and adjusting positioning of spinner

### DIFF
--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -438,14 +438,18 @@ class CollectionEditor extends LocalizeActivityCollectionEditor(EntityMixinLit(L
 
 			.d2l-activity-collection-reorder-spinner {
 				left: 50%;
-				margin: auto;
-				margin-left: -42.5px;
-				position: absolute;
-				top: 0;
+				margin: -42.5px auto auto -42.5px;
+				position: fixed;
+				top: 50%;
 			}
 
 			.d2l-activity-collection-grey-out {
 				pointer-events: none;
+			}
+
+			.d2l-activity-collection-grey-out d2l-list {
+				opacity: 0.6;
+				filter: grayscale(100%);
 			}
 
 			@media only screen and (max-width: 929px) {
@@ -606,12 +610,14 @@ class CollectionEditor extends LocalizeActivityCollectionEditor(EntityMixinLit(L
 				<div class="d2l-activity-collection-body-content">
 					<div class=${classMap(listActionsClasses)}>
 						${addActivityButton}
-						${this._reorderLoading ? html`<d2l-loading-spinner class="d2l-activity-collection-reorder-spinner" size="85"></d2l-loading-spinner>` : null}
 						${activityCount}
 					</div>
 				</div>
 				<div class=${classMap(collectionActivitiesClasses)}>
 					${items}
+					${this._reorderLoading ? html`
+						<d2l-loading-spinner class="d2l-activity-collection-reorder-spinner" size="85"></d2l-loading-spinner>
+					` : null}
 				</div>
 				<d2l-alert-toast id="delete-succeeded-toast" type="default" announce-text=${this.localize('deleteSucceeded', 'activityName', this._currentDeleteItemName)}>
 					${this.localize('deleteSucceeded', 'activityName', this._currentDeleteItemName)}

--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -448,8 +448,8 @@ class CollectionEditor extends LocalizeActivityCollectionEditor(EntityMixinLit(L
 			}
 
 			.d2l-activity-collection-grey-out d2l-list {
-				opacity: 0.6;
 				filter: grayscale(100%);
+				opacity: 0.6;
 			}
 
 			@media only screen and (max-width: 929px) {

--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -447,11 +447,6 @@ class CollectionEditor extends LocalizeActivityCollectionEditor(EntityMixinLit(L
 				pointer-events: none;
 			}
 
-			.d2l-activity-collection-grey-out d2l-list {
-				filter: grayscale(100%);
-				opacity: 0.6;
-			}
-
 			@media only screen and (max-width: 929px) {
 				.d2l-activity-collection-header {
 					padding-left: 1.2rem;


### PR DESCRIPTION
## Context
[DE39933](https://rally1.rallydev.com/#/detail/defect/407518702772?fdp=true)

- Positions the spinner in the center of the page, regardless of the length of activities

In the future, we should also consider doing this when users add activities as well, which is why I moved the spinner to beside the list of items. This made sense to me.

## UX Result
![Kapture 2020-08-13 at 11 41 13](https://user-images.githubusercontent.com/2412740/90155980-f0ccc180-dd59-11ea-8384-008e4bfa8f40.gif)

## Quality
- Tested on Chrome with local BSI and LMS instance