### PR TITLE
Correct Linting Errors (Bump eslint-config-brightspace from 0.7.0 to 0.10.0)

### DIFF
--- a/components/d2l-activity-admin-list/d2l-activity-admin-list.js
+++ b/components/d2l-activity-admin-list/d2l-activity-admin-list.js
@@ -2,7 +2,7 @@ import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { heading1Styles, bodyStandardStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { ActivityUsageCollectionEntity } from 'siren-sdk/src/activities/ActivityUsageCollectionEntity.js';
-import {ifDefined} from 'lit-html/directives/if-defined';
+import { ifDefined } from 'lit-html/directives/if-defined';
 import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/button/button.js';
 import '@brightspace-ui/core/components/list/list.js';
@@ -29,7 +29,7 @@ class AdminList extends EntityMixinLit(LitElement) {
 		collection.onItemsChange((item, index) => {
 			item.onActivityUsageChange((usage) => {
 				usage.onOrganizationChange((organization) => {
-					this._items[index] = {usage, organization};
+					this._items[index] = { usage, organization };
 					this.requestUpdate();
 				});
 			});

--- a/components/d2l-activity-card/ActivityCardLocalize.js
+++ b/components/d2l-activity-card/ActivityCardLocalize.js
@@ -1,20 +1,20 @@
-import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
-import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import 'd2l-localize-behavior/d2l-localize-behavior.js';
-import {LangAr} from './build/lang/ar.js';
-import {LangDe} from './build/lang/de.js';
-import {LangEn} from './build/lang/en.js';
-import {LangEs} from './build/lang/es.js';
-import {LangFi} from './build/lang/fi.js';
-import {LangFr} from './build/lang/fr.js';
-import {LangJa} from './build/lang/ja.js';
-import {LangKo} from './build/lang/ko.js';
-import {LangNl} from './build/lang/nl.js';
-import {LangPt} from './build/lang/pt.js';
-import {LangSv} from './build/lang/sv.js';
-import {LangTr} from './build/lang/tr.js';
-import {LangZhtw} from './build/lang/zh-tw.js';
-import {LangZh} from './build/lang/zh.js';
+import { LangAr } from './build/lang/ar.js';
+import { LangDe } from './build/lang/de.js';
+import { LangEn } from './build/lang/en.js';
+import { LangEs } from './build/lang/es.js';
+import { LangFi } from './build/lang/fi.js';
+import { LangFr } from './build/lang/fr.js';
+import { LangJa } from './build/lang/ja.js';
+import { LangKo } from './build/lang/ko.js';
+import { LangNl } from './build/lang/nl.js';
+import { LangPt } from './build/lang/pt.js';
+import { LangSv } from './build/lang/sv.js';
+import { LangTr } from './build/lang/tr.js';
+import { LangZhtw } from './build/lang/zh-tw.js';
+import { LangZh } from './build/lang/zh.js';
 
 const LangImpl = (prefix, langObj, superClass) => class extends superClass {
 	constructor() {

--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -4,7 +4,7 @@ import { repeat } from 'lit-html/directives/repeat';
 import { until } from 'lit-html/directives/until.js';
 import { guard } from 'lit-html/directives/guard';
 import { classMap } from 'lit-html/directives/class-map.js';
-import { heading1Styles, heading4Styles, bodyCompactStyles, bodyStandardStyles, labelStyles} from '@brightspace-ui/core/components/typography/styles.js';
+import { heading1Styles, heading4Styles, bodyCompactStyles, bodyStandardStyles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { ActivityUsageEntity } from 'siren-sdk/src/activities/ActivityUsageEntity.js';
 import { classes as organizationClasses } from 'siren-sdk/src/organizations/OrganizationEntity.js';
@@ -246,13 +246,13 @@ class CollectionEditor extends LocalizeActivityCollectionEditor(EntityMixinLit(L
 					if (oldValue[i].id !== newVal[i].id) return true;
 				}
 				return false;
-			}},
+			} },
 			_name: { type: String },
 			_selectionCount: { type: Number },
 			_candidateLoad: { type: Object },
-			_candidateItemsLoading: {type: Boolean},
-			_isLoadingMore: {type: Boolean},
-			_reorderLoading: {type: Boolean},
+			_candidateItemsLoading: { type: Boolean },
+			_isLoadingMore: { type: Boolean },
+			_reorderLoading: { type: Boolean },
 			ariaBusy: { type: String, reflect: true, attribute: 'aria-busy' },
 			ariaLive: { type: String, reflect: true, attribute: 'aria-live' },
 			role: { type: String, reflect: true, attribute: 'role' }
@@ -584,8 +584,8 @@ class CollectionEditor extends LocalizeActivityCollectionEditor(EntityMixinLit(L
 
 		const items = this._handleFirstLoad(this._renderItemList.bind(this), () => html`${this._renderItemListSkeleton(3)}`);
 
-		const collectionActivitiesClasses = { 'd2l-activity-collection-activities': true,  'd2l-activity-collection-grey-out': this._reorderLoading};
-		const listActionsClasses = { 'd2l-activity-collection-list-actions': true,  'd2l-activity-collection-grey-out': this._reorderLoading};
+		const collectionActivitiesClasses = { 'd2l-activity-collection-activities': true,  'd2l-activity-collection-grey-out': this._reorderLoading };
+		const listActionsClasses = { 'd2l-activity-collection-list-actions': true,  'd2l-activity-collection-grey-out': this._reorderLoading };
 		return html`
 			<div class="d2l-activity-collection-header">
 				<div class="d2l-activity-collection-header-content">

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-editor.js
@@ -40,12 +40,6 @@ class ActivityAssignmentAnnotationsEditor
 		super(store);
 	}
 
-	_toggleAnnotationToolsAvailability(event) {
-
-		const entity = store.get(this.href);
-		entity.setAnnotationToolsAvailable(event.target.checked);
-	}
-
 	render() {
 
 		const entity = store.get(this.href);
@@ -66,6 +60,12 @@ class ActivityAssignmentAnnotationsEditor
 			</d2l-input-checkbox>
 		`;
 	}
+	_toggleAnnotationToolsAvailability(event) {
+
+		const entity = store.get(this.href);
+		entity.setAnnotationToolsAvailable(event.target.checked);
+	}
+
 }
 
 customElements.define(

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-editor.js
@@ -54,12 +54,6 @@ class ActivityAssignmentAnonymousMarkingEditor
 		super(store);
 	}
 
-	_saveAnonymousMarking(event) {
-
-		const entity = store.get(this.href);
-		entity.setAnonymousMarking(event.target.checked);
-	}
-
 	render() {
 
 		const entity = store.get(this.href);
@@ -90,6 +84,12 @@ class ActivityAssignmentAnonymousMarkingEditor
 			</d2l-input-checkbox-spacer>
 		`;
 	}
+	_saveAnonymousMarking(event) {
+
+		const entity = store.get(this.href);
+		entity.setAnonymousMarking(event.target.checked);
+	}
+
 }
 customElements.define(
 	'd2l-activity-assignment-anonymous-marking-editor',

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
@@ -71,18 +71,41 @@ class ActivityAssignmentAvailabilityEditor extends ActivityEditorFeaturesMixin(L
 		this._m3SpecialAccessEnabled = this._isMilestoneEnabled(Milestones.M3SpecialAccess);
 	}
 
+	render() {
+		return html`
+			<d2l-labs-accordion-collapse
+				flex
+				header-border
+				?opened=${this._isOpened()}
+				@d2l-labs-accordion-collapse-state-changed=${this._onAccordionStateChange}>
+				<h3 class="d2l-heading-3 d2l-activity-summarizer-header" slot="header">
+					${this.localize('hdrAvailability')}
+				</h3>
+				<ul class="d2l-body-small d2l-activity-summarizer-summary" slot="summary">
+					<li>${this._renderAvailabilityDatesSummary()}</li>
+					<li>${this._renderReleaseConditionSummary()}</li>
+					<li>${this._renderSpecialAccessSummary()}</li>
+				</ul>
+				${this._renderAvailabilityDatesEditor()}
+				${this._renderReleaseConditionEditor()}
+				${this._renderSpecialAccessEditor()}
+			</d2l-labs-accordion-collapse>
+		`;
+	}
+	// Returns true if any error states relevant to this accordion are set
+	_errorInAccordion() {
+		const activity = store.get(this.href);
+		if (!activity || !activity.dates) {
+			return false;
+		}
+
+		return !!(activity.dates.endDateErrorTerm || activity.dates.startDateErrorTerm);
+	}
+	_isOpened() {
+		return this._opened || this._errorInAccordion();
+	}
 	_onAccordionStateChange(e) {
 		this._opened = e.detail.opened;
-	}
-
-	_renderAvailabilityDatesSummary() {
-
-		return html`
-			<d2l-activity-availability-dates-summary
-				href="${this.href}"
-				.token="${this.token}">
-			</d2l-activity-availability-dates-summary>
-		`;
 	}
 
 	_renderAvailabilityDatesEditor() {
@@ -96,17 +119,13 @@ class ActivityAssignmentAvailabilityEditor extends ActivityEditorFeaturesMixin(L
 			</div>
 		`;
 	}
-
-	_renderReleaseConditionSummary() {
-		if (!this._m3ReleaseConditionsEnabled) {
-			return html``;
-		}
+	_renderAvailabilityDatesSummary() {
 
 		return html`
-			<d2l-activity-usage-conditions-summary
+			<d2l-activity-availability-dates-summary
 				href="${this.href}"
 				.token="${this.token}">
-			</d2l-activity-usage-conditions-summary>
+			</d2l-activity-availability-dates-summary>
 		`;
 	}
 
@@ -129,17 +148,16 @@ class ActivityAssignmentAvailabilityEditor extends ActivityEditorFeaturesMixin(L
 			</div>
 		`;
 	}
-
-	_renderSpecialAccessSummary() {
-		if (!this._m3SpecialAccessEnabled) {
+	_renderReleaseConditionSummary() {
+		if (!this._m3ReleaseConditionsEnabled) {
 			return html``;
 		}
 
 		return html`
-			<d2l-activity-special-access-summary
+			<d2l-activity-usage-conditions-summary
 				href="${this.href}"
 				.token="${this.token}">
-			</d2l-activity-special-access-summary>
+			</d2l-activity-usage-conditions-summary>
 		`;
 	}
 
@@ -163,40 +181,16 @@ class ActivityAssignmentAvailabilityEditor extends ActivityEditorFeaturesMixin(L
 			</div>
 		`;
 	}
-
-	// Returns true if any error states relevant to this accordion are set
-	_errorInAccordion() {
-		const activity = store.get(this.href);
-		if (!activity || !activity.dates) {
-			return false;
+	_renderSpecialAccessSummary() {
+		if (!this._m3SpecialAccessEnabled) {
+			return html``;
 		}
 
-		return !!(activity.dates.endDateErrorTerm || activity.dates.startDateErrorTerm);
-	}
-
-	_isOpened() {
-		return this._opened || this._errorInAccordion();
-	}
-
-	render() {
 		return html`
-			<d2l-labs-accordion-collapse
-				flex
-				header-border
-				?opened=${this._isOpened()}
-				@d2l-labs-accordion-collapse-state-changed=${this._onAccordionStateChange}>
-				<h3 class="d2l-heading-3 d2l-activity-summarizer-header" slot="header">
-					${this.localize('hdrAvailability')}
-				</h3>
-				<ul class="d2l-body-small d2l-activity-summarizer-summary" slot="summary">
-					<li>${this._renderAvailabilityDatesSummary()}</li>
-					<li>${this._renderReleaseConditionSummary()}</li>
-					<li>${this._renderSpecialAccessSummary()}</li>
-				</ul>
-				${this._renderAvailabilityDatesEditor()}
-				${this._renderReleaseConditionEditor()}
-				${this._renderSpecialAccessEditor()}
-			</d2l-labs-accordion-collapse>
+			<d2l-activity-special-access-summary
+				href="${this.href}"
+				.token="${this.token}">
+			</d2l-activity-special-access-summary>
 		`;
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -75,90 +75,6 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 		this._linksProcessor = new LinksInMessageProcessor();
 	}
 
-	set _entity(entity) {
-		if (this._entityHasChanged(entity)) {
-			this._onAssignmentChange(entity);
-			super._entity = entity;
-		}
-	}
-
-	addLinks(links) {
-		const collection = attachmentCollectionStore.get(this._attachmentsHref);
-		links = links || [];
-		links.forEach(element => {
-			collection.addAttachment(attachmentStore.createLink(element.name, element.url));
-		});
-	}
-
-	_saveInstructions(value) {
-		store.getAssignment(this.href).setInstructions(value);
-		this._debounceJobs.value = Debouncer.debounce(
-			this._debounceJobs.value,
-			timeOut.after(2000),
-			() => this._linksProcessor.process(value, linkAttachments => this.addLinks(linkAttachments))
-		);
-	}
-
-	_onAssignmentChange(assignment) {
-		if (!assignment) {
-			return;
-		}
-
-		this._attachmentsHref = assignment.attachmentsCollectionHref();
-	}
-
-	_saveOnChange(jobName) {
-		this._debounceJobs[jobName] && this._debounceJobs[jobName].flush();
-	}
-
-	_saveName(value) {
-		store.getAssignment(this.href).setName(value);
-	}
-
-	_saveNameOnInput(e) {
-		const name = e.target.value;
-		const isNameEmpty = (name || '').trim().length === 0;
-
-		const errorProperty = '_nameError';
-		const emptyNameErrorLangterm = 'emptyNameError';
-		const tooltipId = 'name-tooltip';
-
-		if (isNameEmpty) {
-			this.setError(errorProperty, emptyNameErrorLangterm, tooltipId);
-		} else {
-			this.clearError(errorProperty);
-			this._debounceJobs.name = Debouncer.debounce(
-				this._debounceJobs.name,
-				timeOut.after(500),
-				() => this._saveName(name)
-			);
-		}
-	}
-
-	_saveInstructionsOnChange(e) {
-		const instructions = e.detail.content;
-
-		this._debounceJobs.instructions = Debouncer.debounce(
-			this._debounceJobs.instructions,
-			timeOut.after(500),
-			() => this._saveInstructions(instructions)
-		);
-	}
-
-	_getNameTooltip() {
-		if (this._nameError) {
-			return html`
-				<d2l-tooltip
-					id="name-tooltip"
-					for="assignment-name"
-					position="bottom"
-					?showing="${this._nameError}">
-					${this._nameError}
-				</d2l-tooltip>
-			`;
-		}
-	}
-
 	render() {
 		const assignment = store.getAssignment(this.href);
 		if (!assignment) {
@@ -240,7 +156,6 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 			</div>
 		`;
 	}
-
 	updated(changedProperties) {
 		super.updated(changedProperties);
 
@@ -249,5 +164,83 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 			super._fetch(() => store.fetchAssignment(this.href, this.token));
 		}
 	}
+	addLinks(links) {
+		const collection = attachmentCollectionStore.get(this._attachmentsHref);
+		links = links || [];
+		links.forEach(element => {
+			collection.addAttachment(attachmentStore.createLink(element.name, element.url));
+		});
+	}
+	set _entity(entity) {
+		if (this._entityHasChanged(entity)) {
+			this._onAssignmentChange(entity);
+			super._entity = entity;
+		}
+	}
+
+	_getNameTooltip() {
+		if (this._nameError) {
+			return html`
+				<d2l-tooltip
+					id="name-tooltip"
+					for="assignment-name"
+					position="bottom"
+					?showing="${this._nameError}">
+					${this._nameError}
+				</d2l-tooltip>
+			`;
+		}
+	}
+	_onAssignmentChange(assignment) {
+		if (!assignment) {
+			return;
+		}
+
+		this._attachmentsHref = assignment.attachmentsCollectionHref();
+	}
+	_saveInstructions(value) {
+		store.getAssignment(this.href).setInstructions(value);
+		this._debounceJobs.value = Debouncer.debounce(
+			this._debounceJobs.value,
+			timeOut.after(2000),
+			() => this._linksProcessor.process(value, linkAttachments => this.addLinks(linkAttachments))
+		);
+	}
+
+	_saveInstructionsOnChange(e) {
+		const instructions = e.detail.content;
+
+		this._debounceJobs.instructions = Debouncer.debounce(
+			this._debounceJobs.instructions,
+			timeOut.after(500),
+			() => this._saveInstructions(instructions)
+		);
+	}
+	_saveName(value) {
+		store.getAssignment(this.href).setName(value);
+	}
+	_saveNameOnInput(e) {
+		const name = e.target.value;
+		const isNameEmpty = (name || '').trim().length === 0;
+
+		const errorProperty = '_nameError';
+		const emptyNameErrorLangterm = 'emptyNameError';
+		const tooltipId = 'name-tooltip';
+
+		if (isNameEmpty) {
+			this.setError(errorProperty, emptyNameErrorLangterm, tooltipId);
+		} else {
+			this.clearError(errorProperty);
+			this._debounceJobs.name = Debouncer.debounce(
+				this._debounceJobs.name,
+				timeOut.after(500),
+				() => this._saveName(name)
+			);
+		}
+	}
+	_saveOnChange(jobName) {
+		this._debounceJobs[jobName] && this._debounceJobs[jobName].flush();
+	}
+
 }
 customElements.define('d2l-activity-assignment-editor-detail', AssignmentEditorDetail);

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-footer.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-footer.js
@@ -51,6 +51,20 @@ class AssignmentEditorFooter extends SaveStatusMixin(EntityMixinLit(RtlMixin(Loc
 		this._activityUsageHref = '';
 	}
 
+	render() {
+		return html`
+			<div class="d2l-activity-assignment-editor-footer-left">
+				<d2l-activity-visibility-editor
+					.href="${this._activityUsageHref}"
+					.token="${this.token}">
+				</d2l-activity-visibility-editor>
+				<d2l-activity-editor-buttons></d2l-activity-editor-buttons>
+			</div>
+			<div class="d2l-activity-assignment-editor-footer-right">
+				<slot name="save-status"></slot>
+			</div>
+		`;
+	}
 	set _entity(entity) {
 		if (this._entityHasChanged(entity)) {
 			this._onAssignmentChange(entity);
@@ -66,19 +80,5 @@ class AssignmentEditorFooter extends SaveStatusMixin(EntityMixinLit(RtlMixin(Loc
 		this._activityUsageHref = assignment.activityUsageHref();
 	}
 
-	render() {
-		return html`
-			<div class="d2l-activity-assignment-editor-footer-left">
-				<d2l-activity-visibility-editor
-					.href="${this._activityUsageHref}"
-					.token="${this.token}">
-				</d2l-activity-visibility-editor>
-				<d2l-activity-editor-buttons></d2l-activity-editor-buttons>
-			</div>
-			<div class="d2l-activity-assignment-editor-footer-right">
-				<slot name="save-status"></slot>
-			</div>
-		`;
-	}
 }
 customElements.define('d2l-activity-assignment-editor-footer', AssignmentEditorFooter);

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-secondary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-secondary.js
@@ -48,21 +48,6 @@ class AssignmentEditorSecondary extends ActivityEditorFeaturesMixin(RtlMixin(Ent
 		this._activityUsageHref = '';
 	}
 
-	set _entity(entity) {
-		if (this._entityHasChanged(entity)) {
-			this._onAssignmentChange(entity);
-			super._entity = entity;
-		}
-	}
-
-	_onAssignmentChange(assignment) {
-		if (!assignment) {
-			return;
-		}
-
-		this._activityUsageHref = assignment.activityUsageHref();
-	}
-
 	render() {
 		const showSubmissionCompletionAccordian = this._isMilestoneEnabled(Milestones.M2);
 		const showEvaluationAccordian = this._isMilestoneEnabled(Milestones.M2) || this._isMilestoneEnabled(Milestones.M3Competencies);
@@ -96,5 +81,20 @@ class AssignmentEditorSecondary extends ActivityEditorFeaturesMixin(RtlMixin(Ent
 		`;
 
 	}
+	set _entity(entity) {
+		if (this._entityHasChanged(entity)) {
+			this._onAssignmentChange(entity);
+			super._entity = entity;
+		}
+	}
+
+	_onAssignmentChange(assignment) {
+		if (!assignment) {
+			return;
+		}
+
+		this._activityUsageHref = assignment.activityUsageHref();
+	}
+
 }
 customElements.define('d2l-activity-assignment-editor-secondary', AssignmentEditorSecondary);

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -367,15 +367,6 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends ActivityEditorFeat
 
 		return html``;
 	}
-_saveCompletionTypeOnChange(event) {
-		store.getAssignment(this.href).setCompletionType(event.target.value);
-	}
-	
-	
-	_saveSubmissionTypeOnChange(event) {
-		store.getAssignment(this.href).setSubmissionType(event.target.value);
-	}
-	
 	_renderAssignmentType() {
 		return html `
 			<div id="assignment-type-container">
@@ -389,7 +380,6 @@ _saveCompletionTypeOnChange(event) {
 			</div>
 		`;
 	}
-
 	_renderAssignmentTypeSummary() {
 		return html`
 			<d2l-activity-assignment-type-summary
@@ -398,7 +388,6 @@ _saveCompletionTypeOnChange(event) {
 			</d2l-activity-assignment-type-summary>
 		`;
 	}
-
 	_renderSubmissionEmailNotificationSummary(assignment) {
 		if (!this._m4EmailNotificationEnabled || !assignment || !assignment.showNotificationEmail) {
 			return html ``;
@@ -410,6 +399,14 @@ _saveCompletionTypeOnChange(event) {
 			</d2l-activity-submission-email-notification-summary>
 		`;
 	}
+	_saveCompletionTypeOnChange(event) {
+		store.getAssignment(this.href).setCompletionType(event.target.value);
+	}
+
+	_saveSubmissionTypeOnChange(event) {
+		store.getAssignment(this.href).setSubmissionType(event.target.value);
+	}
+
 	_setfilesSubmisisonLimit(e) {
 		const assignment = store.getAssignment(this.href);
 		const data = e.target.value;

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -147,7 +147,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends ActivityEditorFeat
 
 		return assignment.submissionAndCompletionProps.submissionTypeOptions.find(opt => String(opt.value) === assignment.submissionAndCompletionProps.submissionType);
 	}
-_getSubmissionTypeOptions(assignment) {
+	_getSubmissionTypeOptions(assignment) {
 		if (!assignment || !assignment.submissionAndCompletionProps) {
 			return html``;
 		}
@@ -156,7 +156,49 @@ _getSubmissionTypeOptions(assignment) {
 			${assignment.submissionAndCompletionProps.submissionTypeOptions.map(option => html`<option value=${option.value} ?selected=${String(option.value) === assignment.submissionAndCompletionProps.submissionType}>${option.title}</option>`)}
 		`;
 	}
-	
+
+	_onNotificationEmailChanged(e) {
+		const assignment = store.getAssignment(this.href);
+		const data = e.target.value;
+		assignment && assignment.setNotificationEmail(data);
+	}
+	_renderAssignmentCompletionType(assignment) {
+		if (!assignment ||
+			!assignment.submissionAndCompletionProps ||
+			!assignment.submissionAndCompletionProps.completionTypeOptions ||
+			assignment.submissionAndCompletionProps.completionTypeOptions.length === 0) {
+			return html``;
+		}
+
+		let completionTypeContent = html``;
+		if (assignment.submissionAndCompletionProps.canEditCompletionType) {
+			completionTypeContent = html`
+				<select
+					id="assignment-completion-type"
+					class="d2l-input-select d2l-block-select"
+					@change="${this._saveCompletionTypeOnChange}">
+						${this._getCompletionTypeOptions(assignment)}
+				</select>
+			`;
+		} else {
+			const completionType = this._getSelectedCompletionType(assignment);
+			if (completionType) {
+				completionTypeContent = html`<div class="d2l-body-compact">${completionType.title}</div>`;
+			}
+		}
+
+		return html`
+			<div id="assignment-completion-type-container">
+				<label class="d2l-label-text" for="assignment-completion-type">
+					${this.localize('completionType')}
+				</label>
+				${completionTypeContent}
+			</div>
+		`;
+	}
+	_renderAssignmentCompletionTypeSummary() {
+		return html``;
+	}
 	_renderAssignmentFilesSubmissionLimit(assignment) {
 		if (!assignment ||
 			!assignment.submissionAndCompletionProps ||
@@ -211,10 +253,6 @@ _getSubmissionTypeOptions(assignment) {
 			</div>
 		`;
 	}
-	_saveCompletionTypeOnChange(event) {
-		store.getAssignment(this.href).setCompletionType(event.target.value);
-	}
-
 
 	_renderAssignmentSubmissionNotificationEmail(assignment) {
 		if (!this._m4EmailNotificationEnabled || !assignment || !assignment.showNotificationEmail) {
@@ -247,12 +285,6 @@ _getSubmissionTypeOptions(assignment) {
 		</div>
 	`;
 	}
-_saveSubmissionTypeOnChange(event) {
-		store.getAssignment(this.href).setSubmissionType(event.target.value);
-	}
-	
-	
-	
 	_renderAssignmentSubmissionsRule(assignment) {
 
 		if (!assignment ||
@@ -290,89 +322,6 @@ _saveSubmissionTypeOnChange(event) {
 				${submissionsRuleContent}
 			</div>
 		`;
-	}
-_renderAssignmentType() {
-		return html `
-			<div id="assignment-type-container">
-				<label class="d2l-label-text">
-					${this.localize('txtAssignmentType')}
-				</label>
-				<d2l-activity-assignment-type-editor
-					href="${this.href}"
-					.token="${this.token}">
-				</d2l-activity-assignment-type-editor>
-			</div>
-		`;
-	}
-	
-	
-	_renderAssignmentTypeSummary() {
-		return html`
-			<d2l-activity-assignment-type-summary
-				href="${this.href}"
-				.token="${this.token}">
-			</d2l-activity-assignment-type-summary>
-		`;
-	}
-	
-	_onNotificationEmailChanged(e) {
-		const assignment = store.getAssignment(this.href);
-		const data = e.target.value;
-		assignment && assignment.setNotificationEmail(data);
-	}
-_setfilesSubmisisonLimit(e) {
-		const assignment = store.getAssignment(this.href);
-		const data = e.target.value;
-		assignment && assignment.setFilesSubmissionLimit(data);
-	}
-
-	
-	_setSubmisisonsRule(e) {
-		const assignment = store.getAssignment(this.href);
-		const data = e.target.value;
-		assignment &&
-		assignment.submissionAndCompletionProps &&
-		assignment.submissionAndCompletionProps.setSubmissionsRule(data);
-	}
-	
-	
-
-	_renderAssignmentCompletionType(assignment) {
-		if (!assignment ||
-			!assignment.submissionAndCompletionProps ||
-			!assignment.submissionAndCompletionProps.completionTypeOptions ||
-			assignment.submissionAndCompletionProps.completionTypeOptions.length === 0) {
-			return html``;
-		}
-
-		let completionTypeContent = html``;
-		if (assignment.submissionAndCompletionProps.canEditCompletionType) {
-			completionTypeContent = html`
-				<select
-					id="assignment-completion-type"
-					class="d2l-input-select d2l-block-select"
-					@change="${this._saveCompletionTypeOnChange}">
-						${this._getCompletionTypeOptions(assignment)}
-				</select>
-			`;
-		} else {
-			const completionType = this._getSelectedCompletionType(assignment);
-			if (completionType) {
-				completionTypeContent = html`<div class="d2l-body-compact">${completionType.title}</div>`;
-			}
-		}
-
-		return html`
-			<div id="assignment-completion-type-container">
-				<label class="d2l-label-text" for="assignment-completion-type">
-					${this.localize('completionType')}
-				</label>
-				${completionTypeContent}
-			</div>
-		`;
-	}
-	_renderAssignmentCompletionTypeSummary() {
-		return html``;
 	}
 	_renderAssignmentSubmissionType(assignment) {
 		if (!assignment || !assignment.submissionAndCompletionProps) {
@@ -418,6 +367,38 @@ _setfilesSubmisisonLimit(e) {
 
 		return html``;
 	}
+_saveCompletionTypeOnChange(event) {
+		store.getAssignment(this.href).setCompletionType(event.target.value);
+	}
+	
+	
+	_saveSubmissionTypeOnChange(event) {
+		store.getAssignment(this.href).setSubmissionType(event.target.value);
+	}
+	
+	_renderAssignmentType() {
+		return html `
+			<div id="assignment-type-container">
+				<label class="d2l-label-text">
+					${this.localize('txtAssignmentType')}
+				</label>
+				<d2l-activity-assignment-type-editor
+					href="${this.href}"
+					.token="${this.token}">
+				</d2l-activity-assignment-type-editor>
+			</div>
+		`;
+	}
+
+	_renderAssignmentTypeSummary() {
+		return html`
+			<d2l-activity-assignment-type-summary
+				href="${this.href}"
+				.token="${this.token}">
+			</d2l-activity-assignment-type-summary>
+		`;
+	}
+
 	_renderSubmissionEmailNotificationSummary(assignment) {
 		if (!this._m4EmailNotificationEnabled || !assignment || !assignment.showNotificationEmail) {
 			return html ``;
@@ -428,6 +409,19 @@ _setfilesSubmisisonLimit(e) {
 				.token="${this.token}">
 			</d2l-activity-submission-email-notification-summary>
 		`;
+	}
+	_setfilesSubmisisonLimit(e) {
+		const assignment = store.getAssignment(this.href);
+		const data = e.target.value;
+		assignment && assignment.setFilesSubmissionLimit(data);
+	}
+
+	_setSubmisisonsRule(e) {
+		const assignment = store.getAssignment(this.href);
+		const data = e.target.value;
+		assignment &&
+		assignment.submissionAndCompletionProps &&
+		assignment.submissionAndCompletionProps.setSubmissionsRule(data);
 	}
 
 }

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -177,7 +177,7 @@ class AssignmentEditor extends ActivityEditorContainerMixin(RtlMixin(LocalizeAct
 
 		await assignment.save();
 	}
-get _editorTemplate() {
+	get _editorTemplate() {
 		const activity = store.getActivity(this.href);
 		if (!activity) {
 			return html``;
@@ -222,8 +222,7 @@ get _editorTemplate() {
 			</d2l-template-primary-secondary>
 		`;
 	}
-	
-	
+
 	_onRequestProvider(e) {
 		if (e.detail.key === 'd2l-provider-html-editor-enabled') {
 			e.detail.provider = this.htmlEditorEnabled;

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
@@ -61,103 +61,6 @@ class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(Loc
 		this._m3CompetenciesEnabled = this._isMilestoneEnabled(Milestones.M3Competencies);
 	}
 
-	_renderAnonymousMarkingSummary() {
-
-		return html`
-			<d2l-activity-assignment-anonymous-marking-summary
-				href="${this.href}"
-				.token="${this.token}">
-			</d2l-activity-assignment-anonymous-marking-summary>
-		`;
-	}
-
-	_renderAnonymousMarkingEditor() {
-
-		return html`
-			<d2l-activity-assignment-anonymous-marking-editor
-				href="${this.href}"
-				.token="${this.token}">
-			</d2l-activity-assignment-anonymous-marking-editor>
-		`;
-	}
-
-	_renderAnnotationsSummary() {
-
-		return html`
-			<d2l-activity-assignment-annotations-summary
-				href="${this.href}"
-				.token="${this.token}">
-			</d2l-activity-assignment-annotations-summary>
-		`;
-	}
-
-	_renderAnnotationsEditor() {
-
-		return html`
-			<d2l-activity-assignment-annotations-editor
-				href="${this.href}"
-				.token="${this.token}">
-			</d2l-activity-assignment-annotations-editor>
-		`;
-	}
-
-	_renderTurnitinSummary() {
-
-		return html`
-			<d2l-assignment-turnitin-summary
-				href="${this.href}"
-				.token="${this.token}">
-			</d2l-assignment-turnitin-summary>
-		`;
-	}
-
-	_renderTurnitinEditor() {
-
-		return html`
-			<d2l-assignment-turnitin-editor
-				href="${this.href}"
-				.token="${this.token}">
-			</d2l-assignment-turnitin-editor>
-		`;
-	}
-
-	_renderRubricsSummary() {
-		return html`
-			<d2l-activity-rubrics-summary-wrapper
-				.href="${this.activityUsageHref}"
-				.token="${this.token}">
-			</d2l-activity-rubrics-summary-wrapper>
-		`;
-	}
-
-	_renderCompetenciesSummary() {
-		return html`
-			<d2l-activity-competencies-summary
-				.href="${this.activityUsageHref}"
-				.token="${this.token}">
-			</d2l-activity-competencies-summary>
-		`;
-	}
-
-	_renderRubricsCollectionEditor() {
-		return html`
-			<d2l-activity-rubrics-list-wrapper
-				.href="${this.activityUsageHref}"
-				.token="${this.token}"
-				.assignmentHref="${this.href}">
-			</d2l-activity-rubrics-list-wrapper>
-		`;
-	}
-
-	_renderCompetenciesOpener() {
-		return html`
-			<d2l-activity-competencies
-				.href="${this.activityUsageHref}"
-				.token="${this.token}">
-			</d2l-activity-competencies>
-		`;
-	}
-
 	render() {
 		const assignment = store.getAssignment(this.href);
 		if (!assignment) {
@@ -191,6 +94,96 @@ class ActivityAssignmentEvaluationEditor extends ActivityEditorFeaturesMixin(Loc
 			</d2l-labs-accordion-collapse>
 		`;
 	}
+	_renderAnnotationsEditor() {
+
+		return html`
+			<d2l-activity-assignment-annotations-editor
+				href="${this.href}"
+				.token="${this.token}">
+			</d2l-activity-assignment-annotations-editor>
+		`;
+	}
+	_renderAnnotationsSummary() {
+
+		return html`
+			<d2l-activity-assignment-annotations-summary
+				href="${this.href}"
+				.token="${this.token}">
+			</d2l-activity-assignment-annotations-summary>
+		`;
+	}
+	_renderAnonymousMarkingEditor() {
+
+		return html`
+			<d2l-activity-assignment-anonymous-marking-editor
+				href="${this.href}"
+				.token="${this.token}">
+			</d2l-activity-assignment-anonymous-marking-editor>
+		`;
+	}
+	_renderAnonymousMarkingSummary() {
+
+		return html`
+			<d2l-activity-assignment-anonymous-marking-summary
+				href="${this.href}"
+				.token="${this.token}">
+			</d2l-activity-assignment-anonymous-marking-summary>
+		`;
+	}
+
+	_renderCompetenciesOpener() {
+		return html`
+			<d2l-activity-competencies
+				.href="${this.activityUsageHref}"
+				.token="${this.token}">
+			</d2l-activity-competencies>
+		`;
+	}
+	_renderCompetenciesSummary() {
+		return html`
+			<d2l-activity-competencies-summary
+				.href="${this.activityUsageHref}"
+				.token="${this.token}">
+			</d2l-activity-competencies-summary>
+		`;
+	}
+	_renderRubricsCollectionEditor() {
+		return html`
+			<d2l-activity-rubrics-list-wrapper
+				.href="${this.activityUsageHref}"
+				.token="${this.token}"
+				.assignmentHref="${this.href}">
+			</d2l-activity-rubrics-list-wrapper>
+		`;
+	}
+	_renderRubricsSummary() {
+		return html`
+			<d2l-activity-rubrics-summary-wrapper
+				.href="${this.activityUsageHref}"
+				.token="${this.token}">
+			</d2l-activity-rubrics-summary-wrapper>
+		`;
+	}
+	_renderTurnitinEditor() {
+
+		return html`
+			<d2l-assignment-turnitin-editor
+				href="${this.href}"
+				.token="${this.token}">
+			</d2l-assignment-turnitin-editor>
+		`;
+	}
+
+	_renderTurnitinSummary() {
+
+		return html`
+			<d2l-assignment-turnitin-summary
+				href="${this.href}"
+				.token="${this.token}">
+			</d2l-assignment-turnitin-summary>
+		`;
+	}
+
 }
 customElements.define(
 	'd2l-activity-assignment-evaluation-editor',

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
@@ -59,50 +59,6 @@ class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 		super(store);
 	}
 
-	_getGroupCategoryOptions(assignment) {
-		if (assignment) {
-			return html`${assignment.groupCategories.map(
-				option => html`
-					<option value=${option.value} ?selected=${String(option.value) === assignment.selectedGroupCategoryId}>
-						${option.title}
-					</option>
-					`
-			)}`;
-		}
-		return html``;
-	}
-
-	_setIndividualAssignmentType() {
-		store.get(this.href).setToIndividualAssignmentType();
-	}
-
-	_setGroupAssignmentType() {
-		store.get(this.href).setToGroupAssignmentType();
-	}
-
-	_changeGroupCategory(event) {
-		store.get(this.href).setAssignmentTypeGroupCategory(event.target.value);
-	}
-
-	_getInformationText(assignment) {
-		if (!assignment) {
-			return;
-		}
-
-		const isIndividualAssignmentType = assignment.isIndividualAssignmentType;
-		const hasSubmissions = assignment.submissionAndCompletionProps && assignment.submissionAndCompletionProps.assignmentHasSubmissions;
-
-		if (!hasSubmissions && isIndividualAssignmentType && assignment.groupCategories.length === 0) {
-			return this.localize('folderTypeNoGroups');
-		}
-
-		if (!hasSubmissions && !isIndividualAssignmentType) {
-			return this.localize('folderTypeCreateGroups');
-		}
-
-		return;
-	}
-
 	render() {
 		const assignment = store.get(this.href);
 
@@ -163,5 +119,46 @@ class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 			</div>
 		`;
 	}
+	_changeGroupCategory(event) {
+		store.get(this.href).setAssignmentTypeGroupCategory(event.target.value);
+	}
+	_getGroupCategoryOptions(assignment) {
+		if (assignment) {
+			return html`${assignment.groupCategories.map(
+				option => html`
+					<option value=${option.value} ?selected=${String(option.value) === assignment.selectedGroupCategoryId}>
+						${option.title}
+					</option>
+					`
+			)}`;
+		}
+		return html``;
+	}
+
+	_getInformationText(assignment) {
+		if (!assignment) {
+			return;
+		}
+
+		const isIndividualAssignmentType = assignment.isIndividualAssignmentType;
+		const hasSubmissions = assignment.submissionAndCompletionProps && assignment.submissionAndCompletionProps.assignmentHasSubmissions;
+
+		if (!hasSubmissions && isIndividualAssignmentType && assignment.groupCategories.length === 0) {
+			return this.localize('folderTypeNoGroups');
+		}
+
+		if (!hasSubmissions && !isIndividualAssignmentType) {
+			return this.localize('folderTypeCreateGroups');
+		}
+
+		return;
+	}
+	_setGroupAssignmentType() {
+		store.get(this.href).setToGroupAssignmentType();
+	}
+	_setIndividualAssignmentType() {
+		store.get(this.href).setToIndividualAssignmentType();
+	}
+
 }
 customElements.define('d2l-activity-assignment-type-editor', AssignmentTypeEditor);

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-assignment-turnitin-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-assignment-turnitin-editor.js
@@ -52,60 +52,6 @@ class AssignmentTurnitinEditor
 		super(store);
 	}
 
-	_onClickEdit() {
-
-		const entity = store.get(this.href);
-		if (!entity) {
-			return;
-		}
-
-		const url = entity.editTurnitinUrl;
-		if (!url) {
-			return;
-		}
-
-		const location = new D2L.LP.Web.Http.UrlLocation(url);
-		const buttons = [
-			{
-				Key: 'save',
-				Text: this.localize('btnSave'),
-				ResponseType: 1, // D2L.Dialog.ResponseType.Positive
-				IsPrimary: true,
-				IsEnabled: true
-			},
-			{
-				Text: this.localize('btnCancel'),
-				ResponseType: 2, // D2L.Dialog.ResponseType.Negative
-				IsPrimary: false,
-				IsEnabled: true
-			}
-		];
-
-		// Launch into our friend, the LMS, to do the thing.
-		const delayedResult = D2L.LP.Web.UI.Legacy.MasterPages.Dialog.Open(
-			/*               opener: */ document.body,
-			/*             location: */ location,
-			/*          srcCallback: */ 'SrcCallback',
-			/*       resizeCallback: */ '',
-			/*      responseDataKey: */ 'result',
-			/*                width: */ 960,
-			/*               height: */ 960,
-			/*            closeText: */ this.localize('btnCloseDialog'),
-			/*              buttons: */ buttons,
-			/* forceTriggerOnCancel: */ false
-		);
-		delayedResult.AddListener(result => {
-
-			const resultIsValid = Array.isArray(result) && result.length >= 2;
-			if (!resultIsValid) {
-				return;
-			}
-
-			const [isOriginalityCheckEnabled, isGradeMarkEnabled] = result;
-			entity.setTurnitin(isOriginalityCheckEnabled, isGradeMarkEnabled);
-		});
-	}
-
 	render() {
 
 		const entity = store.get(this.href);
@@ -164,6 +110,60 @@ class AssignmentTurnitinEditor
 			</div>
 		`;
 	}
+	_onClickEdit() {
+
+		const entity = store.get(this.href);
+		if (!entity) {
+			return;
+		}
+
+		const url = entity.editTurnitinUrl;
+		if (!url) {
+			return;
+		}
+
+		const location = new D2L.LP.Web.Http.UrlLocation(url);
+		const buttons = [
+			{
+				Key: 'save',
+				Text: this.localize('btnSave'),
+				ResponseType: 1, // D2L.Dialog.ResponseType.Positive
+				IsPrimary: true,
+				IsEnabled: true
+			},
+			{
+				Text: this.localize('btnCancel'),
+				ResponseType: 2, // D2L.Dialog.ResponseType.Negative
+				IsPrimary: false,
+				IsEnabled: true
+			}
+		];
+
+		// Launch into our friend, the LMS, to do the thing.
+		const delayedResult = D2L.LP.Web.UI.Legacy.MasterPages.Dialog.Open(
+			/*               opener: */ document.body,
+			/*             location: */ location,
+			/*          srcCallback: */ 'SrcCallback',
+			/*       resizeCallback: */ '',
+			/*      responseDataKey: */ 'result',
+			/*                width: */ 960,
+			/*               height: */ 960,
+			/*            closeText: */ this.localize('btnCloseDialog'),
+			/*              buttons: */ buttons,
+			/* forceTriggerOnCancel: */ false
+		);
+		delayedResult.AddListener(result => {
+
+			const resultIsValid = Array.isArray(result) && result.length >= 2;
+			if (!resultIsValid) {
+				return;
+			}
+
+			const [isOriginalityCheckEnabled, isGradeMarkEnabled] = result;
+			entity.setTurnitin(isOriginalityCheckEnabled, isGradeMarkEnabled);
+		});
+	}
+
 }
 
 customElements.define(

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-store.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-store.js
@@ -8,21 +8,20 @@ export class AssignmentStore {
 		this._activities = new ObjectStore(AssignmentActivityUsage);
 	}
 
-	fetchAssignment(href, token) {
-		return this._assignments.fetch(href, token);
-	}
-
-	getAssignment(href) {
-		return this._assignments.get(href);
-	}
-
 	fetchActivity(href, token) {
 		return this._activities.fetch(href, token);
+	}
+	fetchAssignment(href, token) {
+		return this._assignments.fetch(href, token);
 	}
 
 	getActivity(href) {
 		return this._activities.get(href);
 	}
+	getAssignment(href) {
+		return this._assignments.get(href);
+	}
+
 }
 
 export const shared = new AssignmentStore();

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-submission-and-completion.js
@@ -55,7 +55,7 @@ export class SubmissionAndCompletionProps {
 
 		return isFileSubmission || isTextSubmission;
 	}
-_getCompletionTypeOptions(validCompletionTypes) {
+	_getCompletionTypeOptions(validCompletionTypes) {
 		let completionTypeOptions = [];
 
 		if (validCompletionTypes && validCompletionTypes.length > 0) {
@@ -67,7 +67,6 @@ _getCompletionTypeOptions(validCompletionTypes) {
 		return completionTypeOptions;
 	}
 
-	
 	_getValidCompletionTypes(currentSubmissionType) {
 		const selectedSubmissionType = String(currentSubmissionType);
 
@@ -81,7 +80,6 @@ _getCompletionTypeOptions(validCompletionTypes) {
 
 		return submissionType.completionTypes;
 	}
-
 
 	_isCompletionTypeValid(completionTypeId, validCompletionTypes) {
 		const completionType = String(completionTypeId);

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-submission-and-completion.js
@@ -1,4 +1,4 @@
-import {action, computed, configure as configureMobx, decorate, observable } from 'mobx';
+import { action, computed, configure as configureMobx, decorate, observable } from 'mobx';
 
 configureMobx({ enforceActions: 'observed' });
 
@@ -28,6 +28,46 @@ export class SubmissionAndCompletionProps {
 		}
 	}
 
+	setCompletionType(value) {
+		this.completionType = value;
+	}
+	setFilesSubmissionLimit(value) {
+		this.filesSubmissionLimit = value;
+	}
+	setSubmissionsRule(value) {
+		this.submissionsRule = value;
+	}
+	setSubmissionType(value) {
+		this.submissionType = value;
+
+		this._setValidCompletionTypeForSubmissionType();
+	}
+
+	get showFilesSubmissionLimit() {
+		return this.submissionTypeOptions
+			.find(x => String(x.value) === '0' && `${x.value}` === `${this.submissionType}`);
+	}
+	get showSubmissionsRule() {
+		const isFileSubmission = this.submissionTypeOptions
+			.find(x => String(x.value) === '0' && `${x.value}` === `${this.submissionType}`);
+		const isTextSubmission = this.submissionTypeOptions
+			.find(x => String(x.value) === '1' && `${x.value}` === `${this.submissionType}`);
+
+		return isFileSubmission || isTextSubmission;
+	}
+_getCompletionTypeOptions(validCompletionTypes) {
+		let completionTypeOptions = [];
+
+		if (validCompletionTypes && validCompletionTypes.length > 0) {
+			completionTypeOptions = this.allCompletionTypeOptions.filter(
+				completionType => this._isCompletionTypeValid(completionType.value, validCompletionTypes)
+			);
+		}
+
+		return completionTypeOptions;
+	}
+
+	
 	_getValidCompletionTypes(currentSubmissionType) {
 		const selectedSubmissionType = String(currentSubmissionType);
 
@@ -42,6 +82,7 @@ export class SubmissionAndCompletionProps {
 		return submissionType.completionTypes;
 	}
 
+
 	_isCompletionTypeValid(completionTypeId, validCompletionTypes) {
 		const completionType = String(completionTypeId);
 
@@ -50,18 +91,6 @@ export class SubmissionAndCompletionProps {
 		}
 
 		return validCompletionTypes.some(validCompletionType => validCompletionType.toString() === completionType);
-	}
-
-	_getCompletionTypeOptions(validCompletionTypes) {
-		let completionTypeOptions = [];
-
-		if (validCompletionTypes && validCompletionTypes.length > 0) {
-			completionTypeOptions = this.allCompletionTypeOptions.filter(
-				completionType => this._isCompletionTypeValid(completionType.value, validCompletionTypes)
-			);
-		}
-
-		return completionTypeOptions;
 	}
 
 	_setValidCompletionTypeForSubmissionType() {
@@ -78,37 +107,6 @@ export class SubmissionAndCompletionProps {
 		}
 	}
 
-	setSubmissionType(value) {
-		this.submissionType = value;
-
-		this._setValidCompletionTypeForSubmissionType();
-	}
-
-	setSubmissionsRule(value) {
-		this.submissionsRule = value;
-	}
-
-	setFilesSubmissionLimit(value) {
-		this.filesSubmissionLimit = value;
-	}
-
-	setCompletionType(value) {
-		this.completionType = value;
-	}
-
-	get showFilesSubmissionLimit() {
-		return this.submissionTypeOptions
-			.find(x => String(x.value) === '0' && `${x.value}` === `${this.submissionType}`);
-	}
-
-	get showSubmissionsRule() {
-		const isFileSubmission = this.submissionTypeOptions
-			.find(x => String(x.value) === '0' && `${x.value}` === `${this.submissionType}`);
-		const isTextSubmission = this.submissionTypeOptions
-			.find(x => String(x.value) === '1' && `${x.value}` === `${this.submissionType}`);
-
-		return isFileSubmission || isTextSubmission;
-	}
 }
 
 decorate(SubmissionAndCompletionProps, {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -142,10 +142,6 @@ export class Assignment {
 
 		this.isAnonymousMarkingAvailable = this._getIsAnonymousMarkingAvailable();
 	}
-	_getIsAnonymousMarkingAvailable() {
-		return this._entity.isAnonymousMarkingAvailable() && this._isSubmissionTypeWithAnonMarking();
-	}
-	
 	setToGroupAssignmentType() {
 		this.isIndividualAssignmentType = false;
 		this.selectedGroupCategoryId =
@@ -153,13 +149,6 @@ export class Assignment {
 				? String(this.selectedGroupCategoryId)
 				: String(this.groupCategories[0].value);
 	}
-_isSubmissionTypeWithAnonMarking() {
-		// only file (0) and text (1) submissions can have anonymous marking, see https://docs.valence.desire2learn.com/res/dropbox.html#attributes
-		return ['0', '1'].includes(this.submissionAndCompletionProps.submissionType);
-	}
-
-	
-
 	setToIndividualAssignmentType() {
 		this.isIndividualAssignmentType = true;
 	}
@@ -167,10 +156,18 @@ _isSubmissionTypeWithAnonMarking() {
 		this.isOriginalityCheckEnabled = isOriginalityCheckEnabled;
 		this.isGradeMarkEnabled = isGradeMarkEnabled;
 	}
-
 	get showNotificationEmail() {
 		return typeof this.notificationEmail !== 'undefined' && this.submissionAndCompletionProps.showSubmissionsRule;
 	}
+	_getIsAnonymousMarkingAvailable() {
+		return this._entity.isAnonymousMarkingAvailable() && this._isSubmissionTypeWithAnonMarking();
+	}
+
+	_isSubmissionTypeWithAnonMarking() {
+		// only file (0) and text (1) submissions can have anonymous marking, see https://docs.valence.desire2learn.com/res/dropbox.html#attributes
+		return ['0', '1'].includes(this.submissionAndCompletionProps.submissionType);
+	}
+
 	_makeAssignmentData() {
 		/* NOTE: if you add fields here, please make sure you update the corresponding equals method in siren-sdk.
 		 		 The cancel workflow is making use of that to detect changes.

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -101,15 +101,37 @@ export class Assignment {
 		await this._entity.save(this._makeAssignmentData());
 		await this.fetch();
 	}
+	setAnnotationToolsAvailable(value) {
+		this.annotationToolsAvailable = value;
+	}
+	setAnonymousMarking(value) {
+		this.isAnonymousMarkingEnabled = value;
+	}
+	setAssignmentTypeGroupCategory(value) {
+		this.selectedGroupCategoryId = value;
+	}
 	setCompletionType(value) {
 		this.submissionAndCompletionProps.setCompletionType(value);
+	}
+
+	setDefaultScoringRubric(rubricId) {
+		if (rubricId) {
+			this.defaultScoringRubricId = String(rubricId);
+		}
+	}
+	setFilesSubmissionLimit(value) {
+		this.submissionAndCompletionProps.setFilesSubmissionLimit(value);
+	}
+	setInstructions(value) {
+		this.instructions = value;
 	}
 	_getIsAnonymousMarkingAvailable() {
 		return this._entity.isAnonymousMarkingAvailable() && this._isSubmissionTypeWithAnonMarking();
 	}
 
-	setAnonymousMarking(value) {
-		this.isAnonymousMarkingEnabled = value;
+
+	setName(value) {
+		this.name = value;
 	}
 _isSubmissionTypeWithAnonMarking() {
 		// only file (0) and text (1) submissions can have anonymous marking, see https://docs.valence.desire2learn.com/res/dropbox.html#attributes
@@ -117,25 +139,22 @@ _isSubmissionTypeWithAnonMarking() {
 	}
 	
 	
-	
-	setAssignmentTypeGroupCategory(value) {
-		this.selectedGroupCategoryId = value;
+	setNotificationEmail(value) {
+		this.notificationEmail = value;
 	}
-setFilesSubmissionLimit(value) {
-		this.submissionAndCompletionProps.setFilesSubmissionLimit(value);
+	setSubmissionAndCompletionProps(submissionAndCompletionProps) {
+		this.submissionAndCompletionProps = new SubmissionAndCompletionProps(submissionAndCompletionProps);
 	}
-	setSubmissionsRule(value) {
+setSubmissionsRule(value) {
 		this.submissionAndCompletionProps.setSubmissionsRule(value);
 	}
-setSubmissionType(value) {
+	
+	
+	setSubmissionType(value) {
 		this.submissionAndCompletionProps.setSubmissionType(value);
 
 		this.isAnonymousMarkingAvailable = this._getIsAnonymousMarkingAvailable();
 	}
-	
-	
-	
-	
 	
 	setToGroupAssignmentType() {
 		this.isIndividualAssignmentType = false;
@@ -144,38 +163,13 @@ setSubmissionType(value) {
 				? String(this.selectedGroupCategoryId)
 				: String(this.groupCategories[0].value);
 	}
+
 	setToIndividualAssignmentType() {
 		this.isIndividualAssignmentType = true;
 	}
-setTurnitin(isOriginalityCheckEnabled, isGradeMarkEnabled) {
+	setTurnitin(isOriginalityCheckEnabled, isGradeMarkEnabled) {
 		this.isOriginalityCheckEnabled = isOriginalityCheckEnabled;
 		this.isGradeMarkEnabled = isGradeMarkEnabled;
-	}
-	
-	
-	
-
-	setAnnotationToolsAvailable(value) {
-		this.annotationToolsAvailable = value;
-	}
-
-	setDefaultScoringRubric(rubricId) {
-		if (rubricId) {
-			this.defaultScoringRubricId = String(rubricId);
-		}
-	}
-	setInstructions(value) {
-		this.instructions = value;
-	}
-	setName(value) {
-		this.name = value;
-	}
-
-	setNotificationEmail(value) {
-		this.notificationEmail = value;
-	}
-	setSubmissionAndCompletionProps(submissionAndCompletionProps) {
-		this.submissionAndCompletionProps = new SubmissionAndCompletionProps(submissionAndCompletionProps);
 	}
 
 	get showNotificationEmail() {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -125,35 +125,25 @@ export class Assignment {
 	setInstructions(value) {
 		this.instructions = value;
 	}
-	_getIsAnonymousMarkingAvailable() {
-		return this._entity.isAnonymousMarkingAvailable() && this._isSubmissionTypeWithAnonMarking();
-	}
-
-
 	setName(value) {
 		this.name = value;
 	}
-_isSubmissionTypeWithAnonMarking() {
-		// only file (0) and text (1) submissions can have anonymous marking, see https://docs.valence.desire2learn.com/res/dropbox.html#attributes
-		return ['0', '1'].includes(this.submissionAndCompletionProps.submissionType);
-	}
-	
-	
 	setNotificationEmail(value) {
 		this.notificationEmail = value;
 	}
 	setSubmissionAndCompletionProps(submissionAndCompletionProps) {
 		this.submissionAndCompletionProps = new SubmissionAndCompletionProps(submissionAndCompletionProps);
 	}
-setSubmissionsRule(value) {
+	setSubmissionsRule(value) {
 		this.submissionAndCompletionProps.setSubmissionsRule(value);
 	}
-	
-	
 	setSubmissionType(value) {
 		this.submissionAndCompletionProps.setSubmissionType(value);
 
 		this.isAnonymousMarkingAvailable = this._getIsAnonymousMarkingAvailable();
+	}
+	_getIsAnonymousMarkingAvailable() {
+		return this._entity.isAnonymousMarkingAvailable() && this._isSubmissionTypeWithAnonMarking();
 	}
 	
 	setToGroupAssignmentType() {
@@ -163,6 +153,12 @@ setSubmissionsRule(value) {
 				? String(this.selectedGroupCategoryId)
 				: String(this.groupCategories[0].value);
 	}
+_isSubmissionTypeWithAnonMarking() {
+		// only file (0) and text (1) submissions can have anonymous marking, see https://docs.valence.desire2learn.com/res/dropbox.html#attributes
+		return ['0', '1'].includes(this.submissionAndCompletionProps.submissionType);
+	}
+
+	
 
 	setToIndividualAssignmentType() {
 		this.isIndividualAssignmentType = true;

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachment.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachment.js
@@ -18,18 +18,6 @@ class ActivityAttachment extends ActivityEditorMixin(MobxLitElement) {
 		super(store);
 	}
 
-	_onAttachmentUnfurled(e) {
-		const attachment = store.get(this.href);
-		if (!attachment.attachment.name) {
-			attachment.setName(e.detail.title);
-		}
-	}
-
-	_onToggleRemoved() {
-		const attachment = store.get(this.href);
-		attachment.markDeleted(!attachment.deleted);
-	}
-
 	render() {
 		const item = store.get(this.href);
 
@@ -59,6 +47,18 @@ class ActivityAttachment extends ActivityEditorMixin(MobxLitElement) {
 			</d2l-labs-attachment>
 		`;
 	}
+	_onAttachmentUnfurled(e) {
+		const attachment = store.get(this.href);
+		if (!attachment.attachment.name) {
+			attachment.setName(e.detail.title);
+		}
+	}
+
+	_onToggleRemoved() {
+		const attachment = store.get(this.href);
+		attachment.markDeleted(!attachment.deleted);
+	}
+
 }
 
 customElements.define('d2l-activity-attachment', ActivityAttachment);

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
@@ -50,6 +50,10 @@ class ActivityAttachmentsEditor extends ActivityEditorMixin(MobxLitElement) {
 		`;
 	}
 
+	hasPendingChanges() {
+		const collection = store.get(this.href);
+		return collection && collection.dirty;
+	}
 	async save() {
 		const collection = store.get(this.href);
 		if (collection) {
@@ -57,9 +61,5 @@ class ActivityAttachmentsEditor extends ActivityEditorMixin(MobxLitElement) {
 		}
 	}
 
-	hasPendingChanges() {
-		const collection = store.get(this.href);
-		return collection && collection.dirty;
-	}
 }
 customElements.define('d2l-activity-attachments-editor', ActivityAttachmentsEditor);

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -108,138 +108,6 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeActivityEdit
 		};
 	}
 
-	get _orgUnitId() {
-		const match = this.href.match(/\.(com|d2l)\/(\d+)\//);
-		if (!match || match.length < 3) {
-			return -1;
-		}
-		const orgUnitId = match[2];
-		return orgUnitId;
-	}
-
-	_launchAddFileDialog() {
-		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.FileUploadDialogOpener');
-		if (opener) {
-			opener();
-		}
-	}
-
-	_launchAddQuicklinkDialog() {
-		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.AddQuicklinkDialogOpener');
-		if (!opener) {
-			return;
-		}
-
-		// Required for the async handler below to work in Edge
-		const event = opener();
-		event.AddListener(async event => {
-			const quicklinkTemplate = await this._getQuickLinkTemplate(event);
-			this._addToCollection(attachmentStore.createLink(event.m_title, quicklinkTemplate));
-		});
-	}
-
-	get _sources() {
-		return {
-			announcement: 'news',
-			assignment: 'dropbox',
-			calendar: 'schedule',
-			chat: 'chat',
-			checklist: 'checklist',
-			content: 'content',
-			courseFile: 'coursefile',
-			discussion: 'discuss',
-			ePortfolio: 'epobject',
-			formTemplate: 'form',
-			googleDrive: 'google-drive',
-			lti: 'lti',
-			oneDrive: 'one-drive',
-			quiz: 'quiz',
-			selfAssessment: 'selfassess',
-			survey: 'survey',
-			url: 'url'
-		};
-	}
-
-	async _getQuickLinkTemplate(event) {
-		if (event.m_typeKey === this._sources.url) {
-			return event.m_url;
-		}
-
-		const isRemotePlugin = Boolean(
-			event.m_url &&
-			event.m_url.length > 0 &&
-			!Object.values(this._sources).includes(event.m_typeKey)
-		);
-
-		if (isRemotePlugin) {
-			if (/^(http|https|ftp):\/\//i.test(event.m_url)) {
-				return event.m_url;
-			} else {
-				return decodeURIComponent(event.m_url);
-			}
-		}
-
-		const quicklinkUrl = `/d2l/api/lp/unstable/${this._orgUnitId}/quickLinks/${event.m_typeKey}/${event.m_id}`;
-		const response = await fetch(quicklinkUrl);
-		const json = await response.json();
-		return json.QuickLinkTemplate;
-	}
-
-	_addToCollection(attachment) {
-		const collection = store.get(this.href);
-		collection.addAttachment(attachment);
-	}
-
-	_launchAddLinkDialog() {
-		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.AddLinkDialogOpener');
-		if (!opener) {
-			return;
-		}
-
-		const event = opener();
-		event.AddListener(event => {
-			this._addToCollection(attachmentStore.createLink(event.m_title, event.m_url));
-		});
-	}
-
-	_launchAddGoogleDriveLinkDialog() {
-		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.AddGoogleDriveLinkDialogOpener');
-		if (!opener) {
-			return;
-		}
-
-		const event = opener();
-		event.AddListener(event => {
-			this._addToCollection(attachmentStore.createGoogleDriveLink(event.m_title, event.m_url));
-		});
-	}
-
-	_launchAddOneDriveLinkDialog() {
-		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.AddOneDriveLinkDialogOpener');
-		if (!opener) {
-			return;
-		}
-
-		const event = opener();
-		event.AddListener(event => {
-			this._addToCollection(attachmentStore.createOneDriveLink(event.m_title, event.m_url));
-		});
-	}
-
-	_launchRecordVideoDialog() {
-		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.RecordVideoDialogOpener');
-		if (opener) {
-			opener();
-		}
-	}
-
-	_launchRecordAudioDialog() {
-		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.RecordAudioDialogOpener');
-		if (opener) {
-			opener();
-		}
-	}
-
 	render() {
 		const collection = store.get(this.href);
 		if (!collection) {
@@ -400,5 +268,135 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeActivityEdit
 			</div>
 		`;
 	}
+	_addToCollection(attachment) {
+		const collection = store.get(this.href);
+		collection.addAttachment(attachment);
+	}
+	async _getQuickLinkTemplate(event) {
+		if (event.m_typeKey === this._sources.url) {
+			return event.m_url;
+		}
+
+		const isRemotePlugin = Boolean(
+			event.m_url &&
+			event.m_url.length > 0 &&
+			!Object.values(this._sources).includes(event.m_typeKey)
+		);
+
+		if (isRemotePlugin) {
+			if (/^(http|https|ftp):\/\//i.test(event.m_url)) {
+				return event.m_url;
+			} else {
+				return decodeURIComponent(event.m_url);
+			}
+		}
+
+		const quicklinkUrl = `/d2l/api/lp/unstable/${this._orgUnitId}/quickLinks/${event.m_typeKey}/${event.m_id}`;
+		const response = await fetch(quicklinkUrl);
+		const json = await response.json();
+		return json.QuickLinkTemplate;
+	}
+	_launchAddFileDialog() {
+		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.FileUploadDialogOpener');
+		if (opener) {
+			opener();
+		}
+	}
+	_launchAddGoogleDriveLinkDialog() {
+		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.AddGoogleDriveLinkDialogOpener');
+		if (!opener) {
+			return;
+		}
+
+		const event = opener();
+		event.AddListener(event => {
+			this._addToCollection(attachmentStore.createGoogleDriveLink(event.m_title, event.m_url));
+		});
+	}
+	_launchAddLinkDialog() {
+		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.AddLinkDialogOpener');
+		if (!opener) {
+			return;
+		}
+
+		const event = opener();
+		event.AddListener(event => {
+			this._addToCollection(attachmentStore.createLink(event.m_title, event.m_url));
+		});
+	}
+	_launchAddQuicklinkDialog() {
+		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.AddQuicklinkDialogOpener');
+		if (!opener) {
+			return;
+		}
+
+		// Required for the async handler below to work in Edge
+		const event = opener();
+		event.AddListener(async event => {
+			const quicklinkTemplate = await this._getQuickLinkTemplate(event);
+			this._addToCollection(attachmentStore.createLink(event.m_title, quicklinkTemplate));
+		});
+	}
+	_launchAddOneDriveLinkDialog() {
+		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.AddOneDriveLinkDialogOpener');
+		if (!opener) {
+			return;
+		}
+
+		const event = opener();
+		event.AddListener(event => {
+			this._addToCollection(attachmentStore.createOneDriveLink(event.m_title, event.m_url));
+		});
+	}
+get _orgUnitId() {
+		const match = this.href.match(/\.(com|d2l)\/(\d+)\//);
+		if (!match || match.length < 3) {
+			return -1;
+		}
+		const orgUnitId = match[2];
+		return orgUnitId;
+	}
+
+
+
+
+
+	
+	
+	get _sources() {
+		return {
+			announcement: 'news',
+			assignment: 'dropbox',
+			calendar: 'schedule',
+			chat: 'chat',
+			checklist: 'checklist',
+			content: 'content',
+			courseFile: 'coursefile',
+			discussion: 'discuss',
+			ePortfolio: 'epobject',
+			formTemplate: 'form',
+			googleDrive: 'google-drive',
+			lti: 'lti',
+			oneDrive: 'one-drive',
+			quiz: 'quiz',
+			selfAssessment: 'selfassess',
+			survey: 'survey',
+			url: 'url'
+		};
+	}
+
+	_launchRecordAudioDialog() {
+		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.RecordAudioDialogOpener');
+		if (opener) {
+			opener();
+		}
+	}
+	_launchRecordVideoDialog() {
+		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.RecordVideoDialogOpener');
+		if (opener) {
+			opener();
+		}
+	}
+
 }
 customElements.define('d2l-activity-attachments-picker', ActivityAttachmentsPicker);

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -324,6 +324,17 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeActivityEdit
 			this._addToCollection(attachmentStore.createLink(event.m_title, event.m_url));
 		});
 	}
+	_launchAddOneDriveLinkDialog() {
+		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.AddOneDriveLinkDialogOpener');
+		if (!opener) {
+			return;
+		}
+
+		const event = opener();
+		event.AddListener(event => {
+			this._addToCollection(attachmentStore.createOneDriveLink(event.m_title, event.m_url));
+		});
+	}
 	_launchAddQuicklinkDialog() {
 		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.AddQuicklinkDialogOpener');
 		if (!opener) {
@@ -337,18 +348,20 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeActivityEdit
 			this._addToCollection(attachmentStore.createLink(event.m_title, quicklinkTemplate));
 		});
 	}
-	_launchAddOneDriveLinkDialog() {
-		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.AddOneDriveLinkDialogOpener');
-		if (!opener) {
-			return;
-		}
 
-		const event = opener();
-		event.AddListener(event => {
-			this._addToCollection(attachmentStore.createOneDriveLink(event.m_title, event.m_url));
-		});
+	_launchRecordAudioDialog() {
+		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.RecordAudioDialogOpener');
+		if (opener) {
+			opener();
+		}
 	}
-get _orgUnitId() {
+	_launchRecordVideoDialog() {
+		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.RecordVideoDialogOpener');
+		if (opener) {
+			opener();
+		}
+	}
+	get _orgUnitId() {
 		const match = this.href.match(/\.(com|d2l)\/(\d+)\//);
 		if (!match || match.length < 3) {
 			return -1;
@@ -357,12 +370,6 @@ get _orgUnitId() {
 		return orgUnitId;
 	}
 
-
-
-
-
-	
-	
 	get _sources() {
 		return {
 			announcement: 'news',
@@ -383,19 +390,6 @@ get _orgUnitId() {
 			survey: 'survey',
 			url: 'url'
 		};
-	}
-
-	_launchRecordAudioDialog() {
-		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.RecordAudioDialogOpener');
-		if (opener) {
-			opener();
-		}
-	}
-	_launchRecordVideoDialog() {
-		const opener = D2L.LP.Web.UI.ObjectRepository.TryGet('D2L.ActivityEditor.RecordVideoDialogOpener');
-		if (opener) {
-			opener();
-		}
 	}
 
 }

--- a/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-collection.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-collection.js
@@ -14,6 +14,23 @@ export class AttachmentCollection {
 		this.store = store;
 	}
 
+	addAttachment(attachment) {
+		this.attachments.push(attachment.href);
+	}
+	get dirty() {
+		const attachmentStore = this.store.getAttachmentStore();
+		if (!attachmentStore) {
+			return false;
+		}
+
+		for (const href of this.attachments) {
+			const attachment = attachmentStore.get(href);
+			if (attachment && this._hasChanged(attachment)) {
+				return true;
+			}
+		}
+		return false;
+	}
 	async fetch() {
 		const sirenEntity = await fetchEntity(this.href, this.token);
 		if (sirenEntity) {
@@ -21,31 +38,6 @@ export class AttachmentCollection {
 			this.load(entity);
 		}
 		return this;
-	}
-
-	load(entity) {
-		this._entity = entity;
-
-		this.canAddAttachments = entity.canAddAttachments();
-		this.canAddLink = entity.canAddLinkAttachment();
-		this.canAddFile = entity.canAddFileAttachment();
-		this.canAddGoogleDriveLink = entity.canAddGoogleDriveLinkAttachment();
-		this.canAddOneDriveLink = entity.canAddOneDriveLinkAttachment();
-		this.canRecordVideo = entity.canAddVideoNoteAttachment();
-		this.canRecordAudio = entity.canAddAudioNoteAttachment();
-		this._filesHref = entity.getFilesHref();
-
-		this.attachments = entity.getAttachmentEntityHrefs() || [];
-	}
-
-	async _getFilesEntity() {
-		if (!this._filesEntity) {
-			const sirenEntity = await fetchEntity(this._filesHref, this.token);
-			if (sirenEntity) {
-				this._filesEntity = new FilesHomeEntity(sirenEntity, this.token, { remove: () => { } });
-			}
-		}
-		return this._filesEntity;
 	}
 
 	async getPreviewUrl(fileSystemType, fileId) {
@@ -59,41 +51,19 @@ export class AttachmentCollection {
 			return filePreviewLocation.previewLocation();
 		}
 	}
+	load(entity) {
+		this._entity = entity;
 
-	setCanAddAttachments(value) {
-		this.canAddAttachments = value;
-	}
+		this.canAddAttachments = entity.canAddAttachments();
+		this.canAddLink = entity.canAddLinkAttachment();
+		this.canAddFile = entity.canAddFileAttachment();
+		this.canAddGoogleDriveLink = entity.canAddGoogleDriveLinkAttachment();
+		this.canAddOneDriveLink = entity.canAddOneDriveLinkAttachment();
+		this.canRecordVideo = entity.canAddVideoNoteAttachment();
+		this.canRecordAudio = entity.canAddAudioNoteAttachment();
+		this._filesHref = entity.getFilesHref();
 
-	setCanAddFile(value) {
-		this.canAddFile = value;
-	}
-
-	setCanAddLink(value) {
-		this.canAddLink = value;
-	}
-
-	setCanAddGoogleDriveLink(value) {
-		this.canAddGoogleDriveLink = value;
-	}
-
-	setCanAddOneDriveLink(value) {
-		this.canAddOneDriveLink = value;
-	}
-
-	setCanRecordVideo(value) {
-		this.canAddRecordVideo = value;
-	}
-
-	setCanRecordAudio(value) {
-		this.canRecordAudio = value;
-	}
-
-	setAttachments(attachments) {
-		this.attachments = attachments;
-	}
-
-	addAttachment(attachment) {
-		this.attachments.push(attachment.href);
+		this.attachments = entity.getAttachmentEntityHrefs() || [];
 	}
 
 	async save() {
@@ -115,6 +85,42 @@ export class AttachmentCollection {
 			}
 		}
 	}
+	setAttachments(attachments) {
+		this.attachments = attachments;
+	}
+	setCanAddAttachments(value) {
+		this.canAddAttachments = value;
+	}
+	setCanAddFile(value) {
+		this.canAddFile = value;
+	}
+	async _getFilesEntity() {
+		if (!this._filesEntity) {
+			const sirenEntity = await fetchEntity(this._filesHref, this.token);
+			if (sirenEntity) {
+				this._filesEntity = new FilesHomeEntity(sirenEntity, this.token, { remove: () => { } });
+			}
+		}
+		return this._filesEntity;
+	}
+
+	setCanAddGoogleDriveLink(value) {
+		this.canAddGoogleDriveLink = value;
+	}
+	setCanAddLink(value) {
+		this.canAddLink = value;
+	}
+
+	setCanAddOneDriveLink(value) {
+		this.canAddOneDriveLink = value;
+	}
+
+	setCanRecordAudio(value) {
+		this.canRecordAudio = value;
+	}
+	setCanRecordVideo(value) {
+		this.canAddRecordVideo = value;
+	}
 
 	_hasChanged(attachment) {
 		if (attachment.deleted && !attachment.creating) {
@@ -125,20 +131,6 @@ export class AttachmentCollection {
 		return false;
 	}
 
-	get dirty() {
-		const attachmentStore = this.store.getAttachmentStore();
-		if (!attachmentStore) {
-			return false;
-		}
-
-		for (const href of this.attachments) {
-			const attachment = attachmentStore.get(href);
-			if (attachment && this._hasChanged(attachment)) {
-				return true;
-			}
-		}
-		return false;
-	}
 }
 
 decorate(AttachmentCollection, {

--- a/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-collection.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-collection.js
@@ -119,8 +119,6 @@ export class AttachmentCollection {
 		return this._filesEntity;
 	}
 
-
-
 	_hasChanged(attachment) {
 		if (attachment.deleted && !attachment.creating) {
 			return true;

--- a/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-collection.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-collection.js
@@ -94,6 +94,21 @@ export class AttachmentCollection {
 	setCanAddFile(value) {
 		this.canAddFile = value;
 	}
+	setCanAddGoogleDriveLink(value) {
+		this.canAddGoogleDriveLink = value;
+	}
+	setCanAddLink(value) {
+		this.canAddLink = value;
+	}
+	setCanAddOneDriveLink(value) {
+		this.canAddOneDriveLink = value;
+	}
+	setCanRecordAudio(value) {
+		this.canRecordAudio = value;
+	}
+	setCanRecordVideo(value) {
+		this.canAddRecordVideo = value;
+	}
 	async _getFilesEntity() {
 		if (!this._filesEntity) {
 			const sirenEntity = await fetchEntity(this._filesHref, this.token);
@@ -104,23 +119,7 @@ export class AttachmentCollection {
 		return this._filesEntity;
 	}
 
-	setCanAddGoogleDriveLink(value) {
-		this.canAddGoogleDriveLink = value;
-	}
-	setCanAddLink(value) {
-		this.canAddLink = value;
-	}
 
-	setCanAddOneDriveLink(value) {
-		this.canAddOneDriveLink = value;
-	}
-
-	setCanRecordAudio(value) {
-		this.canRecordAudio = value;
-	}
-	setCanRecordVideo(value) {
-		this.canAddRecordVideo = value;
-	}
 
 	_hasChanged(attachment) {
 		if (attachment.deleted && !attachment.creating) {

--- a/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-store.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-store.js
@@ -37,15 +37,13 @@ export class AttachmentStore extends ObjectStore {
 		this.put(tempId, file);
 		return file;
 	}
-_createLink(Type, name, url) {
+	_createLink(Type, name, url) {
 		const tempId = nextTempId();
 		const link = new Type(tempId);
 		link.initLink(name, url);
 		this.put(tempId, link);
 		return link;
 	}
-	
-	
 
 }
 

--- a/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-store.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-store.js
@@ -12,26 +12,24 @@ export class AttachmentStore extends ObjectStore {
 		super(Attachment);
 	}
 
-	_createLink(Type, name, url) {
-		const tempId = nextTempId();
-		const link = new Type(tempId);
-		link.initLink(name, url);
-		this.put(tempId, link);
-		return link;
+	createAudio(name, fileSystemType, fileId, previewUrl) {
+		return this._createFile(AudioAttachment, name, fileSystemType, fileId, previewUrl);
 	}
-
-	createLink(name, url) {
-		return this._createLink(LinkAttachment, name, url);
+	createFile(name, fileSystemType, fileId, previewUrl) {
+		return this._createFile(FileAttachment, name, fileSystemType, fileId, previewUrl);
 	}
-
 	createGoogleDriveLink(name, url) {
 		return this._createLink(GoogleDriveAttachment, name, url);
 	}
-
+	createLink(name, url) {
+		return this._createLink(LinkAttachment, name, url);
+	}
 	createOneDriveLink(name, url) {
 		return this._createLink(OneDriveAttachment, name, url);
 	}
-
+	createVideo(name, fileSystemType, fileId, previewUrl) {
+		return this._createFile(VideoAttachment, name, fileSystemType, fileId, previewUrl);
+	}
 	_createFile(Type, name, fileSystemType, fileId, previewUrl) {
 		const tempId = nextTempId();
 		const file = new Type(tempId);
@@ -39,18 +37,16 @@ export class AttachmentStore extends ObjectStore {
 		this.put(tempId, file);
 		return file;
 	}
-
-	createFile(name, fileSystemType, fileId, previewUrl) {
-		return this._createFile(FileAttachment, name, fileSystemType, fileId, previewUrl);
+_createLink(Type, name, url) {
+		const tempId = nextTempId();
+		const link = new Type(tempId);
+		link.initLink(name, url);
+		this.put(tempId, link);
+		return link;
 	}
+	
+	
 
-	createAudio(name, fileSystemType, fileId, previewUrl) {
-		return this._createFile(AudioAttachment, name, fileSystemType, fileId, previewUrl);
-	}
-
-	createVideo(name, fileSystemType, fileId, previewUrl) {
-		return this._createFile(VideoAttachment, name, fileSystemType, fileId, previewUrl);
-	}
 }
 
 export const shared = new AttachmentStore();

--- a/components/d2l-activity-editor/d2l-activity-attachments/state/attachment.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/state/attachment.js
@@ -14,6 +14,11 @@ export class Attachment {
 		this.attachment = null;
 	}
 
+	async delete() {
+		if (this._entity) {
+			await this._entity.deleteAttachment();
+		}
+	}
 	async fetch() {
 		const sirenEntity = await fetchEntity(this.href, this.token);
 		if (sirenEntity) {
@@ -47,11 +52,6 @@ export class Attachment {
 		this.attachment.name = name;
 	}
 
-	async delete() {
-		if (this._entity) {
-			await this._entity.deleteAttachment();
-		}
-	}
 }
 
 decorate(Attachment, {

--- a/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
@@ -27,22 +27,6 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeActiv
 		this._overrides = document.documentElement.dataset.intlOverrides || '{}';
 	}
 
-	_onStartDatetimePickerDatetimeCleared() {
-		store.get(this.href).dates.setStartDate('');
-	}
-
-	_onStartDatetimePickerDatetimeChanged(e) {
-		store.get(this.href).dates.setStartDate(e.detail.toISOString());
-	}
-
-	_onEndDatetimePickerDatetimeCleared() {
-		store.get(this.href).dates.setEndDate('');
-	}
-
-	_onEndDatetimePickerDatetimeChanged(e) {
-		store.get(this.href).dates.setEndDate(e.detail.toISOString());
-	}
-
 	render() {
 		const entity = store.get(this.href);
 		const dates = entity ? entity.dates : null;
@@ -103,7 +87,6 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeActiv
 			</div>
 		`;
 	}
-
 	updated(changedProperties) {
 		super.updated(changedProperties);
 
@@ -112,5 +95,18 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeActiv
 			super._fetch(() => store.fetch(this.href, this.token));
 		}
 	}
+	_onEndDatetimePickerDatetimeChanged(e) {
+		store.get(this.href).dates.setEndDate(e.detail.toISOString());
+	}
+	_onEndDatetimePickerDatetimeCleared() {
+		store.get(this.href).dates.setEndDate('');
+	}
+	_onStartDatetimePickerDatetimeChanged(e) {
+		store.get(this.href).dates.setStartDate(e.detail.toISOString());
+	}
+	_onStartDatetimePickerDatetimeCleared() {
+		store.get(this.href).dates.setStartDate('');
+	}
+
 }
 customElements.define('d2l-activity-availability-dates-editor', ActivityAvailabilityDatesEditor);

--- a/components/d2l-activity-editor/d2l-activity-availability-dates-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-summary.js
@@ -13,20 +13,6 @@ class ActivityAvailabilityDatesSummary
 		this._overrides = document.documentElement.dataset.intlOverrides || '{}';
 	}
 
-	updated(changedProperties) {
-
-		super.updated(changedProperties);
-
-		const didHrefTokenChange =
-			changedProperties.has('href') ||
-			changedProperties.has('token');
-
-		if (didHrefTokenChange && this.href && this.token) {
-
-			super._fetch(() => store.fetch(this.href, this.token));
-		}
-	}
-
 	render() {
 
 		const activity = store.get(this.href);
@@ -50,6 +36,19 @@ class ActivityAvailabilityDatesSummary
 		}
 
 		return html`${text}`;
+	}
+	updated(changedProperties) {
+
+		super.updated(changedProperties);
+
+		const didHrefTokenChange =
+			changedProperties.has('href') ||
+			changedProperties.has('token');
+
+		if (didHrefTokenChange && this.href && this.token) {
+
+			super._fetch(() => store.fetch(this.href, this.token));
+		}
 	}
 
 	_formatDate(suspiciousString) {

--- a/components/d2l-activity-editor/d2l-activity-competencies.js
+++ b/components/d2l-activity-editor/d2l-activity-competencies.js
@@ -61,6 +61,27 @@ class ActivityCompetencies extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 		super(store);
 	}
 
+	render() {
+		const activity = store.get(this.href);
+		if (!activity || !activity.competenciesHref) {
+			return html``;
+		}
+
+		const {
+			associatedCompetenciesCount: count,
+			unevaluatedCompetenciesCount: unevalCount,
+			competenciesDialogUrl: dialogUrl
+		} = activity;
+
+		return html`
+			<label class="d2l-label-text">${this.localize('editor.competencies')}</label>
+			<div class="d2l-competencies-count-container">
+				${this._renderCountText(count)}
+			</div>
+			${this._renderUnevalCountText(unevalCount)}
+			${this._renderDialogOpener(dialogUrl)}
+		`;
+	}
 	_openManageCompetencies() {
 		const dialogUrl = store.get(this.href).competenciesDialogUrl;
 
@@ -99,6 +120,18 @@ class ActivityCompetencies extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 		delayedResult.AddReleaseListener(() => store.get(this.href).loadCompetencies(true));
 	}
 
+	_renderCountText(count) {
+		if (count === 0) {
+			const langTerm = this.localize('editor.noLearningObjectives');
+			return html`<div id="no-learning-objectives-summary" class="d2l-body-small">${langTerm}</div>`;
+		} else {
+			const langTerm = this.localize('editor.competenciesCount', { count });
+			return html`
+			<d2l-icon class="d2l-competencies-icon" icon="tier1:user-competencies"></d2l-icon>
+			<div class="d2l-competencies-count-text">${langTerm}</div>
+		`;
+		}
+	}
 	_renderDialogOpener(dialogUrl) {
 		if (!dialogUrl) {
 			return html``;
@@ -113,19 +146,6 @@ class ActivityCompetencies extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 		`;
 	}
 
-	_renderCountText(count) {
-		if (count === 0) {
-			const langTerm = this.localize('editor.noLearningObjectives');
-			return html`<div id="no-learning-objectives-summary" class="d2l-body-small">${langTerm}</div>`;
-		} else {
-			const langTerm = this.localize('editor.competenciesCount', { count });
-			return html`
-			<d2l-icon class="d2l-competencies-icon" icon="tier1:user-competencies"></d2l-icon>
-			<div class="d2l-competencies-count-text">${langTerm}</div>
-		`;
-		}
-	}
-
 	_renderUnevalCountText(count) {
 		if (!count) {
 			return html``;
@@ -136,28 +156,6 @@ class ActivityCompetencies extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 				<d2l-icon class="d2l-competencies-icon d2l-alert-icon" icon="tier1:alert"></d2l-icon>
 				<div class="d2l-competencies-count-text">${this.localize('editor.unevaluatedCompetencies', { count })}</div>
 			</div>
-		`;
-	}
-
-	render() {
-		const activity = store.get(this.href);
-		if (!activity || !activity.competenciesHref) {
-			return html``;
-		}
-
-		const {
-			associatedCompetenciesCount: count,
-			unevaluatedCompetenciesCount: unevalCount,
-			competenciesDialogUrl: dialogUrl
-		} = activity;
-
-		return html`
-			<label class="d2l-label-text">${this.localize('editor.competencies')}</label>
-			<div class="d2l-competencies-count-container">
-				${this._renderCountText(count)}
-			</div>
-			${this._renderUnevalCountText(unevalCount)}
-			${this._renderDialogOpener(dialogUrl)}
 		`;
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-conditions-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-conditions-editor.js
@@ -101,6 +101,20 @@ class ActivityConditionsEditor
 		super(store);
 	}
 
+	render() {
+
+		const entity = store.get(this.href);
+		if (!entity) {
+			return html``;
+		}
+
+		return html`
+			${this._renderDescription(entity)}
+			${this._renderOperators(entity)}
+			${this._renderConditions(entity)}
+			${this._renderAddCondition(entity)}
+		`;
+	}
 	async save() {
 
 		const entity = store.get(this.href);
@@ -109,130 +123,6 @@ class ActivityConditionsEditor
 		}
 
 		await entity.save();
-	}
-
-	_renderDescription({ conditions }) {
-
-		if (conditions.length <= 0) {
-
-			return html`
-				<p class="d2l-body-small">
-					${this.description}
-				</p>
-			`;
-		}
-
-		if (conditions.length === 1) {
-
-			return html`
-				<p class="d2l-label-text">
-					${this.localize('editor.lblConditionsOperator')}
-				</p>
-			`;
-		}
-
-		// label rendered by operator select list for a11y
-		return html``;
-	}
-
-	_renderOperator({ value, selected, title }) {
-
-		return html`
-			<option value="${value}" ?selected="${selected}">
-				${title}
-			</option>
-		`;
-	}
-
-	_setOperator(event) {
-
-		const entity = store.get(this.href);
-		if (!entity) {
-			return;
-		}
-
-		entity.setOperator(event.target.value);
-	}
-
-	_renderOperators({ conditions, operators }) {
-
-		if (conditions.length <= 1) {
-			return html``;
-		}
-
-		return html`
-			<div>
-				<label class="d2l-label-text" for="operator">
-					${this.localize('editor.lblConditionsOperator')}
-				</label>
-				<select
-					class="d2l-input-select"
-					id="operator"
-					@change="${this._setOperator}">
-					${operators.map(this._renderOperator, this)}
-				</select>
-			</div>
-		`;
-	}
-
-	_removeCondition(event) {
-
-		const entity = store.get(this.href);
-		if (!entity) {
-			return;
-		}
-
-		const key = event.target.dataset.key;
-		const conditions = entity.conditions.reduce((map, x) => {
-			map[`${x.key}`] = x.title;
-			return map;
-		}, {});
-
-		const condition = conditions[key];
-		entity.remove(key);
-
-		if (condition) {
-			// don't want <strong> tags in screenreader text
-			const title = condition.replace(/<strong>|<\/strong>/g, '');
-			announce(`${this.localize('editor.txtConditionRemoved', {title})}`);
-		}
-	}
-
-	_renderCondition({ key, title }) {
-
-		return html`
-			<li class="d2l-list-item">
-				<span class="d2l-list-item-body">
-					<span class="d2l-list-item-decoration">
-						<d2l-icon
-							icon="tier2:release-conditions"
-							style="width:30px;height:30px;">
-						</d2l-icon>
-					</span>
-					<span
-						class="d2l-list-item-content d2l-body-compact"
-						.innerHTML="${title}">
-					</span>
-				</span>
-				<span class="d2l-list-item-deleter">
-					<d2l-button-icon
-						text="${this.localize('editor.btnRemoveCondition')}"
-						icon="tier1:close-default"
-						data-key="${key}"
-						@click="${this._removeCondition}">
-					</d2l-button-icon>
-				</span>
-			</li>
-		`;
-	}
-
-	_renderConditions({ conditions }) {
-
-		return html`
-			<ul class="d2l-conditions">
-				${conditions.map(this._renderCondition, this)}
-			</ul>
-		`;
 	}
 
 	_addExisting(event) {
@@ -289,17 +179,16 @@ class ActivityConditionsEditor
 					if (result.length === 1) {
 						// don't want <strong> tags in screenreader text
 						const title = result[0].Text.replace(/<strong>|<\/strong>/g, '');
-						announce(`${this.localize('editor.txtConditionAdded', {title})}`);
+						announce(`${this.localize('editor.txtConditionAdded', { title })}`);
 					}
 					if (result.length > 1) {
 						const count = result.length;
-						announce(`${this.localize('editor.txtConditionsAdded', {count})}`);
+						announce(`${this.localize('editor.txtConditionsAdded', { count })}`);
 					}
 				}
 			}
 		});
 	}
-
 	_createNew(event) {
 
 		const entity = store.get(this.href);
@@ -349,11 +238,32 @@ class ActivityConditionsEditor
 				entity.add(result);
 
 				const title = result.Text.replace(/<strong>|<\/strong>/g, '');
-				announce(`${this.localize('editor.txtConditionAdded', {title})}`);
+				announce(`${this.localize('editor.txtConditionAdded', { title })}`);
 			}
 		});
 	}
+	_removeCondition(event) {
 
+		const entity = store.get(this.href);
+		if (!entity) {
+			return;
+		}
+
+		const key = event.target.dataset.key;
+		const conditions = entity.conditions.reduce((map, x) => {
+			map[`${x.key}`] = x.title;
+			return map;
+		}, {});
+
+		const condition = conditions[key];
+		entity.remove(key);
+
+		if (condition) {
+			// don't want <strong> tags in screenreader text
+			const title = condition.replace(/<strong>|<\/strong>/g, '');
+			announce(`${this.localize('editor.txtConditionRemoved', { title })}`);
+		}
+	}
 	_renderAddCondition(entity) {
 
 		const { canAttachExisting, canCreateNew } = entity;
@@ -394,21 +304,105 @@ class ActivityConditionsEditor
 			</d2l-dropdown>
 		`;
 	}
+	_renderCondition({ key, title }) {
 
-	render() {
+		return html`
+			<li class="d2l-list-item">
+				<span class="d2l-list-item-body">
+					<span class="d2l-list-item-decoration">
+						<d2l-icon
+							icon="tier2:release-conditions"
+							style="width:30px;height:30px;">
+						</d2l-icon>
+					</span>
+					<span
+						class="d2l-list-item-content d2l-body-compact"
+						.innerHTML="${title}">
+					</span>
+				</span>
+				<span class="d2l-list-item-deleter">
+					<d2l-button-icon
+						text="${this.localize('editor.btnRemoveCondition')}"
+						icon="tier1:close-default"
+						data-key="${key}"
+						@click="${this._removeCondition}">
+					</d2l-button-icon>
+				</span>
+			</li>
+		`;
+	}
+	_renderConditions({ conditions }) {
 
-		const entity = store.get(this.href);
-		if (!entity) {
+		return html`
+			<ul class="d2l-conditions">
+				${conditions.map(this._renderCondition, this)}
+			</ul>
+		`;
+	}
+	_renderDescription({ conditions }) {
+
+		if (conditions.length <= 0) {
+
+			return html`
+				<p class="d2l-body-small">
+					${this.description}
+				</p>
+			`;
+		}
+
+		if (conditions.length === 1) {
+
+			return html`
+				<p class="d2l-label-text">
+					${this.localize('editor.lblConditionsOperator')}
+				</p>
+			`;
+		}
+
+		// label rendered by operator select list for a11y
+		return html``;
+	}
+
+
+	_renderOperator({ value, selected, title }) {
+
+		return html`
+			<option value="${value}" ?selected="${selected}">
+				${title}
+			</option>
+		`;
+	}
+
+	_renderOperators({ conditions, operators }) {
+
+		if (conditions.length <= 1) {
 			return html``;
 		}
 
 		return html`
-			${this._renderDescription(entity)}
-			${this._renderOperators(entity)}
-			${this._renderConditions(entity)}
-			${this._renderAddCondition(entity)}
+			<div>
+				<label class="d2l-label-text" for="operator">
+					${this.localize('editor.lblConditionsOperator')}
+				</label>
+				<select
+					class="d2l-input-select"
+					id="operator"
+					@change="${this._setOperator}">
+					${operators.map(this._renderOperator, this)}
+				</select>
+			</div>
 		`;
 	}
+	_setOperator(event) {
+
+		const entity = store.get(this.href);
+		if (!entity) {
+			return;
+		}
+
+		entity.setOperator(event.target.value);
+	}
+
 }
 
 customElements.define(

--- a/components/d2l-activity-editor/d2l-activity-conditions-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-conditions-editor.js
@@ -363,7 +363,6 @@ class ActivityConditionsEditor
 		return html``;
 	}
 
-
 	_renderOperator({ value, selected, title }) {
 
 		return html`

--- a/components/d2l-activity-editor/d2l-activity-due-date-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-due-date-editor.js
@@ -32,37 +32,10 @@ class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 		this._isFirstLoad = true;
 	}
 
-	_onDatetimePickerDatetimeCleared() {
-		store.get(this.href).dates.setDueDate('');
+	firstUpdated() {
+		super.firstUpdated();
+		this._isFirstLoad = false;
 	}
-
-	_onDatetimePickerDatetimeChanged(e) {
-		store.get(this.href).dates.setDueDate(e.detail.toISOString());
-	}
-
-	dateTemplate(date, canEdit, errorTerm) {
-		return html`
-			<div id="datetime-picker-container" ?hidden="${!canEdit}">
-				<d2l-datetime-picker
-					hide-label
-					name="date"
-					id="date"
-					date-label="${this.localize('editor.dueDate')}"
-					time-label="${this.localize('editor.dueTime')}"
-					datetime="${date}"
-					overrides="${this._overrides}"
-					placeholder="${this.localize('editor.noDueDate')}"
-					aria-invalid="${errorTerm ? 'true' : 'false'}"
-					invalid="${errorTerm}"
-					tooltip-red
-					boundary="{&quot;below&quot;:240}"
-					@d2l-datetime-picker-datetime-changed="${this._onDatetimePickerDatetimeChanged}"
-					@d2l-datetime-picker-datetime-cleared="${this._onDatetimePickerDatetimeCleared}">
-				</d2l-datetime-picker>
-			</div>
-		`;
-	}
-
 	render() {
 		const entity = store.get(this.href);
 		const dates = entity ? entity.dates : null;
@@ -91,12 +64,6 @@ class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 			${this.dateTemplate(dueDate, canEditDates, errorTerm)}
 		`;
 	}
-
-	firstUpdated() {
-		super.firstUpdated();
-		this._isFirstLoad = false;
-	}
-
 	updated(changedProperties) {
 		super.updated(changedProperties);
 
@@ -104,6 +71,35 @@ class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 			this.href && this.token) {
 			super._fetch(() => store.fetch(this.href, this.token));
 		}
+	}
+	dateTemplate(date, canEdit, errorTerm) {
+		return html`
+			<div id="datetime-picker-container" ?hidden="${!canEdit}">
+				<d2l-datetime-picker
+					hide-label
+					name="date"
+					id="date"
+					date-label="${this.localize('editor.dueDate')}"
+					time-label="${this.localize('editor.dueTime')}"
+					datetime="${date}"
+					overrides="${this._overrides}"
+					placeholder="${this.localize('editor.noDueDate')}"
+					aria-invalid="${errorTerm ? 'true' : 'false'}"
+					invalid="${errorTerm}"
+					tooltip-red
+					boundary="{&quot;below&quot;:240}"
+					@d2l-datetime-picker-datetime-changed="${this._onDatetimePickerDatetimeChanged}"
+					@d2l-datetime-picker-datetime-cleared="${this._onDatetimePickerDatetimeCleared}">
+				</d2l-datetime-picker>
+			</div>
+		`;
+	}
+	_onDatetimePickerDatetimeChanged(e) {
+		store.get(this.href).dates.setDueDate(e.detail.toISOString());
+	}
+
+	_onDatetimePickerDatetimeCleared() {
+		store.get(this.href).dates.setDueDate('');
 	}
 
 }

--- a/components/d2l-activity-editor/d2l-activity-editor-buttons.js
+++ b/components/d2l-activity-editor/d2l-activity-editor-buttons.js
@@ -36,6 +36,21 @@ class ActivityEditorButtons extends RtlMixin(LocalizeActivityEditorMixin(LitElem
 		`;
 	}
 
+	render() {
+		return html`
+			<d2l-button class="d2l-desktop" primary @click="${this._save}">${this.localize('editor.btnSave')}</d2l-button>
+			<d2l-button class="d2l-mobile d2l-footerBtn" primary @click="${this._save}">${this.localize('editor.btnSaveMobile')}</d2l-button>
+			<d2l-button class="d2l-footerBtn" @click="${this._cancel}">${this.localize('editor.btnCancel')}</d2l-button>
+		`;
+	}
+	_cancel() {
+		const event = new CustomEvent('d2l-activity-editor-cancel', {
+			bubbles: true,
+			composed: true,
+			cancelable: true
+		});
+		this.dispatchEvent(event);
+	}
 	_save() {
 		const event = new CustomEvent('d2l-activity-editor-save', {
 			bubbles: true,
@@ -45,22 +60,6 @@ class ActivityEditorButtons extends RtlMixin(LocalizeActivityEditorMixin(LitElem
 		this.dispatchEvent(event);
 	}
 
-	_cancel() {
-		const event = new CustomEvent('d2l-activity-editor-cancel', {
-			bubbles: true,
-			composed: true,
-			cancelable: true
-		});
-		this.dispatchEvent(event);
-	}
-
-	render() {
-		return html`
-			<d2l-button class="d2l-desktop" primary @click="${this._save}">${this.localize('editor.btnSave')}</d2l-button>
-			<d2l-button class="d2l-mobile d2l-footerBtn" primary @click="${this._save}">${this.localize('editor.btnSaveMobile')}</d2l-button>
-			<d2l-button class="d2l-footerBtn" @click="${this._cancel}">${this.localize('editor.btnCancel')}</d2l-button>
-		`;
-	}
 }
 
 customElements.define('d2l-activity-editor-buttons', ActivityEditorButtons);

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -36,46 +36,6 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 		this._backdropShown = false;
 	}
 
-	async validate() {
-		const activity = store.get(this.href);
-		if (activity) {
-			await activity.validate();
-		}
-	}
-
-	async save() {
-		const activity = store.get(this.href);
-		if (activity) {
-			await activity.save();
-		}
-	}
-
-	update(changedProperties) {
-		super.update(changedProperties);
-		if (changedProperties.has('asyncState') && this.asyncState === asyncStates.complete) {
-			this.logLoadEvent(this.href, this.type, this.telemetryId);
-		}
-	}
-
-	updated(changedProperties) {
-		super.updated(changedProperties);
-		if (changedProperties.has('isSaving')) {
-			this._toggleBackdrop(this.isSaving);
-		}
-	}
-
-	_toggleBackdrop(show) {
-		this._backdropShown = show;
-	}
-
-	hasPendingChanges() {
-		const activity = store.get(this.href);
-		if (activity) {
-			return activity.dirty();
-		}
-		return false;
-	}
-
 	render() {
 		return html`
 			<div ?hidden="${this.asyncState === asyncStates.complete}" class="d2l-activity-editor-loading">${this.localize('editor.loading')}</div>
@@ -91,5 +51,42 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 			</d2l-backdrop>
 		`;
 	}
+	update(changedProperties) {
+		super.update(changedProperties);
+		if (changedProperties.has('asyncState') && this.asyncState === asyncStates.complete) {
+			this.logLoadEvent(this.href, this.type, this.telemetryId);
+		}
+	}
+	updated(changedProperties) {
+		super.updated(changedProperties);
+		if (changedProperties.has('isSaving')) {
+			this._toggleBackdrop(this.isSaving);
+		}
+	}
+	hasPendingChanges() {
+		const activity = store.get(this.href);
+		if (activity) {
+			return activity.dirty();
+		}
+		return false;
+	}
+	async save() {
+		const activity = store.get(this.href);
+		if (activity) {
+			await activity.save();
+		}
+	}
+
+	async validate() {
+		const activity = store.get(this.href);
+		if (activity) {
+			await activity.validate();
+		}
+	}
+
+	_toggleBackdrop(show) {
+		this._backdropShown = show;
+	}
+
 }
 customElements.define('d2l-activity-editor', ActivityEditor);

--- a/components/d2l-activity-editor/d2l-activity-grades-dialog.js
+++ b/components/d2l-activity-editor/d2l-activity-grades-dialog.js
@@ -72,6 +72,72 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeActivityEditorMix
 		super(store);
 	}
 
+	render() {
+		const activity = store.get(this.href);
+		if (!activity) {
+			return html``;
+		}
+
+		const {
+			scoreOutOf,
+			scoreOutOfError,
+			newGradeName
+		} = activity.scoreAndGrade;
+
+		return html`
+			<d2l-dialog title-text="${this.localize('editor.chooseFromGrades')}" width="460" @d2l-dialog-open="${this._onDialogOpen}">
+				<label class="d2l-input-radio-label ${!this._canLinkNewGrade ? 'd2l-input-radio-label-disabled' : ''}">
+					<input
+						type="radio"
+						name="chooseFromGrades"
+						value="createNew"
+						?disabled="${!this._canLinkNewGrade}"
+						.checked="${this._createNewRadioChecked}"
+						@change="${this._dialogRadioChanged}">
+					${this.localize('editor.createAndLinkToNewGradeItem')}
+				</label>
+				<d2l-input-radio-spacer ?hidden="${!this._createNewRadioChecked && this._canLinkNewGrade}">
+					${this._canLinkNewGrade ? html`
+						<div class="d2l-activity-grades-dialog-create-new-container">
+							<div class="d2l-activity-grades-dialog-create-new-icon"><d2l-icon class="d2l-activity-grades-dialog-grade-icon" icon="tier1:grade"></d2l-icon></div>
+							<div>
+								<div class="d2l-activity-grades-dialog-create-new-activity-name">${newGradeName}</div>
+								<div class="d2l-body-small">${scoreOutOf && !scoreOutOfError ? html`
+									${this.localize('editor.points', { points: formatNumber(scoreOutOf, { maximumFractionDigits: 2 }) })}
+								` : null }
+								</div>
+							</div>
+						</div>
+						<d2l-activity-grade-category-selector .href="${this.href}" .token="${this.token}"></d2l-activity-grade-category-selector>
+					` : html`
+						<div class="d2l-body-small">
+							${this.localize('editor.noGradeCreatePermission')}
+						</div>
+					`}
+				</d2l-input-radio-spacer>
+				<label id="linkToExistingGradeItemRadioButton" class="d2l-input-radio-label ${!this._hasGradeCandidates ? 'd2l-input-radio-label-disabled' : ''}">
+					<input
+						type="radio"
+						name="chooseFromGrades"
+						value="linkExisting"
+						?disabled="${!this._hasGradeCandidates}"
+						.checked="${!this._createNewRadioChecked && this._hasGradeCandidates}"
+						@change="${this._dialogRadioChanged}">
+					${this.localize('editor.linkToExistingGradeItem')}
+				</label>
+				<d2l-input-radio-spacer ?hidden="${this._createNewRadioChecked && this._hasGradeCandidates}" ?disabled="${!this._hasGradeCandidates}">
+					${this._hasGradeCandidates ? html`<d2l-activity-grade-candidate-selector
+						.href="${this.href}"
+						.token="${this.token}">
+					</d2l-activity-grade-candidate-selector>` : html`<div class="d2l-body-small">
+						${this.localize('editor.noGradeItems')}
+					</div>`}
+				</d2l-input-radio-spacer>
+				<d2l-button slot="footer" primary dialog-action="done">${this.localize('editor.ok')}</d2l-button>
+				<d2l-button slot="footer" dialog-action="cancel">${this.localize('editor.cancel')}</d2l-button>
+			</d2l-dialog>
+		`;
+	}
 	async open() {
 		const scoreAndGrade = store.get(this.href).scoreAndGrade;
 		await Promise.all([
@@ -124,71 +190,5 @@ class ActivityGradesDialog extends ActivityEditorMixin(LocalizeActivityEditorMix
 		e.target.resize();
 	}
 
-	render() {
-		const activity = store.get(this.href);
-		if (!activity) {
-			return html``;
-		}
-
-		const {
-			scoreOutOf,
-			scoreOutOfError,
-			newGradeName
-		} = activity.scoreAndGrade;
-
-		return html`
-			<d2l-dialog title-text="${this.localize('editor.chooseFromGrades')}" width="460" @d2l-dialog-open="${this._onDialogOpen}">
-				<label class="d2l-input-radio-label ${!this._canLinkNewGrade ? 'd2l-input-radio-label-disabled' : ''}">
-					<input
-						type="radio"
-						name="chooseFromGrades"
-						value="createNew"
-						?disabled="${!this._canLinkNewGrade}"
-						.checked="${this._createNewRadioChecked}"
-						@change="${this._dialogRadioChanged}">
-					${this.localize('editor.createAndLinkToNewGradeItem')}
-				</label>
-				<d2l-input-radio-spacer ?hidden="${!this._createNewRadioChecked && this._canLinkNewGrade}">
-					${this._canLinkNewGrade ? html`
-						<div class="d2l-activity-grades-dialog-create-new-container">
-							<div class="d2l-activity-grades-dialog-create-new-icon"><d2l-icon class="d2l-activity-grades-dialog-grade-icon" icon="tier1:grade"></d2l-icon></div>
-							<div>
-								<div class="d2l-activity-grades-dialog-create-new-activity-name">${newGradeName}</div>
-								<div class="d2l-body-small">${scoreOutOf && !scoreOutOfError ? html`
-									${this.localize('editor.points', { points: formatNumber(scoreOutOf, { maximumFractionDigits: 2 })})}
-								` : null }
-								</div>
-							</div>
-						</div>
-						<d2l-activity-grade-category-selector .href="${this.href}" .token="${this.token}"></d2l-activity-grade-category-selector>
-					` : html`
-						<div class="d2l-body-small">
-							${this.localize('editor.noGradeCreatePermission')}
-						</div>
-					`}
-				</d2l-input-radio-spacer>
-				<label id="linkToExistingGradeItemRadioButton" class="d2l-input-radio-label ${!this._hasGradeCandidates ? 'd2l-input-radio-label-disabled' : ''}">
-					<input
-						type="radio"
-						name="chooseFromGrades"
-						value="linkExisting"
-						?disabled="${!this._hasGradeCandidates}"
-						.checked="${!this._createNewRadioChecked && this._hasGradeCandidates}"
-						@change="${this._dialogRadioChanged}">
-					${this.localize('editor.linkToExistingGradeItem')}
-				</label>
-				<d2l-input-radio-spacer ?hidden="${this._createNewRadioChecked && this._hasGradeCandidates}" ?disabled="${!this._hasGradeCandidates}">
-					${this._hasGradeCandidates ? html`<d2l-activity-grade-candidate-selector
-						.href="${this.href}"
-						.token="${this.token}">
-					</d2l-activity-grade-candidate-selector>` : html`<div class="d2l-body-small">
-						${this.localize('editor.noGradeItems')}
-					</div>`}
-				</d2l-input-radio-spacer>
-				<d2l-button slot="footer" primary dialog-action="done">${this.localize('editor.ok')}</d2l-button>
-				<d2l-button slot="footer" dialog-action="cancel">${this.localize('editor.cancel')}</d2l-button>
-			</d2l-dialog>
-		`;
-	}
 }
 customElements.define('d2l-activity-grades-dialog', ActivityGradesDialog);

--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grade-candidate-selector.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grade-candidate-selector.js
@@ -32,37 +32,6 @@ class ActivityGradeCandidateSelector extends ActivityEditorMixin(LocalizeActivit
 		super(store);
 	}
 
-	_renderGradeCandidateTemplates(gradeCandidates, selected) {
-		return gradeCandidates.map(gc => {
-			if (gc.isCategory) {
-				return this._renderGradeCategory(gc, selected);
-			} else {
-				return this._renderGradeCandidate(gc, selected);
-			}
-		});
-	}
-
-	_renderGradeCandidate(gc, selected) {
-		return html`<option value="${gc.href}" .selected="${selected && gc.href === selected.href}">${gc.name}</option>`;
-	}
-
-	_renderGradeCategory(gradeCategory, selected) {
-		return html`
-			<optgroup label="${gradeCategory.name}">
-				${gradeCategory.gradeCandidates.map(gc => this._renderGradeCandidate(gc, selected))}
-			</optgroup>
-		`;
-	}
-
-	_setSelected(event) {
-		if (event && event.target && event.target.value) {
-			const activity = store.get(this.href);
-			if (activity && activity.scoreAndGrade.gradeCandidateCollection) {
-				activity.scoreAndGrade.gradeCandidateCollection.setSelected(event.target.value);
-			}
-		}
-	}
-
 	render() {
 		const activity = store.get(this.href);
 
@@ -94,6 +63,36 @@ class ActivityGradeCandidateSelector extends ActivityEditorMixin(LocalizeActivit
 			</div>
 		`;
 	}
+	_renderGradeCandidate(gc, selected) {
+		return html`<option value="${gc.href}" .selected="${selected && gc.href === selected.href}">${gc.name}</option>`;
+	}
+	_renderGradeCandidateTemplates(gradeCandidates, selected) {
+		return gradeCandidates.map(gc => {
+			if (gc.isCategory) {
+				return this._renderGradeCategory(gc, selected);
+			} else {
+				return this._renderGradeCandidate(gc, selected);
+			}
+		});
+	}
+
+	_renderGradeCategory(gradeCategory, selected) {
+		return html`
+			<optgroup label="${gradeCategory.name}">
+				${gradeCategory.gradeCandidates.map(gc => this._renderGradeCandidate(gc, selected))}
+			</optgroup>
+		`;
+	}
+
+	_setSelected(event) {
+		if (event && event.target && event.target.value) {
+			const activity = store.get(this.href);
+			if (activity && activity.scoreAndGrade.gradeCandidateCollection) {
+				activity.scoreAndGrade.gradeCandidateCollection.setSelected(event.target.value);
+			}
+		}
+	}
+
 }
 
 customElements.define('d2l-activity-grade-candidate-selector', ActivityGradeCandidateSelector);

--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grade-category-selector.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grade-category-selector.js
@@ -39,14 +39,6 @@ class ActivityGradeCategorySelector extends ActivityEditorMixin(LocalizeActivity
 		super(store);
 	}
 
-	_setSelected(e) {
-		if (e.target && e.target.value) {
-			this.newGradeCandidatesCollection.setSelected(e.target.value);
-		} else {
-			this.newGradeCandidatesCollection.setSelected();
-		}
-	}
-
 	render() {
 		const activity = store.get(this.href);
 
@@ -78,6 +70,14 @@ class ActivityGradeCategorySelector extends ActivityEditorMixin(LocalizeActivity
 			</div>
 		`;
 	}
+	_setSelected(e) {
+		if (e.target && e.target.value) {
+			this.newGradeCandidatesCollection.setSelected(e.target.value);
+		} else {
+			this.newGradeCandidatesCollection.setSelected();
+		}
+	}
+
 }
 
 customElements.define('d2l-activity-grade-category-selector', ActivityGradeCategorySelector);

--- a/components/d2l-activity-editor/d2l-activity-grades/state/grade-candidate-collection.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/state/grade-candidate-collection.js
@@ -30,10 +30,17 @@ export class GradeCandidateCollection {
 		return gradeCandidate;
 	}
 
+	hasNewGradeCandidateWithCategory() {
+		if (!this.gradeCandidates) {
+			return false;
+		}
+
+		return this.gradeCandidates.some(gc => gc.isNewGradeCandidateWithCategory());
+	}
 	async load(entity) {
 		this._entity = entity;
 		const gradeCandidatePromises = entity.getGradeCandidates().map(gc => {
-			const gradeCandidateEntity = new GradeCandidateEntity(gc, this.token, { remove: () => { }});
+			const gradeCandidateEntity = new GradeCandidateEntity(gc, this.token, { remove: () => { } });
 			return this.fetchGradeCandidate(gradeCandidateEntity);
 		});
 
@@ -47,29 +54,6 @@ export class GradeCandidateCollection {
 
 	setSelected(href) {
 		this.selected = this._findGradeCandidate(href, this.gradeCandidates);
-	}
-
-	hasNewGradeCandidateWithCategory() {
-		if (!this.gradeCandidates) {
-			return false;
-		}
-
-		return this.gradeCandidates.some(gc => gc.isNewGradeCandidateWithCategory());
-	}
-
-	_findGradeCandidate(href, gradeCandidates) {
-		if (!gradeCandidates) {
-			return;
-		}
-		for (const gc of gradeCandidates) {
-			if (href === gc.href || (!gc.href && href === 'undefined')) {
-				return gc;
-			}
-			const findGradeCandidate = this._findGradeCandidate(href, gc.gradeCandidates);
-			if (findGradeCandidate) {
-				return findGradeCandidate;
-			}
-		}
 	}
 
 	_findCurrentAssociation(gradeCandidates) {
@@ -86,7 +70,6 @@ export class GradeCandidateCollection {
 			}
 		}
 	}
-
 	_findFirstGradeItemFromCandidates(gradeCandidates) {
 		if (!gradeCandidates) {
 			return;
@@ -98,6 +81,21 @@ export class GradeCandidateCollection {
 			return this._findFirstGradeItemFromCandidates(gc.gradeCandidates);
 		}
 	}
+	_findGradeCandidate(href, gradeCandidates) {
+		if (!gradeCandidates) {
+			return;
+		}
+		for (const gc of gradeCandidates) {
+			if (href === gc.href || (!gc.href && href === 'undefined')) {
+				return gc;
+			}
+			const findGradeCandidate = this._findGradeCandidate(href, gc.gradeCandidates);
+			if (findGradeCandidate) {
+				return findGradeCandidate;
+			}
+		}
+	}
+
 }
 
 decorate(GradeCandidateCollection, {

--- a/components/d2l-activity-editor/d2l-activity-grades/state/grade-candidate.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/state/grade-candidate.js
@@ -41,6 +41,9 @@ export class GradeCandidate {
 		return gradeCandidate;
 	}
 
+	isNewGradeCandidateWithCategory() {
+		return this.isNewGradeCandidate && this.href;
+	}
 	async load(entity) {
 		this.href = this.gradeCandidateEntity.href();
 		this.isNewGradeCandidate = this.gradeCandidateEntity.isNewGradeCandidate();
@@ -54,15 +57,12 @@ export class GradeCandidate {
 			this.maxPoints = entity.maxPoints();
 		}
 		const gradeCandidatePromises = this.gradeCandidateEntity.getGradeCandidates().map(gc => {
-			const gradeCandidateEntity = new GradeCandidateEntity(gc, this.token, { remove: () => { }});
+			const gradeCandidateEntity = new GradeCandidateEntity(gc, this.token, { remove: () => { } });
 			return this.fetchGradeCandidate(gradeCandidateEntity);
 		});
 		this.gradeCandidates = await Promise.all(gradeCandidatePromises);
 	}
 
-	isNewGradeCandidateWithCategory() {
-		return this.isNewGradeCandidate && this.href;
-	}
 }
 
 decorate(GradeCandidate, {

--- a/components/d2l-activity-editor/d2l-activity-html-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-editor.js
@@ -60,17 +60,6 @@ class ActivityHtmlEditor extends LocalizeActivityEditorMixin(LitElement) {
 		this._htmlEditorUniqueId = `htmleditor-${getUniqueId()}`;
 	}
 
-	_onContentChange() {
-		const content = this.shadowRoot.querySelector('d2l-html-editor').getContent();
-		this.dispatchEvent(new CustomEvent('d2l-activity-html-editor-change', {
-			bubbles: true,
-			composed: true,
-			detail: {
-				content: content
-			}
-		}));
-	}
-
 	render() {
 		return html`
 			<d2l-html-editor
@@ -98,7 +87,6 @@ class ActivityHtmlEditor extends LocalizeActivityEditorMixin(LitElement) {
 				</div>
 			</d2l-html-editor>`;
 	}
-
 	updated(changedProperties) {
 		super.updated(changedProperties);
 		// This is acknowledged to be non-idiomatic (manipulating DOM outside render), but this
@@ -117,6 +105,17 @@ class ActivityHtmlEditor extends LocalizeActivityEditorMixin(LitElement) {
 			}
 		}
 	}
+	_onContentChange() {
+		const content = this.shadowRoot.querySelector('d2l-html-editor').getContent();
+		this.dispatchEvent(new CustomEvent('d2l-activity-html-editor-change', {
+			bubbles: true,
+			composed: true,
+			detail: {
+				content: content
+			}
+		}));
+	}
+
 }
 
 customElements.define('d2l-activity-html-editor', ActivityHtmlEditor);

--- a/components/d2l-activity-editor/d2l-activity-outcomes.js
+++ b/components/d2l-activity-editor/d2l-activity-outcomes.js
@@ -48,69 +48,6 @@ class ActivityOutcomes extends ActivityEditorFeaturesMixin(ActivityEditorMixin(R
 		this._outcomesTerm = this._dispatchRequestProvider('d2l-provider-outcomes-term');
 	}
 
-	_dispatchRequestProvider(key) {
-		const event = new CustomEvent('d2l-request-provider', {
-			detail: { key: key },
-			bubbles: true,
-			composed: true,
-			cancelable: true
-		});
-		this.dispatchEvent(event);
-		return event.detail.provider;
-	}
-
-	_onDialogAdd() {
-		this._closeDialog();
-
-		// react to outcomes being added/removed via selector dialog
-	}
-
-	_onDialogCancel() {
-		this._closeDialog();
-
-		// react to outcomes selector dialog being closed via cancel
-	}
-
-	_onOutcomeTagDeleted() {
-		// react to an outcomes tag being deleted
-	}
-
-	_openDialog() {
-		this._opened = true;
-	}
-
-	_closeDialog() {
-		this._opened = false;
-	}
-
-	_renderDialogOpener() {
-		return html`<d2l-button-subtle
-			text="${this._outcomesTerm}"
-			@click="${this._openDialog}"
-			h-align="text">
-		</d2l-button-subtle>`;
-	}
-
-	_renderTags() {
-		return html`<label class="d2l-label-text" ?hidden="${!this._hasAlignments}">${this._outcomesTerm}</label>
-			<d2l-activity-alignment-tags
-				href="${this.href}"
-				.token="${this.token}"
-				?deferred-save="${this.deferredSave}"
-				?hide-indirect-alignments="${this.hideIndirectAlignments}"
-				browse-outcomes-text="${this._browseOutcomesText}"
-				@d2l-activity-alignment-outcomes-updated="${this._onOutcomeTagDeleted}"
-				@d2l-activity-alignment-tags-update="${this._openDialog}"
-				@empty-changed="${this._alignmentTagsEmptyChanged}"
-				?read-only=${!this._hasAlignments}>
-			</d2l-activity-alignment-tags>`;
-	}
-
-	_alignmentTagsEmptyChanged(e) {
-		this._hasAlignments = !e.detail.value;
-		this.requestUpdate();
-	}
-
 	render() {
 		const activity = store.get(this.href);
 		if (!activity || !this._featureEnabled) {
@@ -146,5 +83,66 @@ class ActivityOutcomes extends ActivityEditorFeaturesMixin(ActivityEditorMixin(R
 			</d2l-dialog>` : null}
 		`;
 	}
+	_alignmentTagsEmptyChanged(e) {
+		this._hasAlignments = !e.detail.value;
+		this.requestUpdate();
+	}
+	_closeDialog() {
+		this._opened = false;
+	}
+	_dispatchRequestProvider(key) {
+		const event = new CustomEvent('d2l-request-provider', {
+			detail: { key: key },
+			bubbles: true,
+			composed: true,
+			cancelable: true
+		});
+		this.dispatchEvent(event);
+		return event.detail.provider;
+	}
+
+	_onDialogAdd() {
+		this._closeDialog();
+
+		// react to outcomes being added/removed via selector dialog
+	}
+
+	_onDialogCancel() {
+		this._closeDialog();
+
+		// react to outcomes selector dialog being closed via cancel
+	}
+
+	_onOutcomeTagDeleted() {
+		// react to an outcomes tag being deleted
+	}
+
+	_openDialog() {
+		this._opened = true;
+	}
+
+	_renderDialogOpener() {
+		return html`<d2l-button-subtle
+			text="${this._outcomesTerm}"
+			@click="${this._openDialog}"
+			h-align="text">
+		</d2l-button-subtle>`;
+	}
+
+	_renderTags() {
+		return html`<label class="d2l-label-text" ?hidden="${!this._hasAlignments}">${this._outcomesTerm}</label>
+			<d2l-activity-alignment-tags
+				href="${this.href}"
+				.token="${this.token}"
+				?deferred-save="${this.deferredSave}"
+				?hide-indirect-alignments="${this.hideIndirectAlignments}"
+				browse-outcomes-text="${this._browseOutcomesText}"
+				@d2l-activity-alignment-outcomes-updated="${this._onOutcomeTagDeleted}"
+				@d2l-activity-alignment-tags-update="${this._openDialog}"
+				@empty-changed="${this._alignmentTagsEmptyChanged}"
+				?read-only=${!this._hasAlignments}>
+			</d2l-activity-alignment-tags>`;
+	}
+
 }
 customElements.define('d2l-activity-outcomes', ActivityOutcomes);

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -159,10 +159,6 @@ class ActivityRubricsListContainer extends ActivityEditorFeaturesMixin(ActivityE
 			editNewAssociationOverlay.close();
 		}
 	}
-	_resizeDialog(e) {
-		e.currentTarget.resize();
-	}
-	
 	async _createNewAssociation() {
 
 		const entity = associationStore.get(this.href);
@@ -189,22 +185,9 @@ class ActivityRubricsListContainer extends ActivityEditorFeaturesMixin(ActivityE
 		}
 
 	}
-_toggleDialog(toggle) {
-
-		const dialog = this.shadowRoot.querySelector('#attach-rubric-dialog');
-		if (dialog) {
-			if (toggle) {
-				this.shadowRoot.querySelector('d2l-add-associations').reset();
-			}
-			dialog.opened = toggle;
-		}
-	}
-	
-	
 	_openAttachRubricDialog() {
 		this._toggleDialog(true);
 	}
-
 	_renderAddRubricDropdown(entity) {
 
 		const canCreatePotentialAssociation = entity.canCreatePotentialAssociation();
@@ -280,6 +263,10 @@ _toggleDialog(toggle) {
 			return html``;
 		}
 	}
+	_resizeDialog(e) {
+		e.currentTarget.resize();
+	}
+
 
 	_renderRubricsList(entity) {
 		const canCreatePotentialAssociation = entity.canCreatePotentialAssociation();
@@ -304,6 +291,18 @@ _toggleDialog(toggle) {
 			></d2l-activity-rubrics-list-editor>
 			`;
 	}
+_toggleDialog(toggle) {
+
+		const dialog = this.shadowRoot.querySelector('#attach-rubric-dialog');
+		if (dialog) {
+			if (toggle) {
+				this.shadowRoot.querySelector('d2l-add-associations').reset();
+			}
+			dialog.opened = toggle;
+		}
+	}
+
+	
 
 	_saveDefaultScoringRubricOnChange(event) {
 		const assignment = assignmentStore.getAssignment(this.assignmentHref);

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -263,11 +263,6 @@ class ActivityRubricsListContainer extends ActivityEditorFeaturesMixin(ActivityE
 			return html``;
 		}
 	}
-	_resizeDialog(e) {
-		e.currentTarget.resize();
-	}
-
-
 	_renderRubricsList(entity) {
 		const canCreatePotentialAssociation = entity.canCreatePotentialAssociation();
 		const canCreateAssociation = entity.canCreateAssociation();
@@ -291,18 +286,9 @@ class ActivityRubricsListContainer extends ActivityEditorFeaturesMixin(ActivityE
 			></d2l-activity-rubrics-list-editor>
 			`;
 	}
-_toggleDialog(toggle) {
-
-		const dialog = this.shadowRoot.querySelector('#attach-rubric-dialog');
-		if (dialog) {
-			if (toggle) {
-				this.shadowRoot.querySelector('d2l-add-associations').reset();
-			}
-			dialog.opened = toggle;
-		}
+	_resizeDialog(e) {
+		e.currentTarget.resize();
 	}
-
-	
 
 	_saveDefaultScoringRubricOnChange(event) {
 		const assignment = assignmentStore.getAssignment(this.assignmentHref);
@@ -312,6 +298,16 @@ _toggleDialog(toggle) {
 		}
 
 		assignment.setDefaultScoringRubric(event.target.value);
+	}
+	_toggleDialog(toggle) {
+
+		const dialog = this.shadowRoot.querySelector('#attach-rubric-dialog');
+		if (dialog) {
+			if (toggle) {
+				this.shadowRoot.querySelector('d2l-add-associations').reset();
+			}
+			dialog.opened = toggle;
+		}
 	}
 
 }

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
@@ -46,6 +46,28 @@ class ActivityRubricsListEditor extends ActivityEditorFeaturesMixin(ActivityEdit
 		super(store);
 	}
 
+	render() {
+
+		const entity = store.get(this.href);
+
+		if (!entity) {
+			return html``;
+		}
+
+		const associations = entity.fetchAssociations();
+		return html`${associations.map(this._renderAssociation, this)}`;
+	}
+	hasPendingChanges() {
+		const entity = store.get(this.href);
+		return entity && entity.dirty;
+	}
+	async save() {
+		const entity = store.get(this.href);
+		if (!entity) {
+			return;
+		}
+		await entity.save();
+	}
 	_deleteAssociation(e) {
 		const m3FeatureFlagEnabled = this._isMilestoneEnabled(Milestones.M3DefaultScoringRubric);
 
@@ -67,14 +89,6 @@ class ActivityRubricsListEditor extends ActivityEditorFeaturesMixin(ActivityEdit
 			entity.deleteAssociation_DoNotUse(e.target.dataset.id);
 			announce(this.localize('rubrics.txtRubricRemoved'));
 		}
-	}
-
-	async save() {
-		const entity = store.get(this.href);
-		if (!entity) {
-			return;
-		}
-		await entity.save();
 	}
 
 	_renderAssociation(association) {
@@ -104,23 +118,6 @@ class ActivityRubricsListEditor extends ActivityEditorFeaturesMixin(ActivityEdit
 		} else {
 			return html``;
 		}
-	}
-
-	render() {
-
-		const entity = store.get(this.href);
-
-		if (!entity) {
-			return html``;
-		}
-
-		const associations = entity.fetchAssociations();
-		return html`${associations.map(this._renderAssociation, this)}`;
-	}
-
-	hasPendingChanges() {
-		const entity = store.get(this.href);
-		return entity && entity.dirty;
 	}
 
 }

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -311,14 +311,12 @@ class ActivityScoreEditor extends ActivityEditorMixin(LocalizeActivityEditorMixi
 		const scoreAndGrade = store.get(this.href).scoreAndGrade;
 		scoreAndGrade.setGraded(scoreAndGrade.canEditGrades);
 	}
-_setNewGradeName(name) {
+	_setNewGradeName(name) {
 		const activity = store.get(this.href);
 		if (activity) {
 			activity.scoreAndGrade.setNewGradeName(name);
 		}
 	}
-
-	
 
 	_setUngraded() {
 		store.get(this.href).scoreAndGrade.setUngraded();

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -159,87 +159,6 @@ class ActivityScoreEditor extends ActivityEditorMixin(LocalizeActivityEditorMixi
 		super(store);
 	}
 
-	updated(changedProperties) {
-		super.updated(changedProperties);
-
-		if ((changedProperties.has('href') || changedProperties.has('token')) &&
-			this.href && this.token) {
-			this.store && this._fetch(() => {
-				const fetch = this.store.fetch(this.href, this.token);
-				fetch.then(() => {
-					this._setNewGradeName(this.activityName);
-				});
-			});
-		}
-
-		changedProperties.forEach((oldValue, propName) => {
-			if (propName === '_focusUngraded' && typeof oldValue !== 'undefined') {
-				const toFocus = this._focusUngraded ?
-					this.shadowRoot.querySelector('#ungraded') :
-					this.shadowRoot.querySelector('#score-out-of');
-				toFocus.focus();
-			} else if (propName === 'activityName') {
-				this._setNewGradeName(this.activityName);
-			}
-		});
-	}
-
-	_setNewGradeName(name) {
-		const activity = store.get(this.href);
-		if (activity) {
-			activity.scoreAndGrade.setNewGradeName(name);
-		}
-	}
-
-	_onScoreOutOfChanged() {
-		const scoreAndGrade = store.get(this.href).scoreAndGrade;
-		const scoreOutOf = this.shadowRoot.querySelector('#score-out-of').value;
-		if (scoreOutOf === scoreAndGrade.scoreOutOf) {
-			return;
-		}
-
-		scoreAndGrade.setScoreOutOf(scoreOutOf);
-	}
-
-	_addToGrades() {
-		store.get(this.href).scoreAndGrade.addToGrades();
-	}
-
-	_removeFromGrades() {
-		store.get(this.href).scoreAndGrade.removeFromGrades();
-	}
-
-	_setGraded() {
-		const scoreAndGrade = store.get(this.href).scoreAndGrade;
-		scoreAndGrade.setGraded(scoreAndGrade.canEditGrades);
-	}
-
-	_setUngraded() {
-		store.get(this.href).scoreAndGrade.setUngraded();
-	}
-
-	_addOrRemoveMenuItem() {
-		const scoreAndGrade = store.get(this.href).scoreAndGrade;
-		return scoreAndGrade.inGrades ? html`
-			<d2l-menu-item
-				text="${this.localize('editor.removeFromGrades')}"
-				@d2l-menu-item-select="${this._removeFromGrades}"
-			></d2l-menu-item>
-		` : scoreAndGrade.canEditGrades ? html`
-			<d2l-menu-item
-				text="${this.localize('editor.addToGrades')}"
-				@d2l-menu-item-select="${this._addToGrades}"
-			></d2l-menu-item>
-		` : null;
-	}
-
-	_chooseFromGrades() {
-		const activityGradesElement = this.shadowRoot.querySelector('d2l-activity-grades-dialog');
-		if (activityGradesElement) {
-			activityGradesElement.open();
-		}
-	}
-
 	render() {
 		const activity = store.get(this.href);
 		if (!activity) {
@@ -327,5 +246,83 @@ class ActivityScoreEditor extends ActivityEditorMixin(LocalizeActivityEditorMixi
 			</div>
 		`;
 	}
+	updated(changedProperties) {
+		super.updated(changedProperties);
+
+		if ((changedProperties.has('href') || changedProperties.has('token')) &&
+			this.href && this.token) {
+			this.store && this._fetch(() => {
+				const fetch = this.store.fetch(this.href, this.token);
+				fetch.then(() => {
+					this._setNewGradeName(this.activityName);
+				});
+			});
+		}
+
+		changedProperties.forEach((oldValue, propName) => {
+			if (propName === '_focusUngraded' && typeof oldValue !== 'undefined') {
+				const toFocus = this._focusUngraded ?
+					this.shadowRoot.querySelector('#ungraded') :
+					this.shadowRoot.querySelector('#score-out-of');
+				toFocus.focus();
+			} else if (propName === 'activityName') {
+				this._setNewGradeName(this.activityName);
+			}
+		});
+	}
+
+	_addOrRemoveMenuItem() {
+		const scoreAndGrade = store.get(this.href).scoreAndGrade;
+		return scoreAndGrade.inGrades ? html`
+			<d2l-menu-item
+				text="${this.localize('editor.removeFromGrades')}"
+				@d2l-menu-item-select="${this._removeFromGrades}"
+			></d2l-menu-item>
+		` : scoreAndGrade.canEditGrades ? html`
+			<d2l-menu-item
+				text="${this.localize('editor.addToGrades')}"
+				@d2l-menu-item-select="${this._addToGrades}"
+			></d2l-menu-item>
+		` : null;
+	}
+	_addToGrades() {
+		store.get(this.href).scoreAndGrade.addToGrades();
+	}
+	_chooseFromGrades() {
+		const activityGradesElement = this.shadowRoot.querySelector('d2l-activity-grades-dialog');
+		if (activityGradesElement) {
+			activityGradesElement.open();
+		}
+	}
+	_onScoreOutOfChanged() {
+		const scoreAndGrade = store.get(this.href).scoreAndGrade;
+		const scoreOutOf = this.shadowRoot.querySelector('#score-out-of').value;
+		if (scoreOutOf === scoreAndGrade.scoreOutOf) {
+			return;
+		}
+
+		scoreAndGrade.setScoreOutOf(scoreOutOf);
+	}
+
+	_removeFromGrades() {
+		store.get(this.href).scoreAndGrade.removeFromGrades();
+	}
+	_setGraded() {
+		const scoreAndGrade = store.get(this.href).scoreAndGrade;
+		scoreAndGrade.setGraded(scoreAndGrade.canEditGrades);
+	}
+_setNewGradeName(name) {
+		const activity = store.get(this.href);
+		if (activity) {
+			activity.scoreAndGrade.setNewGradeName(name);
+		}
+	}
+
+	
+
+	_setUngraded() {
+		store.get(this.href).scoreAndGrade.setUngraded();
+	}
+
 }
 customElements.define('d2l-activity-score-editor', ActivityScoreEditor);

--- a/components/d2l-activity-editor/d2l-activity-special-access-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-special-access-editor.js
@@ -50,6 +50,61 @@ class ActivitySpecialAccessEditor extends ActivityEditorMixin(RtlMixin(LocalizeA
 		this.description = '';
 	}
 
+	render() {
+		const entity = store.get(this.href);
+
+		if (!entity || !entity.specialAccess) {
+			return html``;
+		}
+
+		return html`
+			${this._renderDescription(entity.specialAccess)}
+			${this._renderManageButton(entity.specialAccess)}
+		`;
+	}
+	_openSpecialAccessDialog() {
+		const specialAccess = store.get(this.href).specialAccess;
+		const dialogUrl = specialAccess && specialAccess.url;
+
+		if (!dialogUrl) {
+			return;
+		}
+
+		const location = new D2L.LP.Web.Http.UrlLocation(dialogUrl);
+
+		const buttons = [
+			{
+				Key: 'save',
+				Text: this.localize('editor.btnSave'),
+				ResponseType: 1, // D2L.Dialog.ResponseType.Positive
+				IsPrimary: true,
+				IsEnabled: true
+			},
+			{
+				Text: this.localize('editor.btnCancel'),
+				ResponseType: 2, // D2L.Dialog.ResponseType.Negative
+				IsPrimary: false,
+				IsEnabled: true
+			}
+		];
+
+		// Launch into our "friend", the LMS, to do the thing.
+		const delayedResult = D2L.LP.Web.UI.Legacy.MasterPages.Dialog.OpenFullscreen(
+			/*             location: */ location,
+			/*          srcCallback: */ 'SrcCallback',
+			/*      responseDataKey: */ 'result',
+			/*              buttons: */ buttons,
+			/* forceTriggerOnCancel: */ false,
+			/*            titleText: */ ''
+		);
+
+		// "X" abort handler
+		// refetch special access in case the user count has changed
+		delayedResult.AddReleaseListener(() => specialAccess.fetch(true));
+
+		// Save or Cancel button handler
+		delayedResult.AddListener(() => specialAccess.fetch(true));
+	}
 	_renderDescription(specialAccess) {
 		const { isRestricted, userCount } = specialAccess;
 
@@ -97,62 +152,6 @@ class ActivitySpecialAccessEditor extends ActivityEditorMixin(RtlMixin(LocalizeA
 		`;
 	}
 
-	_openSpecialAccessDialog() {
-		const specialAccess = store.get(this.href).specialAccess;
-		const dialogUrl = specialAccess && specialAccess.url;
-
-		if (!dialogUrl) {
-			return;
-		}
-
-		const location = new D2L.LP.Web.Http.UrlLocation(dialogUrl);
-
-		const buttons = [
-			{
-				Key: 'save',
-				Text: this.localize('editor.btnSave'),
-				ResponseType: 1, // D2L.Dialog.ResponseType.Positive
-				IsPrimary: true,
-				IsEnabled: true
-			},
-			{
-				Text: this.localize('editor.btnCancel'),
-				ResponseType: 2, // D2L.Dialog.ResponseType.Negative
-				IsPrimary: false,
-				IsEnabled: true
-			}
-		];
-
-		// Launch into our "friend", the LMS, to do the thing.
-		const delayedResult = D2L.LP.Web.UI.Legacy.MasterPages.Dialog.OpenFullscreen(
-			/*             location: */ location,
-			/*          srcCallback: */ 'SrcCallback',
-			/*      responseDataKey: */ 'result',
-			/*              buttons: */ buttons,
-			/* forceTriggerOnCancel: */ false,
-			/*            titleText: */ ''
-		);
-
-		// "X" abort handler
-		// refetch special access in case the user count has changed
-		delayedResult.AddReleaseListener(() => specialAccess.fetch(true));
-
-		// Save or Cancel button handler
-		delayedResult.AddListener(() => specialAccess.fetch(true));
-	}
-
-	render() {
-		const entity = store.get(this.href);
-
-		if (!entity || !entity.specialAccess) {
-			return html``;
-		}
-
-		return html`
-			${this._renderDescription(entity.specialAccess)}
-			${this._renderManageButton(entity.specialAccess)}
-		`;
-	}
 }
 
 customElements.define(

--- a/components/d2l-activity-editor/d2l-activity-special-access-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-special-access-summary.js
@@ -10,6 +10,15 @@ class ActivitySpecialAccessSummary extends ActivityEditorMixin(LocalizeActivityE
 		super(store);
 	}
 
+	render() {
+
+		const entity = store.get(this.href);
+		if (!entity || !entity.specialAccess) {
+			return html``;
+		} else {
+			return html`${this._renderSummary(entity.specialAccess)}`;
+		}
+	}
 	_renderSummary(specialAccess) {
 		const { isRestricted, userCount } = specialAccess;
 
@@ -22,15 +31,6 @@ class ActivitySpecialAccessSummary extends ActivityEditorMixin(LocalizeActivityE
 		}
 	}
 
-	render() {
-
-		const entity = store.get(this.href);
-		if (!entity || !entity.specialAccess) {
-			return html``;
-		} else {
-			return html`${this._renderSummary(entity.specialAccess)}`;
-		}
-	}
 }
 
 customElements.define(

--- a/components/d2l-activity-editor/d2l-activity-text-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-text-editor.js
@@ -13,26 +13,6 @@ class ActivityTextEditor extends LitElement {
 		};
 	}
 
-	_onPlaintextChange() {
-		const content = this.shadowRoot.querySelector('d2l-input-textarea').value;
-		this._dispatchChangeEvent(content);
-	}
-
-	_onRichtextChange(e) {
-		const content = e.detail.content;
-		this._dispatchChangeEvent(content);
-	}
-
-	_dispatchChangeEvent(content) {
-		this.dispatchEvent(new CustomEvent('d2l-activity-text-editor-change', {
-			bubbles: true,
-			composed: true,
-			detail: {
-				content: content
-			}
-		}));
-	}
-
 	render() {
 		const event = new CustomEvent('d2l-request-provider', {
 			detail: { key: 'd2l-provider-html-editor-enabled' },
@@ -65,6 +45,24 @@ class ActivityTextEditor extends LitElement {
 				</d2l-input-textarea>
 			`;
 		}
+	}
+	_dispatchChangeEvent(content) {
+		this.dispatchEvent(new CustomEvent('d2l-activity-text-editor-change', {
+			bubbles: true,
+			composed: true,
+			detail: {
+				content: content
+			}
+		}));
+	}
+	_onPlaintextChange() {
+		const content = this.shadowRoot.querySelector('d2l-input-textarea').value;
+		this._dispatchChangeEvent(content);
+	}
+
+	_onRichtextChange(e) {
+		const content = e.detail.content;
+		this._dispatchChangeEvent(content);
 	}
 
 }

--- a/components/d2l-activity-editor/d2l-activity-visibility-auto-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-visibility-auto-editor.js
@@ -21,6 +21,17 @@ class ActivityVisibilityAutoEditor extends SaveStatusMixin(EntityMixinLit(LitEle
 		this.disabled = false;
 	}
 
+	render() {
+
+		return html`
+			<d2l-activity-visibility-editor-toggle
+				?disabled="${this.disabled}"
+				?is-draft="${this._isDraft}"
+				?can-edit-draft="${this._canEditDraft}"
+				@d2l-activity-visibility-editor-toggle-change="${this._updateVisibility}">
+			</d2l-activity-visibility-editor-toggle>
+		`;
+	}
 	set _entity(entity) {
 		if (this._entityHasChanged(entity)) {
 			this._onActivityUsageChange(entity);
@@ -40,16 +51,5 @@ class ActivityVisibilityAutoEditor extends SaveStatusMixin(EntityMixinLit(LitEle
 		this.wrapSaveAction(super._entity.setDraftStatus(!this._isDraft));
 	}
 
-	render() {
-
-		return html`
-			<d2l-activity-visibility-editor-toggle
-				?disabled="${this.disabled}"
-				?is-draft="${this._isDraft}"
-				?can-edit-draft="${this._canEditDraft}"
-				@d2l-activity-visibility-editor-toggle-change="${this._updateVisibility}">
-			</d2l-activity-visibility-editor-toggle>
-		`;
-	}
 }
 customElements.define('d2l-activity-visibility-auto-editor', ActivityVisibilityAutoEditor);

--- a/components/d2l-activity-editor/d2l-activity-visibility-editor-toggle.js
+++ b/components/d2l-activity-editor/d2l-activity-visibility-editor-toggle.js
@@ -34,16 +34,6 @@ class ActivityVisibilityEditorToggle extends LocalizeActivityEditorMixin(LitElem
 		this._textHidden = false;
 	}
 
-	_onChange() {
-		this.dispatchEvent(
-			new CustomEvent('d2l-activity-visibility-editor-toggle-change', { bubbles: true })
-		);
-	}
-
-	get switchEnabled() {
-		return this.canEditDraft && !this.disabled;
-	}
-
 	connectedCallback() {
 		super.connectedCallback();
 		this._narrowViewportQuery = matchMedia('only screen and (max-width: 615px)');
@@ -56,7 +46,6 @@ class ActivityVisibilityEditorToggle extends LocalizeActivityEditorMixin(LitElem
 			this._narrowViewportQuery.addListener((e) => this._textHidden = e.matches);
 		}
 	}
-
 	render() {
 		if (this.switchEnabled) {
 			return html`
@@ -70,7 +59,7 @@ class ActivityVisibilityEditorToggle extends LocalizeActivityEditorMixin(LitElem
 			return html`
 				<div class="d2l-label-text">
 					<d2l-icon icon="${this.isDraft ? 'tier1:visibility-hide' : 'tier1:visibility-show'}"></d2l-icon>
-					<span class="${classMap({'d2l-offscreen': this._textHidden})}">
+					<span class="${classMap({ 'd2l-offscreen': this._textHidden })}">
 						${this.isDraft ? this.localize('editor.hidden') : this.localize('editor.visible')}
 					</span>
 				</div>
@@ -78,5 +67,14 @@ class ActivityVisibilityEditorToggle extends LocalizeActivityEditorMixin(LitElem
 		}
 
 	}
+	get switchEnabled() {
+		return this.canEditDraft && !this.disabled;
+	}
+	_onChange() {
+		this.dispatchEvent(
+			new CustomEvent('d2l-activity-visibility-editor-toggle-change', { bubbles: true })
+		);
+	}
+
 }
 customElements.define('d2l-activity-visibility-editor-toggle', ActivityVisibilityEditorToggle);

--- a/components/d2l-activity-editor/d2l-activity-visibility-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-visibility-editor.js
@@ -17,13 +17,6 @@ class ActivityVisibilityEditor extends (ActivityEditorMixin(MobxLitElement)) {
 		this.disabled = false;
 	}
 
-	_updateVisibility() {
-		const activity = store.get(this.href);
-		if (activity) {
-			activity.setDraftStatus(!activity.isDraft);
-		}
-	}
-
 	render() {
 		const activity = store.get(this.href);
 
@@ -46,7 +39,6 @@ class ActivityVisibilityEditor extends (ActivityEditorMixin(MobxLitElement)) {
 			</d2l-activity-visibility-editor-toggle>
 		`;
 	}
-
 	updated(changedProperties) {
 		super.updated(changedProperties);
 
@@ -55,5 +47,12 @@ class ActivityVisibilityEditor extends (ActivityEditorMixin(MobxLitElement)) {
 			super._fetch(() => store.fetch(this.href, this.token, this.autoSave));
 		}
 	}
+	_updateVisibility() {
+		const activity = store.get(this.href);
+		if (activity) {
+			activity.setDraftStatus(!activity.isDraft);
+		}
+	}
+
 }
 customElements.define('d2l-activity-visibility-editor', ActivityVisibilityEditor);

--- a/components/d2l-activity-editor/error-handling-mixin.js
+++ b/components/d2l-activity-editor/error-handling-mixin.js
@@ -2,15 +2,14 @@ import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 
 export const ErrorHandlingMixin = superclass => class extends LocalizeMixin(superclass) {
 
+	clearError(errorProperty) {
+		this[errorProperty] = '';
+	}
 	async setError(errorProperty, langterm, tooltipId) {
 		this[errorProperty] = this.localize(langterm);
 
 		await this.updateComplete;
 		this._showTooltip(tooltipId);
-	}
-
-	clearError(errorProperty) {
-		this[errorProperty] = '';
 	}
 
 	_showTooltip(tooltipId) {

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
@@ -81,15 +81,13 @@ export const ActivityEditorContainerMixin = superclass => class extends Activity
 		}
 		return false;
 	}
+	_hasSkipAlertAncestor(node) {
+		return null !== findComposedAncestor(node, elm => elm && elm.hasAttribute && elm.hasAttribute('skip-alert'));
+	}
 	_registerEditor(e) {
 		this._editors.add(e.detail.editor);
 		e.detail.container = this;
 		e.stopPropagation();
-	}
-
-
-	_hasSkipAlertAncestor(node) {
-		return null !== findComposedAncestor(node, elm => elm && elm.hasAttribute && elm.hasAttribute('skip-alert'));
 	}
 
 	async _save() {

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
@@ -32,24 +32,6 @@ export const ActivityEditorContainerMixin = superclass => class extends Activity
 		this.isSaving = false;
 	}
 
-	_registerEditor(e) {
-		this._editors.add(e.detail.editor);
-		e.detail.container = this;
-		e.stopPropagation();
-	}
-
-	unregisterEditor(editor) {
-		this._editors.delete(editor);
-	}
-
-	get saveCompleteEvent() {
-		return new CustomEvent('d2l-activity-editor-save-complete', {
-			bubbles: true,
-			composed: true,
-			cancelable: true
-		});
-	}
-
 	get cancelCompleteEvent() {
 		return new CustomEvent('d2l-activity-editor-cancel-complete', {
 			bubbles: true,
@@ -57,11 +39,37 @@ export const ActivityEditorContainerMixin = superclass => class extends Activity
 			cancelable: true
 		});
 	}
-
-	_hasSkipAlertAncestor(node) {
-		return null !== findComposedAncestor(node, elm => elm && elm.hasAttribute && elm.hasAttribute('skip-alert'));
+	async delete() {}
+	get saveCompleteEvent() {
+		return new CustomEvent('d2l-activity-editor-save-complete', {
+			bubbles: true,
+			composed: true,
+			cancelable: true
+		});
+	}
+	unregisterEditor(editor) {
+		this._editors.delete(editor);
 	}
 
+	async _cancel() {
+		const editorsPendingChanges = await Promise.all(
+			Array.from(this._editors).map(editor => editor.hasPendingChanges())
+		);
+
+		if (editorsPendingChanges.some(Boolean)) {
+			const dialog = this.shadowRoot.querySelector('d2l-dialog-confirm');
+			const action = await dialog.open();
+			if (action === 'cancel' || action === 'abort') {
+				return;
+			}
+		}
+
+		if (this.isNew) {
+			await this.delete();
+		}
+
+		this.dispatchEvent(this.cancelCompleteEvent);
+	}
 	_focusOnInvalid() {
 		const isAriaInvalid = node => node.getAttribute('aria-invalid') === 'true' && node.getClientRects().length > 0 && !this._hasSkipAlertAncestor(node);
 		for (const editor of this._editors) {
@@ -73,8 +81,16 @@ export const ActivityEditorContainerMixin = superclass => class extends Activity
 		}
 		return false;
 	}
+	_registerEditor(e) {
+		this._editors.add(e.detail.editor);
+		e.detail.container = this;
+		e.stopPropagation();
+	}
 
-	async delete() {}
+
+	_hasSkipAlertAncestor(node) {
+		return null !== findComposedAncestor(node, elm => elm && elm.hasAttribute && elm.hasAttribute('skip-alert'));
+	}
 
 	async _save() {
 		this.isSaving = true;
@@ -117,23 +133,4 @@ export const ActivityEditorContainerMixin = superclass => class extends Activity
 		this.logSaveEvent(this.href, this.type, this.telemetryId);
 	}
 
-	async _cancel() {
-		const editorsPendingChanges = await Promise.all(
-			Array.from(this._editors).map(editor => editor.hasPendingChanges())
-		);
-
-		if (editorsPendingChanges.some(Boolean)) {
-			const dialog = this.shadowRoot.querySelector('d2l-dialog-confirm');
-			const action = await dialog.open();
-			if (action === 'cancel' || action === 'abort') {
-				return;
-			}
-		}
-
-		if (this.isNew) {
-			await this.delete();
-		}
-
-		this.dispatchEvent(this.cancelCompleteEvent);
-	}
 };

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
@@ -41,13 +41,36 @@ export const ActivityEditorMixin = superclass => class extends superclass {
 		this.saveOrder = 1000;
 	}
 
-	async validate() {}
+	connectedCallback() {
+		if (super.connectedCallback) {
+			super.connectedCallback();
+		}
 
-	async save() {}
+		this._dispatchActivityEditorEvent();
+	}
+	disconnectedCallback() {
+		if (this._container) {
+			this._container.unregisterEditor(this);
+		}
 
+		if (super.disconnectedCallback) {
+			super.disconnectedCallback();
+		}
+	}
+	updated(changedProperties) {
+		super.updated(changedProperties);
+
+		if ((changedProperties.has('href') || changedProperties.has('token')) &&
+			this.href && this.token) {
+			this.store && this._fetch(() => this.store.fetch(this.href, this.token));
+		}
+	}
 	hasPendingChanges() {
 		return false;
 	}
+	async save() {}
+
+	async validate() {}
 
 	_dispatchActivityEditorEvent() {
 		const event = new CustomEvent('d2l-activity-editor-connected', {
@@ -73,30 +96,4 @@ export const ActivityEditorMixin = superclass => class extends superclass {
 		this.dispatchEvent(pendingEvent);
 	}
 
-	connectedCallback() {
-		if (super.connectedCallback) {
-			super.connectedCallback();
-		}
-
-		this._dispatchActivityEditorEvent();
-	}
-
-	disconnectedCallback() {
-		if (this._container) {
-			this._container.unregisterEditor(this);
-		}
-
-		if (super.disconnectedCallback) {
-			super.disconnectedCallback();
-		}
-	}
-
-	updated(changedProperties) {
-		super.updated(changedProperties);
-
-		if ((changedProperties.has('href') || changedProperties.has('token')) &&
-			this.href && this.token) {
-			this.store && this._fetch(() => this.store.fetch(this.href, this.token));
-		}
-	}
 };

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-telemetry-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-telemetry-mixin.js
@@ -27,6 +27,9 @@ export const ActivityEditorTelemetryMixin = superclass => class extends supercla
 		performance.mark(saveStartMarkName);
 	}
 
+	_getSaveStartMarkName(type) {
+		return `d2l-activity-${type}-editor.page.save.start`;
+	}
 	async _logUserEvent(href, action, type, telemetryId, performanceMeasureName) {
 		if (!href || !action || !type || !telemetryId || !performanceMeasureName) return;
 
@@ -43,7 +46,4 @@ export const ActivityEditorTelemetryMixin = superclass => class extends supercla
 		client.logUserEvent(event);
 	}
 
-	_getSaveStartMarkName(type) {
-		return `d2l-activity-${type}-editor.page.save.start`;
-	}
 };

--- a/components/d2l-activity-editor/state/activity-dates.js
+++ b/components/d2l-activity-editor/state/activity-dates.js
@@ -14,22 +14,16 @@ export class ActivityDates {
 		this.endDateErrorTerm = null;
 	}
 
+	setCanEditDates(value) {
+		this.canEditDates = value;
+	}
 	setDueDate(date) {
 		this.dueDate = date;
-	}
-
-	setStartDate(date) {
-		this.startDate = date;
 	}
 
 	setEndDate(date) {
 		this.endDate = date;
 	}
-
-	setCanEditDates(value) {
-		this.canEditDates = value;
-	}
-
 	setErrorLangTerms(errorType) {
 		if (errorType && errorType.includes('end-due-start-date-error')) {
 			this.dueDateErrorTerm = 'editor.dueBetweenStartEndDate';
@@ -77,6 +71,10 @@ export class ActivityDates {
 		this.startDateErrorTerm = null;
 		this.endDateErrorTerm = null;
 	}
+	setStartDate(date) {
+		this.startDate = date;
+	}
+
 }
 
 decorate(ActivityDates, {

--- a/components/d2l-activity-editor/state/activity-score-grade.js
+++ b/components/d2l-activity-editor/state/activity-score-grade.js
@@ -77,40 +77,38 @@ export class ActivityScoreGrade {
 		this.createNewGrade = true;
 		this.setGraded();
 	}
-removeFromGrades() {
-		this.inGrades = false;
-		if (this.scoreOutOfError === 'emptyScoreOutOfError') {
-			this.scoreOutOfError = null;
-		}
-	}
-	
-	setGraded() {
-		this.inGrades = true;
-		this.isUngraded = false;
-	}
-
 	async primeGradeSave() {
 		if (this.inGrades && this.createNewGrade) {
 			await this.fetchNewGradeCandidates();
 		}
 	}
-setScoreOutOf(value) {
+	removeFromGrades() {
+		this.inGrades = false;
+		if (this.scoreOutOfError === 'emptyScoreOutOfError') {
+			this.scoreOutOfError = null;
+		}
+	}
+
+	setGraded() {
+		this.inGrades = true;
+		this.isUngraded = false;
+	}
+
+	setNewGradeName(name) {
+		this.newGradeName = name;
+	}
+	setScoreOutOf(value) {
 		this.scoreOutOf = value;
 		this.scoreOutOfError = null;
 		this.validate();
 	}
-	
-	
+
 	setUngraded() {
 		this.inGrades = false;
 		this.isUngraded = true;
 		this.setScoreOutOf('');
 	}
-	
-	
-	setNewGradeName(name) {
-		this.newGradeName = name;
-	}
+
 	validate() {
 		// This validation was hardcoded in the original UI implementation.
 		// It might have been better to come up with a way to represent this in the Siren representation

--- a/components/d2l-activity-editor/state/activity-score-grade.js
+++ b/components/d2l-activity-editor/state/activity-score-grade.js
@@ -22,6 +22,9 @@ export class ActivityScoreGrade {
 		this.newGradeCandidatesCollection = null;
 	}
 
+	addToGrades() {
+		this.inGrades = true;
+	}
 	async fetchGradeCandidates() {
 		if (this.gradeCandidateCollection) {
 			return;
@@ -40,40 +43,74 @@ export class ActivityScoreGrade {
 		await this.newGradeCandidatesCollection.fetch();
 	}
 
-	setScoreOutOf(value) {
-		this.scoreOutOf = value;
-		this.scoreOutOfError = null;
-		this.validate();
-	}
-
-	setUngraded() {
-		this.inGrades = false;
-		this.isUngraded = true;
-		this.setScoreOutOf('');
-	}
-
-	setGraded() {
-		this.inGrades = true;
-		this.isUngraded = false;
-	}
-
-	removeFromGrades() {
-		this.inGrades = false;
-		if (this.scoreOutOfError === 'emptyScoreOutOfError') {
-			this.scoreOutOfError = null;
-		}
-	}
-
-	addToGrades() {
-		this.inGrades = true;
-	}
-
 	getAssociatedGradeEntity() {
 		if (this.gradeCandidateCollection && this.gradeCandidateCollection.selected) {
 			return this.gradeCandidateCollection.selected.gradeCandidateEntity;
 		}
 	}
+	getAssociateNewGradeAction() {
+		let newGradeCandidateEntity;
+		if (this.newGradeCandidatesCollection && this.newGradeCandidatesCollection.selected) {
+			newGradeCandidateEntity = this.newGradeCandidatesCollection.selected.gradeCandidateEntity;
+		}
 
+		if (!newGradeCandidateEntity) {
+			return;
+		}
+
+		return newGradeCandidateEntity.getSaveAction();
+	}
+	linkToExistingGrade() {
+		if (!this.gradeCandidateCollection) {
+			return;
+		}
+
+		this.createNewGrade = false;
+		this.setGraded();
+
+		const gradeCandidate = this.gradeCandidateCollection.selected;
+		if (gradeCandidate.maxPoints !== undefined) {
+			this.setScoreOutOf(gradeCandidate.maxPoints.toString());
+		}
+	}
+	linkToNewGrade() {
+		this.createNewGrade = true;
+		this.setGraded();
+	}
+removeFromGrades() {
+		this.inGrades = false;
+		if (this.scoreOutOfError === 'emptyScoreOutOfError') {
+			this.scoreOutOfError = null;
+		}
+	}
+	
+	setGraded() {
+		this.inGrades = true;
+		this.isUngraded = false;
+	}
+
+	async primeGradeSave() {
+		if (this.inGrades && this.createNewGrade) {
+			await this.fetchNewGradeCandidates();
+		}
+	}
+setScoreOutOf(value) {
+		this.scoreOutOf = value;
+		this.scoreOutOfError = null;
+		this.validate();
+	}
+	
+	
+	setUngraded() {
+		this.inGrades = false;
+		this.isUngraded = true;
+		this.setScoreOutOf('');
+	}
+	
+	
+	setNewGradeName(name) {
+		this.newGradeName = name;
+	}
 	validate() {
 		// This validation was hardcoded in the original UI implementation.
 		// It might have been better to come up with a way to represent this in the Siren representation
@@ -89,47 +126,6 @@ export class ActivityScoreGrade {
 		return !this.scoreOutOfError;
 	}
 
-	linkToExistingGrade() {
-		if (!this.gradeCandidateCollection) {
-			return;
-		}
-
-		this.createNewGrade = false;
-		this.setGraded();
-
-		const gradeCandidate = this.gradeCandidateCollection.selected;
-		if (gradeCandidate.maxPoints !== undefined) {
-			this.setScoreOutOf(gradeCandidate.maxPoints.toString());
-		}
-	}
-
-	linkToNewGrade() {
-		this.createNewGrade = true;
-		this.setGraded();
-	}
-
-	setNewGradeName(name) {
-		this.newGradeName = name;
-	}
-
-	getAssociateNewGradeAction() {
-		let newGradeCandidateEntity;
-		if (this.newGradeCandidatesCollection && this.newGradeCandidatesCollection.selected) {
-			newGradeCandidateEntity = this.newGradeCandidatesCollection.selected.gradeCandidateEntity;
-		}
-
-		if (!newGradeCandidateEntity) {
-			return;
-		}
-
-		return newGradeCandidateEntity.getSaveAction();
-	}
-
-	async primeGradeSave() {
-		if (this.inGrades && this.createNewGrade) {
-			await this.fetchNewGradeCandidates();
-		}
-	}
 }
 
 decorate(ActivityScoreGrade, {

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -85,6 +85,21 @@ export class ActivityUsage {
 	setCanEditDraft(value) {
 		this.canEditDraft = value;
 	}
+	setCanUpdateAlignments(value) {
+		this.canUpdateAlignments = value;
+	}
+	setDates(val) {
+		this.dates = val;
+	}
+	setDraftStatus(isDraft) {
+		this.isDraft = isDraft;
+	}
+	setErrorLangTerms(errorType) {
+		this.dates.setErrorLangTerms(errorType);
+	}
+	setIsError(value) {
+		this.isError = value;
+	}
 	async _loadCompetencyOutcomes(entity) {
 		/**
 		 * Legacy Competencies
@@ -109,51 +124,11 @@ export class ActivityUsage {
 			await this._loadOutcomes();
 		}
 	}
-	
-	setCanUpdateAlignments(value) {
-		this.canUpdateAlignments = value;
-	}
-	setDates(val) {
-		this.dates = val;
-	}
-async _loadOutcomes() {
-		const alignmentsEntity = await fetchEntity(this.alignmentsHref, this.token);
 
-		runInAction(() => {
-			const alignmentsCollection = new AlignmentsCollectionEntity(alignmentsEntity);
-			this.canUpdateAlignments = alignmentsCollection.canUpdateAlignments();
-		});
-	}
-
-
-	
-	async _loadSpecialAccess(entity) {
-		const specialAccessHref = entity.specialAccessHref();
-		let specialAccess = null;
-
-		if (specialAccessHref) {
-			specialAccess = new ActivitySpecialAccess(specialAccessHref, this.token);
-			await specialAccess.fetch();
-		}
-
-		runInAction(() => this.specialAccess = specialAccess);
-	}
-	
-	setDraftStatus(isDraft) {
-		this.isDraft = isDraft;
-	}
-
-	setErrorLangTerms(errorType) {
-		this.dates.setErrorLangTerms(errorType);
-	}
-	setIsError(value) {
-		this.isError = value;
-	}
 
 	setScoreAndGrade(val) {
 		this.scoreAndGrade = val;
 	}
-
 	async validate() {
 		if (!this._entity) {
 			return;
@@ -182,6 +157,27 @@ async _loadOutcomes() {
 		if (this.isError) {
 			throw new Error('Activity Usage validation failed');
 		}
+	}
+async _loadOutcomes() {
+		const alignmentsEntity = await fetchEntity(this.alignmentsHref, this.token);
+
+		runInAction(() => {
+			const alignmentsCollection = new AlignmentsCollectionEntity(alignmentsEntity);
+			this.canUpdateAlignments = alignmentsCollection.canUpdateAlignments();
+		});
+	}
+	
+	
+	async _loadSpecialAccess(entity) {
+		const specialAccessHref = entity.specialAccessHref();
+		let specialAccess = null;
+
+		if (specialAccessHref) {
+			specialAccess = new ActivitySpecialAccess(specialAccessHref, this.token);
+			await specialAccess.fetch();
+		}
+
+		runInAction(() => this.specialAccess = specialAccess);
 	}
 
 	async _alignmentsDirty() {

--- a/components/d2l-activity-editor/state/conditions.js
+++ b/components/d2l-activity-editor/state/conditions.js
@@ -106,7 +106,19 @@ export class Conditions {
 
 		return this._entity ? this._entity.createNewDialogUrl() : null;
 	}
-async fetch() {
+	get createNewNegativeButtonText() {
+
+		return this._entity ? this._entity.createNewNegativeButtonText() : null;
+	}
+	get createNewOpenButtonText() {
+
+		return this._entity ? this._entity.createNewOpenButtonText() : null;
+	}
+	get createNewPositiveButtonText() {
+
+		return this._entity ? this._entity.createNewPositiveButtonText() : null;
+	}
+	async fetch() {
 
 		const sirenEntity = await fetchEntity(this.href, this.token);
 		if (sirenEntity) {
@@ -116,22 +128,6 @@ async fetch() {
 		}
 
 		return this;
-	}
-	
-	
-
-	get createNewNegativeButtonText() {
-
-		return this._entity ? this._entity.createNewNegativeButtonText() : null;
-	}
-	get createNewOpenButtonText() {
-
-		return this._entity ? this._entity.createNewOpenButtonText() : null;
-	}
-
-	get createNewPositiveButtonText() {
-
-		return this._entity ? this._entity.createNewPositiveButtonText() : null;
 	}
 
 	load(entity) {

--- a/components/d2l-activity-editor/state/conditions.js
+++ b/components/d2l-activity-editor/state/conditions.js
@@ -21,7 +21,52 @@ export class Conditions {
 		this._conditionsToAdd = new Map(); // Id -> text
 	}
 
-	async fetch() {
+	add(dto) {
+
+		if (dto === undefined) {
+			return;
+		}
+
+		if (Array.isArray(dto)) {
+			dto.forEach(this.add, this);
+			return;
+		}
+
+		const isExistingCondition = this._conditions.has(dto.Id);
+		if (isExistingCondition) {
+			this._conditionsToRemove.delete(dto.Id);
+		} else if (dto.Id) {
+			this._conditionsToAdd.set(`${dto.Id}`, dto.Text);
+		} else {
+			this._conditionsToCreate.set(this._constructKey(dto), dto);
+		}
+	}
+	get attachExistingDialogTitle() {
+
+		return this._entity ? this._entity.attachExistingDialogTitle() : null;
+	}
+	get attachExistingDialogUrl() {
+
+		return this._entity ? this._entity.attachExistingDialogUrl() : null;
+	}
+	get attachExistingNegativeButtonText() {
+
+		return this._entity ? this._entity.attachExistingNegativeButtonText() : null;
+	}
+	get attachExistingOpenButtonText() {
+
+		return this._entity ? this._entity.attachExistingOpenButtonText() : null;
+	}
+	get canAttachExisting() {
+
+		return this._entity ? this._entity.canAttachExisting() : false;
+	}
+	
+	get attachExistingPositiveButtonText() {
+
+		return this._entity ? this._entity.attachExistingPositiveButtonText() : null;
+	}
+async fetch() {
 
 		const sirenEntity = await fetchEntity(this.href, this.token);
 		if (sirenEntity) {
@@ -33,66 +78,17 @@ export class Conditions {
 		return this;
 	}
 
-	get canAttachExisting() {
-
-		return this._entity ? this._entity.canAttachExisting() : false;
-	}
-
-	get attachExistingDialogUrl() {
-
-		return this._entity ? this._entity.attachExistingDialogUrl() : null;
-	}
-
-	get attachExistingOpenButtonText() {
-
-		return this._entity ? this._entity.attachExistingOpenButtonText() : null;
-	}
-
-	get attachExistingDialogTitle() {
-
-		return this._entity ? this._entity.attachExistingDialogTitle() : null;
-	}
-
-	get attachExistingPositiveButtonText() {
-
-		return this._entity ? this._entity.attachExistingPositiveButtonText() : null;
-	}
-
-	get attachExistingNegativeButtonText() {
-
-		return this._entity ? this._entity.attachExistingNegativeButtonText() : null;
-	}
+	
 
 	get canCreateNew() {
 
 		return this._entity ? this._entity.canCreateNew() : false;
 	}
 
-	get createNewDialogUrl() {
+	get canSave() {
 
-		return this._entity ? this._entity.createNewDialogUrl() : null;
+		return this._entity ? this._entity.canSave() : false;
 	}
-
-	get createNewOpenButtonText() {
-
-		return this._entity ? this._entity.createNewOpenButtonText() : null;
-	}
-
-	get createNewDialogTitle() {
-
-		return this._entity ? this._entity.createNewDialogTitle() : null;
-	}
-
-	get createNewPositiveButtonText() {
-
-		return this._entity ? this._entity.createNewPositiveButtonText() : null;
-	}
-
-	get createNewNegativeButtonText() {
-
-		return this._entity ? this._entity.createNewNegativeButtonText() : null;
-	}
-
 	get conditions() {
 
 		const results = [];
@@ -117,23 +113,27 @@ export class Conditions {
 
 		return results;
 	}
+	get createNewDialogTitle() {
 
-	get operators() {
+		return this._entity ? this._entity.createNewDialogTitle() : null;
+	}
+	get createNewDialogUrl() {
 
-		const results = [];
-
-		for (const { value, title } of this._operators) {
-
-			results.push({ value, title, selected: value === this._operator });
-		}
-
-		return results;
+		return this._entity ? this._entity.createNewDialogUrl() : null;
 	}
 
-	_getSelectedOperator(operators) {
+	get createNewNegativeButtonText() {
 
-		const item = operators.find(x => x.selected);
-		return item ? item.value : DefaultOperator;
+		return this._entity ? this._entity.createNewNegativeButtonText() : null;
+	}
+	get createNewOpenButtonText() {
+
+		return this._entity ? this._entity.createNewOpenButtonText() : null;
+	}
+
+	get createNewPositiveButtonText() {
+
+		return this._entity ? this._entity.createNewPositiveButtonText() : null;
 	}
 
 	load(entity) {
@@ -146,39 +146,16 @@ export class Conditions {
 		this._conditionsToRemove = new Set();
 		this._conditionsToAdd = new Map();
 	}
+	get operators() {
 
-	_constructKey(dto) {
+		const results = [];
 
-		return `${dto.ConditionTypeId},${dto.Id1},${dto.Id2},${dto.Id2},${dto.Percentage1},${dto.Percentage2},${dto.Int1}`;
-	}
+		for (const { value, title } of this._operators) {
 
-	setOperator(value) {
-
-		const item = this._operators.find(x => x.value === value);
-		if (item) {
-			this._operator = item.value;
-		}
-	}
-
-	add(dto) {
-
-		if (dto === undefined) {
-			return;
+			results.push({ value, title, selected: value === this._operator });
 		}
 
-		if (Array.isArray(dto)) {
-			dto.forEach(this.add, this);
-			return;
-		}
-
-		const isExistingCondition = this._conditions.has(dto.Id);
-		if (isExistingCondition) {
-			this._conditionsToRemove.delete(dto.Id);
-		} else if (dto.Id) {
-			this._conditionsToAdd.set(`${dto.Id}`, dto.Text);
-		} else {
-			this._conditionsToCreate.set(this._constructKey(dto), dto);
-		}
+		return results;
 	}
 
 	remove(key) {
@@ -195,46 +172,6 @@ export class Conditions {
 			this._conditionsToRemove.add(id);
 		}
 	}
-
-	get canSave() {
-
-		return this._entity ? this._entity.canSave() : false;
-	}
-
-	_formatNewCondition(dto) {
-
-		return {
-			ConditionType: dto.ConditionTypeId,
-			Id1: dto.Id1,
-			Id2: dto.Id2,
-			Percentage1: dto.Percentage1,
-			Percentage2: dto.Percentage2,
-			Int1: dto.Int1
-		};
-	}
-
-	get _shouldSave() {
-
-		if (this._conditionsToCreate.size > 0) {
-			return true;
-		}
-
-		if (this._conditionsToRemove.size > 0) {
-			return true;
-		}
-
-		if (this._conditionsToAdd.size > 0) {
-			return true;
-		}
-
-		const operator = this._getSelectedOperator(this._operators);
-		if (operator !== this._operator) {
-			return true;
-		}
-
-		return false;
-	}
-
 	async save() {
 
 		if (!this.canSave) {
@@ -261,6 +198,61 @@ export class Conditions {
 		});
 		await this.fetch();
 	}
+	setOperator(value) {
+
+		const item = this._operators.find(x => x.value === value);
+		if (item) {
+			this._operator = item.value;
+		}
+	}
+	_constructKey(dto) {
+
+		return `${dto.ConditionTypeId},${dto.Id1},${dto.Id2},${dto.Id2},${dto.Percentage1},${dto.Percentage2},${dto.Int1}`;
+	}
+	_formatNewCondition(dto) {
+
+		return {
+			ConditionType: dto.ConditionTypeId,
+			Id1: dto.Id1,
+			Id2: dto.Id2,
+			Percentage1: dto.Percentage1,
+			Percentage2: dto.Percentage2,
+			Int1: dto.Int1
+		};
+	}
+_getSelectedOperator(operators) {
+
+		const item = operators.find(x => x.selected);
+		return item ? item.value : DefaultOperator;
+	}
+
+
+
+
+	
+
+	get _shouldSave() {
+
+		if (this._conditionsToCreate.size > 0) {
+			return true;
+		}
+
+		if (this._conditionsToRemove.size > 0) {
+			return true;
+		}
+
+		if (this._conditionsToAdd.size > 0) {
+			return true;
+		}
+
+		const operator = this._getSelectedOperator(this._operators);
+		if (operator !== this._operator) {
+			return true;
+		}
+
+		return false;
+	}
+
 }
 
 decorate(Conditions, {

--- a/components/d2l-activity-editor/state/conditions.js
+++ b/components/d2l-activity-editor/state/conditions.js
@@ -57,34 +57,19 @@ export class Conditions {
 
 		return this._entity ? this._entity.attachExistingOpenButtonText() : null;
 	}
-	get canAttachExisting() {
-
-		return this._entity ? this._entity.canAttachExisting() : false;
-	}
-	
 	get attachExistingPositiveButtonText() {
 
 		return this._entity ? this._entity.attachExistingPositiveButtonText() : null;
 	}
-async fetch() {
+	get canAttachExisting() {
 
-		const sirenEntity = await fetchEntity(this.href, this.token);
-		if (sirenEntity) {
-
-			const entity = new LegacyConditions(sirenEntity, this.token);
-			this.load(entity);
-		}
-
-		return this;
+		return this._entity ? this._entity.canAttachExisting() : false;
 	}
-
-	
 
 	get canCreateNew() {
 
 		return this._entity ? this._entity.canCreateNew() : false;
 	}
-
 	get canSave() {
 
 		return this._entity ? this._entity.canSave() : false;
@@ -121,6 +106,19 @@ async fetch() {
 
 		return this._entity ? this._entity.createNewDialogUrl() : null;
 	}
+async fetch() {
+
+		const sirenEntity = await fetchEntity(this.href, this.token);
+		if (sirenEntity) {
+
+			const entity = new LegacyConditions(sirenEntity, this.token);
+			this.load(entity);
+		}
+
+		return this;
+	}
+	
+	
 
 	get createNewNegativeButtonText() {
 
@@ -220,16 +218,11 @@ async fetch() {
 			Int1: dto.Int1
 		};
 	}
-_getSelectedOperator(operators) {
+	_getSelectedOperator(operators) {
 
 		const item = operators.find(x => x.selected);
 		return item ? item.value : DefaultOperator;
 	}
-
-
-
-
-	
 
 	get _shouldSave() {
 

--- a/components/d2l-activity-editor/state/object-store.js
+++ b/components/d2l-activity-editor/state/object-store.js
@@ -7,6 +7,10 @@ export class ObjectStore {
 		this._objects = new Map();
 	}
 
+	clear() {
+		this._objects.clear();
+		this._fetches.clear();
+	}
 	async fetch(href, token) {
 		let promise = this._fetches.get(href);
 		if (!promise) {
@@ -39,10 +43,6 @@ export class ObjectStore {
 		this._fetches.delete(href);
 	}
 
-	clear() {
-		this._objects.clear();
-		this._fetches.clear();
-	}
 }
 
 decorate(ObjectStore, {

--- a/components/d2l-activity-evaluation-icon/ActivityEvaluationIconBaseLocalize.js
+++ b/components/d2l-activity-evaluation-icon/ActivityEvaluationIconBaseLocalize.js
@@ -1,20 +1,20 @@
-import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
-import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import 'd2l-localize-behavior/d2l-localize-behavior.js';
-import {LangAr} from './build/lang/ar.js';
-import {LangDe} from './build/lang/de.js';
-import {LangEn} from './build/lang/en.js';
-import {LangEs} from './build/lang/es.js';
-import {LangFi} from './build/lang/fi.js';
-import {LangFr} from './build/lang/fr.js';
-import {LangJa} from './build/lang/ja.js';
-import {LangKo} from './build/lang/ko.js';
-import {LangNl} from './build/lang/nl.js';
-import {LangPt} from './build/lang/pt.js';
-import {LangSv} from './build/lang/sv.js';
-import {LangTr} from './build/lang/tr.js';
-import {LangZhtw} from './build/lang/zh-tw.js';
-import {LangZh} from './build/lang/zh.js';
+import { LangAr } from './build/lang/ar.js';
+import { LangDe } from './build/lang/de.js';
+import { LangEn } from './build/lang/en.js';
+import { LangEs } from './build/lang/es.js';
+import { LangFi } from './build/lang/fi.js';
+import { LangFr } from './build/lang/fr.js';
+import { LangJa } from './build/lang/ja.js';
+import { LangKo } from './build/lang/ko.js';
+import { LangNl } from './build/lang/nl.js';
+import { LangPt } from './build/lang/pt.js';
+import { LangSv } from './build/lang/sv.js';
+import { LangTr } from './build/lang/tr.js';
+import { LangZhtw } from './build/lang/zh-tw.js';
+import { LangZh } from './build/lang/zh.js';
 
 const LangImpl = (prefix, langObj, superClass) => class extends superClass {
 	constructor() {

--- a/components/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon.js
+++ b/components/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon.js
@@ -1,7 +1,7 @@
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 import 'd2l-polymer-siren-behaviors/store/entity-behavior.js';
 import './d2l-activity-evaluation-icon-base.js';
-import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 
 /**
  * @customElement

--- a/components/d2l-activity-list-item/ActivityListItemLocalize.js
+++ b/components/d2l-activity-list-item/ActivityListItemLocalize.js
@@ -1,20 +1,20 @@
-import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
-import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import 'd2l-localize-behavior/d2l-localize-behavior.js';
-import {LangAr} from './build/lang/ar.js';
-import {LangDe} from './build/lang/de.js';
-import {LangEn} from './build/lang/en.js';
-import {LangEs} from './build/lang/es.js';
-import {LangFi} from './build/lang/fi.js';
-import {LangFr} from './build/lang/fr.js';
-import {LangJa} from './build/lang/ja.js';
-import {LangKo} from './build/lang/ko.js';
-import {LangNl} from './build/lang/nl.js';
-import {LangPt} from './build/lang/pt.js';
-import {LangSv} from './build/lang/sv.js';
-import {LangTr} from './build/lang/tr.js';
-import {LangZhtw} from './build/lang/zh-tw.js';
-import {LangZh} from './build/lang/zh.js';
+import { LangAr } from './build/lang/ar.js';
+import { LangDe } from './build/lang/de.js';
+import { LangEn } from './build/lang/en.js';
+import { LangEs } from './build/lang/es.js';
+import { LangFi } from './build/lang/fi.js';
+import { LangFr } from './build/lang/fr.js';
+import { LangJa } from './build/lang/ja.js';
+import { LangKo } from './build/lang/ko.js';
+import { LangNl } from './build/lang/nl.js';
+import { LangPt } from './build/lang/pt.js';
+import { LangSv } from './build/lang/sv.js';
+import { LangTr } from './build/lang/tr.js';
+import { LangZhtw } from './build/lang/zh-tw.js';
+import { LangZh } from './build/lang/zh.js';
 
 const LangImpl = (prefix, langObj, superClass) => class extends superClass {
 	constructor() {

--- a/components/d2l-activity-list-item/ActivityListItemResponsiveConstants.js
+++ b/components/d2l-activity-list-item/ActivityListItemResponsiveConstants.js
@@ -1,4 +1,4 @@
-import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 
 /* @polymerMixin */
 const ActivityListItemResponsiveConstantsImpl = (superClass) => class extends superClass {

--- a/components/d2l-activity-list-item/d2l-activity-list-item-enroll.js
+++ b/components/d2l-activity-list-item/d2l-activity-list-item-enroll.js
@@ -1,5 +1,5 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
-import {ActivityListItemLocalize} from './ActivityListItemLocalize.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { ActivityListItemLocalize } from './ActivityListItemLocalize.js';
 import 'd2l-typography/d2l-typography.js';
 import 'd2l-button/d2l-button.js';
 import SirenParse from 'siren-parser';

--- a/components/d2l-activity-list-item/d2l-activity-list-item.js
+++ b/components/d2l-activity-list-item/d2l-activity-list-item.js
@@ -1,13 +1,13 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
-import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';
-import {MutableData} from '@polymer/polymer/lib/mixins/mutable-data.js';
-import {beforeNextRender, afterNextRender} from '@polymer/polymer/lib/utils/render-status.js';
-import {IronResizableBehavior} from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+import { MutableData } from '@polymer/polymer/lib/mixins/mutable-data.js';
+import { beforeNextRender, afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
+import { IronResizableBehavior } from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';
 import 'fastdom/fastdom.min.js';
 import 'd2l-offscreen/d2l-offscreen-shared-styles.js';
 import 'd2l-icons/d2l-icon.js';
 import 'd2l-icons/tier1-icons.js';
-import {Rels} from 'd2l-hypermedia-constants';
+import { Rels } from 'd2l-hypermedia-constants';
 import 'd2l-fetch/d2l-fetch.js';
 import 'd2l-organizations/components/d2l-organization-image/d2l-organization-image.js';
 import 'd2l-organizations/components/d2l-organization-name/d2l-organization-name.js';
@@ -16,8 +16,8 @@ import 'd2l-polymer-behaviors/d2l-focusable-behavior.js';
 import 'd2l-button/d2l-button.js';
 import './d2l-activity-list-item-enroll.js';
 import SirenParse from 'siren-parser';
-import {ActivityListItemResponsiveConstants} from './ActivityListItemResponsiveConstants.js';
-import {ActivityListItemLocalize} from './ActivityListItemLocalize.js';
+import { ActivityListItemResponsiveConstants } from './ActivityListItemResponsiveConstants.js';
+import { ActivityListItemLocalize } from './ActivityListItemLocalize.js';
 import 'd2l-colors/d2l-colors.js';
 
 /**

--- a/components/d2l-activity-name/d2l-activity-name.js
+++ b/components/d2l-activity-name/d2l-activity-name.js
@@ -1,9 +1,9 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import 'd2l-icons/d2l-icon.js';
 import 'd2l-icons/tier1-icons.js';
 import 'd2l-polymer-siren-behaviors/store/entity-behavior.js';
-import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';
-import {Rels, Classes} from 'd2l-hypermedia-constants';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+import { Rels, Classes } from 'd2l-hypermedia-constants';
 
 /**
  * @customElement

--- a/components/d2l-quick-eval/QuickEvalLocalize.js
+++ b/components/d2l-quick-eval/QuickEvalLocalize.js
@@ -1,22 +1,22 @@
-import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
-import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import 'd2l-localize-behavior/d2l-localize-behavior.js';
-import {LangAr} from './build/lang/ar.js';
-import {LangDadk} from './build/lang/da-dk.js';
-import {LangDe} from './build/lang/de.js';
-import {LangEn} from './build/lang/en.js';
-import {LangEs} from './build/lang/es.js';
-import {LangFi} from './build/lang/fi.js';
-import {LangFr} from './build/lang/fr.js';
-import {LangFrfr} from './build/lang/fr-fr.js';
-import {LangJa} from './build/lang/ja.js';
-import {LangKo} from './build/lang/ko.js';
-import {LangNl} from './build/lang/nl.js';
-import {LangPt} from './build/lang/pt.js';
-import {LangSv} from './build/lang/sv.js';
-import {LangTr} from './build/lang/tr.js';
-import {LangZhtw} from './build/lang/zh-tw.js';
-import {LangZh} from './build/lang/zh.js';
+import { LangAr } from './build/lang/ar.js';
+import { LangDadk } from './build/lang/da-dk.js';
+import { LangDe } from './build/lang/de.js';
+import { LangEn } from './build/lang/en.js';
+import { LangEs } from './build/lang/es.js';
+import { LangFi } from './build/lang/fi.js';
+import { LangFr } from './build/lang/fr.js';
+import { LangFrfr } from './build/lang/fr-fr.js';
+import { LangJa } from './build/lang/ja.js';
+import { LangKo } from './build/lang/ko.js';
+import { LangNl } from './build/lang/nl.js';
+import { LangPt } from './build/lang/pt.js';
+import { LangSv } from './build/lang/sv.js';
+import { LangTr } from './build/lang/tr.js';
+import { LangZhtw } from './build/lang/zh-tw.js';
+import { LangZh } from './build/lang/zh.js';
 
 const LangImpl = (prefix, langObj, superClass) => class extends superClass {
 	constructor() {

--- a/components/d2l-quick-eval/QuickEvalLogging.js
+++ b/components/d2l-quick-eval/QuickEvalLogging.js
@@ -1,4 +1,4 @@
-import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
 
 /*
  * @polymer

--- a/components/d2l-quick-eval/activities-list/d2l-quick-eval-activities-list.js
+++ b/components/d2l-quick-eval/activities-list/d2l-quick-eval-activities-list.js
@@ -1,5 +1,5 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
-import {QuickEvalLocalize} from '../QuickEvalLocalize.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { QuickEvalLocalize } from '../QuickEvalLocalize.js';
 import '../activity-card/d2l-quick-eval-activity-card.js';
 import 'd2l-colors/d2l-colors.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-action-button-more.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-action-button-more.js
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
-import {LitQuickEvalLocalize} from '../LitQuickEvalLocalize.js';
+import { LitQuickEvalLocalize } from '../LitQuickEvalLocalize.js';
 import 'd2l-dropdown/d2l-dropdown.js';
 import 'd2l-dropdown/d2l-dropdown-menu.js';
 import 'd2l-menu/d2l-menu.js';

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-action-button.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-action-button.js
@@ -1,4 +1,4 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import 'd2l-icons/d2l-icon.js';
 import 'd2l-icons/tier3-icons.js';

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-items.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-items.js
@@ -1,4 +1,4 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import 'd2l-colors/d2l-colors.js';
 
 class D2LQuickEvalActivityCardItems extends PolymerElement {

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-new-submissions.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-new-submissions.js
@@ -1,5 +1,5 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
-import {QuickEvalLocalize} from '../QuickEvalLocalize.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { QuickEvalLocalize } from '../QuickEvalLocalize.js';
 import 'd2l-tooltip/d2l-tooltip.js';
 import 'd2l-polymer-behaviors/d2l-id.js';
 

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-subtitle.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-subtitle.js
@@ -1,6 +1,6 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
-import {formatDateTime} from '@brightspace-ui/intl/lib/dateTime.js';
-import {QuickEvalLocalize} from '../QuickEvalLocalize.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { formatDateTime } from '@brightspace-ui/intl/lib/dateTime.js';
+import { QuickEvalLocalize } from '../QuickEvalLocalize.js';
 import '../../d2l-subtitle/d2l-subtitle.js';
 
 class D2LQuickEvalActivityCardSubtitle extends QuickEvalLocalize(PolymerElement) {

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card.js
@@ -1,5 +1,5 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
-import {QuickEvalLocalize} from '../QuickEvalLocalize.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { QuickEvalLocalize } from '../QuickEvalLocalize.js';
 import '../../d2l-activity-name/d2l-activity-name.js';
 import 'd2l-colors/d2l-colors.js';
 import 'd2l-icons/d2l-icon.js';

--- a/components/d2l-quick-eval/behaviors/d2l-quick-eval-siren-helper-behavior.js
+++ b/components/d2l-quick-eval/behaviors/d2l-quick-eval-siren-helper-behavior.js
@@ -1,6 +1,6 @@
-import {Rels, Classes} from 'd2l-hypermedia-constants';
+import { Rels, Classes } from 'd2l-hypermedia-constants';
 import './d2l-siren-helper-behavior.js';
-import {DISMISS_TYPES} from '../dismiss/dismiss-types.js';
+import { DISMISS_TYPES } from '../dismiss/dismiss-types.js';
 
 window.D2L = window.D2L || {};
 window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};

--- a/components/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
+++ b/components/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
@@ -48,13 +48,13 @@ D2L.PolymerBehaviors.Siren.D2LSirenHelperBehaviorImpl = {
 
 		Object.keys(searchParams).forEach(function(key) {
 			if (!action.fields.filter(x => x.name === key)[0]) {
-				action.fields.push({name: key, value: searchParams[key], type: 'hidden'});
+				action.fields.push({ name: key, value: searchParams[key], type: 'hidden' });
 			}
 		});
 
 		if (customParams) {
 			Object.keys(customParams).forEach(function(paramName) {
-				action.fields.push({name: paramName, value: customParams[paramName], type: 'hidden'});
+				action.fields.push({ name: paramName, value: customParams[paramName], type: 'hidden' });
 			});
 		}
 

--- a/components/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -1,8 +1,8 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
-import {QuickEvalLocalize} from './QuickEvalLocalize.js';
-import {QuickEvalLogging} from './QuickEvalLogging.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { QuickEvalLocalize } from './QuickEvalLocalize.js';
+import { QuickEvalLogging } from './QuickEvalLogging.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
-import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import 'd2l-alert/d2l-alert.js';
 import 'd2l-alert/d2l-alert-toast.js';
 import 'd2l-common/components/d2l-hm-filter/d2l-hm-filter.js';
@@ -323,7 +323,7 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 			this.logAndDestroyPerformanceEvent('activities', 'qeViewLoadStart', 'activitiesLoadEnd');
 		} catch (e) {
 			this._handleLoadFailure();
-			this._logError(e, {developerMessage: 'activities-view: Unable to load activities from entity.'});
+			this._logError(e, { developerMessage: 'activities-view: Unable to load activities from entity.' });
 			throw e;
 		} finally {
 			this._loading = false;
@@ -361,7 +361,7 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 					dismissHref: dismissHref
 				};
 			} catch (e) {
-				this._logError(e, {developerMessage: `Error loading activity data for ${this._getHref(activity, 'self')}.`});
+				this._logError(e, { developerMessage: `Error loading activity data for ${this._getHref(activity, 'self')}.` });
 				return null;
 			}
 		}.bind(this)));
@@ -382,7 +382,7 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 	_groupByCourse(act) {
 		if (act) {
 			const grouped = act.reduce((acts, a) => {
-				acts[a.key] = acts[a.key] || { name: a.courseName, activities: []};
+				acts[a.key] = acts[a.key] || { name: a.courseName, activities: [] };
 				acts[a.key].activities.push(a);
 				return acts;
 			}, {});
@@ -480,7 +480,7 @@ class D2LQuickEvalActivities extends mixinBehaviors(
 				this.shadowRoot.querySelector('.d2l-quick-eval-activities-toast-dismiss-success').open = true;
 			}).catch((error) => {
 				this.shadowRoot.querySelector('.d2l-quick-eval-activities-toast-dismiss-critical').open = true;
-				this._logError(error, {developerMessage: `Error dismissing activity href ${evt.detail.dismissHref}`});
+				this._logError(error, { developerMessage: `Error dismissing activity href ${evt.detail.dismissHref}` });
 			});
 		});
 	}

--- a/components/d2l-quick-eval/d2l-quick-eval-no-criteria-results-image.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-no-criteria-results-image.js
@@ -1,4 +1,4 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 /**
  * @customElement

--- a/components/d2l-quick-eval/d2l-quick-eval-no-submissions-image.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-no-submissions-image.js
@@ -1,4 +1,4 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 /**
  * @customElement

--- a/components/d2l-quick-eval/d2l-quick-eval-no-submissions-text.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-no-submissions-text.js
@@ -1,6 +1,6 @@
-import {html, LitElement} from 'lit-element/lit-element.js';
-import {LitQuickEvalLocalize} from './LitQuickEvalLocalize.js';
-import {unsafeHTML} from 'lit-html/directives/unsafe-html.js';
+import { html, LitElement } from 'lit-element/lit-element.js';
+import { LitQuickEvalLocalize } from './LitQuickEvalLocalize.js';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { heading2Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import '@brightspace-ui/core/components/link/link.js';
 
@@ -35,7 +35,7 @@ class D2LQuickEvalNoSubmissionsText extends LitQuickEvalLocalize(LitElement) {
 	}
 	_computeCheckBackOftenText(courseLevel, multiCourseQuickEvalHref) {
 		if (courseLevel && multiCourseQuickEvalHref) {
-			return unsafeHTML(this.localize('checkBackOftenCourseLevel', {startTag: `<d2l-link href="${this.multiCourseQuickEvalHref}">`, endTag: '</d2l-link>'}));
+			return unsafeHTML(this.localize('checkBackOftenCourseLevel', { startTag: `<d2l-link href="${this.multiCourseQuickEvalHref}">`, endTag: '</d2l-link>' }));
 		}
 		return this.localize('checkBackOften');
 	}

--- a/components/d2l-quick-eval/d2l-quick-eval-search-results-summary-container.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-search-results-summary-container.js
@@ -1,5 +1,5 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
-import {QuickEvalLocalize} from './QuickEvalLocalize.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { QuickEvalLocalize } from './QuickEvalLocalize.js';
 import 'd2l-link/d2l-link.js';
 
 class D2LQuickEvalSearchResultsSummaryContainer extends QuickEvalLocalize(PolymerElement) {

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions-skeleton.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions-skeleton.js
@@ -1,4 +1,4 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 /**
  * @customElement

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions-table.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions-table.js
@@ -1,6 +1,6 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
-import {QuickEvalLocalize} from './QuickEvalLocalize.js';
-import {QuickEvalLogging} from './QuickEvalLogging.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { QuickEvalLocalize } from './QuickEvalLocalize.js';
+import { QuickEvalLogging } from './QuickEvalLogging.js';
 import 'd2l-alert/d2l-alert.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
 import 'd2l-table/d2l-table.js';

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -296,7 +296,7 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 			this.perfMark('submissionsLoadEnd');
 			this.logAndDestroyPerformanceEvent('submissions', 'qeViewLoadStart', 'submissionsLoadEnd');
 		} catch (e) {
-			this._logError(e, {developerMessage: 'Unable to load activities from entity.'});
+			this._logError(e, { developerMessage: 'Unable to load activities from entity.' });
 			this._handleFullLoadFailure();
 			return Promise.reject(e);
 		} finally {
@@ -340,7 +340,7 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 			}.bind(this))
 			.then(this._clearAlerts.bind(this))
 			.catch(function(e) {
-				this._logError(e, {developerMessage: 'Unable to load more.'});
+				this._logError(e, { developerMessage: 'Unable to load more.' });
 				this._loadingMore = false;
 				this._handleLoadMoreFailure();
 			}.bind(this));

--- a/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-view-toggle.js
@@ -1,5 +1,5 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
-import {QuickEvalLocalize} from './QuickEvalLocalize.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { QuickEvalLocalize } from './QuickEvalLocalize.js';
 import './view-toggle/d2l-quick-eval-view-toggle-button.js';
 import 'd2l-colors/d2l-colors.js';
 import 'd2l-fetch/d2l-fetch.js';

--- a/components/d2l-quick-eval/d2l-quick-eval.js
+++ b/components/d2l-quick-eval/d2l-quick-eval.js
@@ -1,5 +1,5 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
-import {QuickEvalLocalize} from './QuickEvalLocalize.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { QuickEvalLocalize } from './QuickEvalLocalize.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
 import './d2l-quick-eval-view-toggle.js';

--- a/components/d2l-quick-eval/dismiss/d2l-quick-eval-dismissed-activities-list.js
+++ b/components/d2l-quick-eval/dismiss/d2l-quick-eval-dismissed-activities-list.js
@@ -38,7 +38,7 @@ class D2LQuickEvalDismissedActivitiesList extends LitQuickEvalLocalize(LitElemen
 	_computeSubtitleText(act) {
 		const result = [act.course];
 		if (act.dismissedDate) {
-			result.push(this.localize('dismissedOn', {date: formatDateTime(new Date(act.dismissedDate))}));
+			result.push(this.localize('dismissedOn', { date: formatDateTime(new Date(act.dismissedDate)) }));
 		}
 		return result;
 	}

--- a/components/d2l-quick-eval/dismiss/d2l-quick-eval-dismissed-activities.js
+++ b/components/d2l-quick-eval/dismiss/d2l-quick-eval-dismissed-activities.js
@@ -1,9 +1,9 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
-import {QuickEvalLocalize} from '../QuickEvalLocalize.js';
-import {QuickEvalLogging} from '../QuickEvalLogging.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { QuickEvalLocalize } from '../QuickEvalLocalize.js';
+import { QuickEvalLogging } from '../QuickEvalLogging.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
 import 'd2l-alert/d2l-alert-toast.js';
-import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import './d2l-quick-eval-ellipsis-dismiss-dialog.js';
 import '../behaviors/d2l-quick-eval-siren-helper-behavior.js';
 import '../behaviors/d2l-quick-eval-refresh-behavior.js';
@@ -119,7 +119,7 @@ class D2LQuickEvalDismissedActivities extends mixinBehaviors(
 					unDismiss: dismiss.unDismissAction
 				};
 			} catch (e) {
-				this._logError(e, {developerMessage: `Error loading activity data for ${this._getHref(activity, 'self')}.`});
+				this._logError(e, { developerMessage: `Error loading activity data for ${this._getHref(activity, 'self')}.` });
 				return null;
 			}
 		}.bind(this)));

--- a/components/d2l-quick-eval/dismiss/d2l-quick-eval-ellipsis-dismiss-dialog.js
+++ b/components/d2l-quick-eval/dismiss/d2l-quick-eval-ellipsis-dismiss-dialog.js
@@ -12,7 +12,7 @@ class D2LQuickEvalEllipsisDialog extends LitQuickEvalLocalize(LitElement) {
 			opened: { type: Boolean },
 			dismissedActivities: { type: Array },
 			loading: { type: Boolean },
-			restoreDisabled: {type: Boolean}
+			restoreDisabled: { type: Boolean }
 		};
 	}
 

--- a/demo/d2l-quick-eval/d2l-quick-eval-submissions-table-empty.html
+++ b/demo/d2l-quick-eval/d2l-quick-eval-submissions-table-empty.html
@@ -18,10 +18,10 @@
 			import 'd2l-typography/d2l-typography.js';
 			import './update-direction.js';
 
-			import {formatPage } from './page-handler';
+			import { formatPage } from './page-handler';
 			import startMockServer from './interceptor';
 
-			const mappings = {'pages/0': formatPage(undefined, '', '')};
+			const mappings = { 'pages/0': formatPage(undefined, '', '') };
 			startMockServer(mappings, true);
 
 			// For IE11, we need to import the component after we've started the mock observer

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "chai-a11y-axe": "^1.2.2",
     "chai-as-promised": "^7.1.1",
     "eslint": "^5.1.0",
-    "eslint-config-brightspace": "^0.7.0",
+    "eslint-config-brightspace": "^0.10.0",
     "eslint-plugin-html": "^6.0.0",
     "eslint-plugin-lit": "^1.2.0",
     "eslint-plugin-sort-class-members": "^1.6.0",

--- a/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-activity-usage.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-activity-usage.spec.js
@@ -1,4 +1,4 @@
-import { AssignmentActivityUsage} from '../../../../components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-activity-usage.js';
+import { AssignmentActivityUsage } from '../../../../components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-activity-usage.js';
 import { AssignmentActivityUsageEntity } from 'siren-sdk/src/activities/assignments/AssignmentActivityUsageEntity.js';
 import { expect } from 'chai';
 import { fetchEntity } from '../../../../components/d2l-activity-editor/state/fetch-entity.js';

--- a/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
@@ -39,10 +39,10 @@ describe('Assignment ', function() {
 				getAvailableAnnotationTools: () => undefined,
 				activityUsageHref: () => 'http://activity/1',
 				submissionTypeOptions: () => [
-					{title: 'File submission', value: 0, completionTypes: null, selected: false},
-					{title: 'Text submission', value: 1, completionTypes: null, selected: false},
-					{title: 'On paper submission', value: 2, completionTypes: [1, 2], selected: true},
-					{title: 'Observed in person', value: 3, completionTypes: [3], selected: false}
+					{ title: 'File submission', value: 0, completionTypes: null, selected: false },
+					{ title: 'Text submission', value: 1, completionTypes: null, selected: false },
+					{ title: 'On paper submission', value: 2, completionTypes: [1, 2], selected: true },
+					{ title: 'Observed in person', value: 3, completionTypes: [3], selected: false }
 				],
 				allCompletionTypeOptions: () => [
 					{
@@ -72,8 +72,8 @@ describe('Assignment ', function() {
 				canEditDefaultScoringRubric: () => true,
 				getDefaultScoringRubric: () => '-1',
 				filesSubmissionLimit: () => 'unlimited',
-				submissionType: () => { return {title: 'On paper submission', value: 2}; },
-				completionType: () => { return {title: 'Manually by learners', value: 2}; },
+				submissionType: () => { return { title: 'On paper submission', value: 2 }; },
+				completionType: () => { return { title: 'Manually by learners', value: 2 }; },
 				completionTypeValue: () => { return '2'; },
 				isGroupAssignmentTypeDisabled: () => false,
 				isIndividualAssignmentType: () => true,
@@ -123,14 +123,14 @@ describe('Assignment ', function() {
 		expect(assignment.instructions).to.equal('These are your instructions');
 		expect(assignment.activityUsageHref).to.equal('http://activity/1');
 		expect(assignment.submissionAndCompletionProps.submissionTypeOptions).to.eql([
-			{title: 'File submission', value: 0, completionTypes: null, selected: false},
-			{title: 'Text submission', value: 1, completionTypes: null, selected: false},
-			{title: 'On paper submission', value: 2, completionTypes: [1, 2], selected: true},
-			{title: 'Observed in person', value: 3, completionTypes: [3], selected: false}
+			{ title: 'File submission', value: 0, completionTypes: null, selected: false },
+			{ title: 'Text submission', value: 1, completionTypes: null, selected: false },
+			{ title: 'On paper submission', value: 2, completionTypes: [1, 2], selected: true },
+			{ title: 'Observed in person', value: 3, completionTypes: [3], selected: false }
 		]);
 		expect(assignment.submissionAndCompletionProps.completionTypeOptions).to.eql([
-			{selected: false, title: 'Manually by learners', value: 1},
-			{selected: false, title: 'Automatically on evaluation', value: 2}
+			{ selected: false, title: 'Manually by learners', value: 1 },
+			{ selected: false, title: 'Automatically on evaluation', value: 2 }
 		]);
 		expect(assignment.submissionAndCompletionProps.canEditSubmissionType).to.equal(true);
 		expect(assignment.submissionAndCompletionProps.canEditCompletionType).to.equal(true);

--- a/test/d2l-activity-editor/d2l-activity-attachments/state/attachment-collection.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-attachments/state/attachment-collection.spec.js
@@ -218,25 +218,25 @@ describe('Attachment Collection', function() {
 	describe('detect change', () => {
 		it('when attachment deleted=true creating=true', () => {
 			const collection = new AttachmentCollection('http://collection/1', 'token', {});
-			const attachment = {deleted: true, creating: true};
+			const attachment = { deleted: true, creating: true };
 			const result = collection._hasChanged(attachment);
 			expect(false).equals(result);
 		});
 		it('when attachment deleted=false creating=false', () => {
 			const collection = new AttachmentCollection('http://collection/1', 'token', {});
-			const attachment = {deleted: false, creating: false};
+			const attachment = { deleted: false, creating: false };
 			const result = collection._hasChanged(attachment);
 			expect(false).equals(result);
 		});
 		it('when attachment deleted=true creating=false', () => {
 			const collection = new AttachmentCollection('http://collection/1', 'token', {});
-			const attachment = {deleted: true, creating: false};
+			const attachment = { deleted: true, creating: false };
 			const result = collection._hasChanged(attachment);
 			expect(true).equals(result);
 		});
 		it('when attachment deleted=false creating=true', () => {
 			const collection = new AttachmentCollection('http://collection/1', 'token', {});
-			const attachment = {deleted: false, creating: true};
+			const attachment = { deleted: false, creating: true };
 			const result = collection._hasChanged(attachment);
 			expect(true).equals(result);
 		});

--- a/test/d2l-activity-editor/d2l-activity-grades/state/grade-candidate-collection.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-grades/state/grade-candidate-collection.spec.js
@@ -24,8 +24,8 @@ describe('Grade Candidate Collection', function() {
 
 		const gradeCandidateCollectionEntityMock = {
 			getGradeCandidates: () => [
-				{'test': 1},
-				{'test': 2}
+				{ 'test': 1 },
+				{ 'test': 2 }
 			],
 			getAssociateNewGradeAction: () => {}
 		};
@@ -135,8 +135,8 @@ describe('New Grade Candidate Collection', function() {
 
 		const gradeCandidateCollectionEntityMock = {
 			getGradeCandidates: () => [
-				{'test': 1},
-				{'test': 2}
+				{ 'test': 1 },
+				{ 'test': 2 }
 			],
 			getAssociateNewGradeAction: () => {}
 		};

--- a/test/d2l-activity-editor/d2l-activity-grades/state/grade-candidate.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-grades/state/grade-candidate.spec.js
@@ -80,7 +80,7 @@ describe('Grade Candidate', function() {
 				isCurrentAssociation: () => false,
 				href: () => 'http://grade-candidate-href-category',
 				getGradeCandidates: () => [
-					{'testgrade' : 1}
+					{ 'testgrade' : 1 }
 				],
 				newGradeCandidatesHref: () => undefined,
 				isNewGradeCandidate: () => false

--- a/test/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
+++ b/test/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
@@ -1,5 +1,5 @@
 import { defineCE, expect, fixture, nextFrame } from '@open-wc/testing';
-import { ActivityEditorContainerMixin} from '../../../components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js';
+import { ActivityEditorContainerMixin } from '../../../components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js';
 
 const container = defineCE(
 	class extends ActivityEditorContainerMixin(HTMLElement) {
@@ -8,6 +8,9 @@ const container = defineCE(
 
 const editor = defineCE(
 	class extends HTMLElement {
+		hasPendingChanges() {
+			this.hasPendingChangesCalled = true;
+		}
 		save() {
 			this.saveCalled = true;
 		}
@@ -16,9 +19,6 @@ const editor = defineCE(
 			this.validateCalled = true;
 		}
 
-		hasPendingChanges() {
-			this.hasPendingChangesCalled = true;
-		}
 	}
 );
 

--- a/test/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
+++ b/test/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
@@ -1,6 +1,6 @@
 import { defineCE, expect, fixture, oneEvent } from '@open-wc/testing';
 import { ActivityEditorContainerMixin } from '../../../components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js';
-import { ActivityEditorMixin} from '../../../components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js';
+import { ActivityEditorMixin } from '../../../components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js';
 import { AsyncStateEvent } from '@brightspace-ui/core/helpers/asyncStateEvent.js';
 
 const container = defineCE(

--- a/test/d2l-activity-editor/state/activity-score-grade.spec.js
+++ b/test/d2l-activity-editor/state/activity-score-grade.spec.js
@@ -1,4 +1,4 @@
-import { ActivityScoreGrade} from '../../../components/d2l-activity-editor/state/activity-score-grade.js';
+import { ActivityScoreGrade } from '../../../components/d2l-activity-editor/state/activity-score-grade.js';
 import { expect } from 'chai';
 import { fetchEntity } from '../../../components/d2l-activity-editor/state/fetch-entity.js';
 import { GradeCandidate } from '../../../components/d2l-activity-editor/d2l-activity-grades/state/grade-candidate.js';

--- a/test/d2l-activity-editor/state/activity-special-access.spec.js
+++ b/test/d2l-activity-editor/state/activity-special-access.spec.js
@@ -1,4 +1,4 @@
-import { ActivitySpecialAccess} from '../../../components/d2l-activity-editor/state/activity-special-access.js';
+import { ActivitySpecialAccess } from '../../../components/d2l-activity-editor/state/activity-special-access.js';
 import { ActivitySpecialAccessEntity } from 'siren-sdk/src/activities/ActivitySpecialAccessEntity.js';
 import { expect } from 'chai';
 import { fetchEntity } from '../../../components/d2l-activity-editor/state/fetch-entity.js';

--- a/test/d2l-activity-editor/state/activity-usage.spec.js
+++ b/test/d2l-activity-editor/state/activity-usage.spec.js
@@ -1,5 +1,5 @@
 import { ActivitySpecialAccessEntity } from 'siren-sdk/src/activities/ActivitySpecialAccessEntity.js';
-import { ActivityUsage} from '../../../components/d2l-activity-editor/state/activity-usage.js';
+import { ActivityUsage } from '../../../components/d2l-activity-editor/state/activity-usage.js';
 import { ActivityUsageEntity } from 'siren-sdk/src/activities/ActivityUsageEntity.js';
 import { AlignmentsCollectionEntity } from 'siren-sdk/src/alignments/AlignmentsCollectionEntity.js';
 import { CompetenciesEntity } from 'siren-sdk/src/competencies/CompetenciesEntity.js';

--- a/test/d2l-activity-name/perceptual/d2l-activity-name.visual-diff.js
+++ b/test/d2l-activity-name/perceptual/d2l-activity-name.visual-diff.js
@@ -10,8 +10,8 @@ describe('d2l-activity-name', function() {
 	before(async() => {
 		browser = await puppeteer.launch();
 		page = await browser.newPage();
-		await page.setViewport({width: 800, height: 800, deviceScaleFactor: 2});
-		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-activity-name/perceptual/d2l-activity-name.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
+		await page.setViewport({ width: 800, height: 800, deviceScaleFactor: 2 });
+		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-activity-name/perceptual/d2l-activity-name.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
 		await page.bringToFront();
 	});
 

--- a/test/d2l-quick-eval/behaviors/d2l-hm-filter-behavior-test-component.js
+++ b/test/d2l-quick-eval/behaviors/d2l-hm-filter-behavior-test-component.js
@@ -1,6 +1,6 @@
 import '../../../components/d2l-quick-eval/behaviors/d2l-hm-filter-behavior.js';
-import {PolymerElement} from '@polymer/polymer/polymer-element.js';
-import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 
 class D2LHMFilterBehaviourTestComponent extends mixinBehaviors([D2L.PolymerBehaviors.QuickEval.D2LHMFilterBehaviour], PolymerElement) {
 	static get is() { return 'd2l-hm-filter-behavior-test-component'; }

--- a/test/d2l-quick-eval/behaviors/d2l-hm-search-behavior-test-component.js
+++ b/test/d2l-quick-eval/behaviors/d2l-hm-search-behavior-test-component.js
@@ -1,6 +1,6 @@
 import '../../../components/d2l-quick-eval/behaviors/d2l-hm-search-behavior.js';
-import {PolymerElement} from '@polymer/polymer/polymer-element.js';
-import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 
 class D2LHMSearchBehaviourTestComponent extends mixinBehaviors([D2L.PolymerBehaviors.QuickEval.D2LHMSearchBehaviour], PolymerElement) {
 	static get is() { return 'd2l-hm-search-behavior-test-component'; }

--- a/test/d2l-quick-eval/behaviors/d2l-hm-search-behavior.js
+++ b/test/d2l-quick-eval/behaviors/d2l-hm-search-behavior.js
@@ -97,7 +97,7 @@ import SirenParse from 'siren-parser';
 		});
 
 		test('d2l-hm-search-error sets searchError correctly', () => {
-			const errorDetail = {error: true};
+			const errorDetail = { error: true };
 			searchBehavior.dispatchEvent(
 				new CustomEvent(
 					'd2l-hm-search-error',

--- a/test/d2l-quick-eval/behaviors/d2l-quick-eval-siren-helper-behavior-test-component.js
+++ b/test/d2l-quick-eval/behaviors/d2l-quick-eval-siren-helper-behavior-test-component.js
@@ -1,6 +1,6 @@
 import '../../../components/d2l-quick-eval/behaviors/d2l-quick-eval-siren-helper-behavior.js';
-import {PolymerElement} from '@polymer/polymer/polymer-element.js';
-import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 
 class D2LQuickEvalSirenHelperBehaviorTestComponent extends mixinBehaviors([D2L.PolymerBehaviors.QuickEval.D2LQuickEvalSirenHelperBehavior], PolymerElement) {
 	static get is() { return 'd2l-quick-eval-siren-helper-behavior-test-component'; }

--- a/test/d2l-quick-eval/behaviors/d2l-quick-eval-telemetry-behavior-test-component.js
+++ b/test/d2l-quick-eval/behaviors/d2l-quick-eval-telemetry-behavior-test-component.js
@@ -1,6 +1,6 @@
 import '../../../components/d2l-quick-eval/behaviors/d2l-quick-eval-telemetry-behavior.js';
-import {PolymerElement} from '@polymer/polymer/polymer-element.js';
-import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 
 class D2LTelemetryBehaviourTestComponent extends mixinBehaviors([D2L.PolymerBehaviors.QuickEval.TelemetryBehaviorImpl], PolymerElement) {
 	static get is() { return 'd2l-quick-eval-telemetry-behavior-test-component'; }

--- a/test/d2l-quick-eval/behaviors/d2l-siren-helper-behavior-test-component.js
+++ b/test/d2l-quick-eval/behaviors/d2l-siren-helper-behavior-test-component.js
@@ -1,6 +1,6 @@
 import '../../../components/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js';
-import {PolymerElement} from '@polymer/polymer/polymer-element.js';
-import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 
 class D2LSirenHelperBehaviorTestComponent extends mixinBehaviors([D2L.PolymerBehaviors.Siren.D2LSirenHelperBehavior], PolymerElement) {
 	static get is() { return 'd2l-siren-helper-behavior-test-component'; }

--- a/test/d2l-quick-eval/compatability/ie11shims.js
+++ b/test/d2l-quick-eval/compatability/ie11shims.js
@@ -40,11 +40,11 @@ suite('GetQueryStringParams', () => {
 		{ queryString: '', expectedResult: {} },
 		{ queryString: '?x', expectedResult: {} },
 		{ queryString: '?x=', expectedResult: { x: '' } },
-		{ queryString: '?x=1&x=2', expectedResult: {x: '1'} },
-		{ queryString: '?x=1&y=2', expectedResult: {x: '1', y: '2'} },
-		{ queryString: '?x=1&&y=2', expectedResult: {x: '1', y: '2'} },
-		{ queryString: '?x=%3Fencoded%3Dstring%25%26here&y=2', expectedResult: {x: '?encoded=string%&here', y: '2'} },
-		{ queryString: '?%3F%3F=1', expectedResult: {'??': '1'} }
+		{ queryString: '?x=1&x=2', expectedResult: { x: '1' } },
+		{ queryString: '?x=1&y=2', expectedResult: { x: '1', y: '2' } },
+		{ queryString: '?x=1&&y=2', expectedResult: { x: '1', y: '2' } },
+		{ queryString: '?x=%3Fencoded%3Dstring%25%26here&y=2', expectedResult: { x: '?encoded=string%&here', y: '2' } },
+		{ queryString: '?%3F%3F=1', expectedResult: { '??': '1' } }
 	];
 
 	testCases.forEach(function(testCase) {
@@ -87,13 +87,13 @@ suite('GetQueryStringParam', () => {
 suite('DictToQueryString', () => {
 	const testCases = [
 		{ params: {}, expectedStringParams: [] },
-		{ params: {'x': null }, expectedStringParams: ['x=null'] },
-		{ params: {'x': undefined }, expectedStringParams: ['x=undefined'] },
-		{ params: {'x': 1 }, expectedStringParams: ['x=1'] },
-		{ params: {'x': 1, 'y': 2 }, expectedStringParams: ['x=1', 'y=2'] },
-		{ params: {'y': 2, 'x': 1 }, expectedStringParams: ['x=1', 'y=2'] },
-		{ params: {'x': '??' }, expectedStringParams: ['x=%3F%3F'] },
-		{ params: {'??': 1 }, expectedStringParams: ['%3F%3F=1'] },
+		{ params: { 'x': null }, expectedStringParams: ['x=null'] },
+		{ params: { 'x': undefined }, expectedStringParams: ['x=undefined'] },
+		{ params: { 'x': 1 }, expectedStringParams: ['x=1'] },
+		{ params: { 'x': 1, 'y': 2 }, expectedStringParams: ['x=1', 'y=2'] },
+		{ params: { 'y': 2, 'x': 1 }, expectedStringParams: ['x=1', 'y=2'] },
+		{ params: { 'x': '??' }, expectedStringParams: ['x=%3F%3F'] },
+		{ params: { '??': 1 }, expectedStringParams: ['%3F%3F=1'] },
 	];
 
 	testCases.forEach(function(testCase) {

--- a/test/d2l-quick-eval/d2l-quick-eval-dismissed-activities.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-dismissed-activities.js
@@ -86,7 +86,7 @@ suite('d2l-quick-eval-activities', function() {
 		test('_getSelectedActivities returns correct result', () => {
 			act._data = expectedData();
 			testCase.toggles.forEach(tc => {
-				act._handleListItemSelected({detail:{key: tc, selected: !(act._data[tc].selected)}});
+				act._handleListItemSelected({ detail:{ key: tc, selected: !(act._data[tc].selected) } });
 			});
 			const selected = act._getSelectedActivities();
 			assert.equal(selected.length, testCase.expected.length);

--- a/test/d2l-quick-eval/d2l-quick-eval-logging.html
+++ b/test/d2l-quick-eval/d2l-quick-eval-logging.html
@@ -76,7 +76,7 @@
 
 					assert.equal(testErrorMessage, message.errorMessage);
 					assert.isTrue(message.stackTrace !== null && message.stackTrace !== undefined);
-					assert.deepEqual({moreInfo: expectedInfo}, message.additionalContext);
+					assert.deepEqual({ moreInfo: expectedInfo }, message.additionalContext);
 
 					done();
 				});
@@ -102,7 +102,7 @@
 					assert.isTrue(Array.isArray(messageBody));
 
 					const message = messageBody[0];
-					assert.deepEqual({errorMessage: throwingMessage, additionalContext: {}}, message);
+					assert.deepEqual({ errorMessage: throwingMessage, additionalContext: {} }, message);
 
 					done();
 				});

--- a/test/d2l-quick-eval/d2l-quick-eval-submissions-table-sorting.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-submissions-table-sorting.js
@@ -1,4 +1,4 @@
-import {Rels} from 'd2l-hypermedia-constants';
+import { Rels } from 'd2l-hypermedia-constants';
 import SirenParse from 'siren-parser';
 
 function resetSortHeaders(list) {
@@ -103,7 +103,7 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 		});
 
 		test('_handleSorts determines which headers are sortable', () => {
-			const enabledSortClasses = [{ className:'activity-name' }, {className: 'course-name' }];
+			const enabledSortClasses = [{ className:'activity-name' }, { className: 'course-name' }];
 			const entity = {};
 
 			stubLoadSorts(list, entity, enabledSortClasses);

--- a/test/d2l-quick-eval/d2l-quick-eval-submissions-table.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-submissions-table.js
@@ -379,12 +379,12 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 		});
 		suite('_getWidthCssClass and _defaultColumnWidth', () => {
 			[
-				{ input: 15, output: 'd2l-quick-eval-15-column'},
-				{ input: 20, output: 'd2l-quick-eval-20-column'},
-				{ input: 25, output: 'd2l-quick-eval-25-column'},
-				{ input: 30, output: 'd2l-quick-eval-30-column'},
-				{ input: null, output: 'd2l-quick-eval-25-column'},
-				{ input: undefined, output: 'd2l-quick-eval-25-column'}
+				{ input: 15, output: 'd2l-quick-eval-15-column' },
+				{ input: 20, output: 'd2l-quick-eval-20-column' },
+				{ input: 25, output: 'd2l-quick-eval-25-column' },
+				{ input: 30, output: 'd2l-quick-eval-30-column' },
+				{ input: null, output: 'd2l-quick-eval-25-column' },
+				{ input: undefined, output: 'd2l-quick-eval-25-column' }
 			].forEach(testCase => {
 				test(`_getWidthCssClass returns ${testCase.output} when given ${testCase.input}`, () => {
 					list.headerColumns = [{}, {}, {}, {}];
@@ -414,7 +414,7 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 				{ input: null, match: 'none', expected: true }
 			].forEach((testCase) => {
 				test(`Calling _isColumn with ${testCase.input} and ${testCase.match} should ${testCase.expected ? '' : 'not '} match.`, () => {
-					assert.equal(list._isColumn({type: testCase.input}, testCase.match), testCase.expected);
+					assert.equal(list._isColumn({ type: testCase.input }, testCase.match), testCase.expected);
 				});
 			});
 		});

--- a/test/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -22,10 +22,10 @@ suite('d2l-quick-eval-submissions', function() {
 
 	suite('Headers', () => {
 		[
-			{ masterTeacher: true, courseLevel: true, expected: [ 'displayName', 'activityName', 'localizedSubmissionDate', 'masterTeacher']},
-			{ masterTeacher: true, courseLevel: false, expected: [ 'displayName', 'activityName', 'courseName', 'localizedSubmissionDate', 'masterTeacher']},
-			{ masterTeacher: false, courseLevel: true, expected: [ 'displayName', 'activityName', 'localizedSubmissionDate']},
-			{ masterTeacher: false, courseLevel: false, expected: [ 'displayName', 'activityName', 'courseName', 'localizedSubmissionDate']}
+			{ masterTeacher: true, courseLevel: true, expected: [ 'displayName', 'activityName', 'localizedSubmissionDate', 'masterTeacher'] },
+			{ masterTeacher: true, courseLevel: false, expected: [ 'displayName', 'activityName', 'courseName', 'localizedSubmissionDate', 'masterTeacher'] },
+			{ masterTeacher: false, courseLevel: true, expected: [ 'displayName', 'activityName', 'localizedSubmissionDate'] },
+			{ masterTeacher: false, courseLevel: false, expected: [ 'displayName', 'activityName', 'courseName', 'localizedSubmissionDate'] }
 		].forEach(testCase => {
 			test('Headers are computed correctly', () => {
 				submissions.masterTeacher = testCase.masterTeacher;

--- a/test/d2l-quick-eval/d2l-quick-eval.html
+++ b/test/d2l-quick-eval/d2l-quick-eval.html
@@ -206,8 +206,8 @@
 				});
 				[
 					{ hrefKey: 'href', child: 'd2l-quick-eval-submissions', expected: 'newValue' },
-					{ hrefKey: 'submissionsHref', child: 'd2l-quick-eval-submissions', expected: 'newValue'},
-					{ hrefKey: 'activitiesHref', child: 'd2l-quick-eval-activities', expected: 'newValue'}
+					{ hrefKey: 'submissionsHref', child: 'd2l-quick-eval-submissions', expected: 'newValue' },
+					{ hrefKey: 'activitiesHref', child: 'd2l-quick-eval-activities', expected: 'newValue' }
 				].forEach(function(testCase) {
 					test(`Setting ${testCase.hrefKey} gets passed to the href for ${testCase.child}`, function() {
 						quickEval.href = '';

--- a/test/d2l-quick-eval/perceptual/d2l-quick-eval-action-dismiss-dialog.visual-diff.js
+++ b/test/d2l-quick-eval/perceptual/d2l-quick-eval-action-dismiss-dialog.visual-diff.js
@@ -10,8 +10,8 @@ describe.skip('d2l-quick-eval-action-dismiss-dialog', function() {
 	before(async() => {
 		browser = await puppeteer.launch();
 		page = await browser.newPage();
-		await page.setViewport({width: 900, height: 800, deviceScaleFactor: 2});
-		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-action-dismiss-dialog.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
+		await page.setViewport({ width: 900, height: 800, deviceScaleFactor: 2 });
+		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-action-dismiss-dialog.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
 		await page.bringToFront();
 	});
 

--- a/test/d2l-quick-eval/perceptual/d2l-quick-eval-activities-list.visual-diff.js
+++ b/test/d2l-quick-eval/perceptual/d2l-quick-eval-activities-list.visual-diff.js
@@ -10,8 +10,8 @@ describe('d2l-quick-eval-activities-list', function() {
 	before(async() => {
 		browser = await puppeteer.launch();
 		page = await browser.newPage();
-		await page.setViewport({width: 900, height: 800, deviceScaleFactor: 2});
-		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-activities-list.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
+		await page.setViewport({ width: 900, height: 800, deviceScaleFactor: 2 });
+		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-activities-list.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
 		await page.bringToFront();
 	});
 

--- a/test/d2l-quick-eval/perceptual/d2l-quick-eval-activity-card-action-button-more.visual-diff.js
+++ b/test/d2l-quick-eval/perceptual/d2l-quick-eval-activity-card-action-button-more.visual-diff.js
@@ -10,8 +10,8 @@ describe.skip('d2l-quick-eval-activity-card-action-button-more', function() {
 	before(async() => {
 		browser = await puppeteer.launch();
 		page = await browser.newPage();
-		await page.setViewport({width: 900, height: 800, deviceScaleFactor: 2});
-		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-activity-card-action-button-more.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
+		await page.setViewport({ width: 900, height: 800, deviceScaleFactor: 2 });
+		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-activity-card-action-button-more.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
 		await page.bringToFront();
 	});
 

--- a/test/d2l-quick-eval/perceptual/d2l-quick-eval-activity-card-action-button.visual-diff.js
+++ b/test/d2l-quick-eval/perceptual/d2l-quick-eval-activity-card-action-button.visual-diff.js
@@ -10,8 +10,8 @@ describe('d2l-quick-eval-activity-card-action-button', function() {
 	before(async() => {
 		browser = await puppeteer.launch();
 		page = await browser.newPage();
-		await page.setViewport({width: 900, height: 800, deviceScaleFactor: 2});
-		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-activity-card-action-button.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
+		await page.setViewport({ width: 900, height: 800, deviceScaleFactor: 2 });
+		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-activity-card-action-button.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
 		await page.bringToFront();
 	});
 
@@ -57,7 +57,7 @@ describe('d2l-quick-eval-activity-card-action-button', function() {
 							await page.focus(`.${name}`);
 							break;
 					}
-					await page.setViewport({width: 899, height: 800, deviceScaleFactor: 2});
+					await page.setViewport({ width: 899, height: 800, deviceScaleFactor: 2 });
 					const rect = await visualDiff.getRect(page, `#${name}`);
 					await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 				});

--- a/test/d2l-quick-eval/perceptual/d2l-quick-eval-activity-card-new-submissions.visual-diff.js
+++ b/test/d2l-quick-eval/perceptual/d2l-quick-eval-activity-card-new-submissions.visual-diff.js
@@ -10,8 +10,8 @@ describe('d2l-quick-eval-activity-card-new-submissions', function() {
 	before(async() => {
 		browser = await puppeteer.launch();
 		page = await browser.newPage();
-		await page.setViewport({width: 800, height: 800, deviceScaleFactor: 2});
-		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-activity-card-new-submissions.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
+		await page.setViewport({ width: 800, height: 800, deviceScaleFactor: 2 });
+		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-activity-card-new-submissions.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
 		await page.bringToFront();
 	});
 

--- a/test/d2l-quick-eval/perceptual/d2l-quick-eval-activity-card.visual-diff.js
+++ b/test/d2l-quick-eval/perceptual/d2l-quick-eval-activity-card.visual-diff.js
@@ -10,8 +10,8 @@ describe('d2l-quick-eval-activity-card', function() {
 	before(async() => {
 		browser = await puppeteer.launch();
 		page = await browser.newPage();
-		await page.setViewport({width: 900, height: 800, deviceScaleFactor: 2});
-		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-activity-card.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
+		await page.setViewport({ width: 900, height: 800, deviceScaleFactor: 2 });
+		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-activity-card.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
 		await page.bringToFront();
 	});
 
@@ -48,31 +48,31 @@ describe('d2l-quick-eval-activity-card', function() {
 	});
 
 	it('tablet-viewport', async function() {
-		await page.setViewport({width: 899, height: 800, deviceScaleFactor: 2});
+		await page.setViewport({ width: 899, height: 800, deviceScaleFactor: 2 });
 		const rect = await visualDiff.getRect(page, '#tablet-viewport');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});
 
 	it('dismiss-tablet-viewport', async function() {
-		await page.setViewport({width: 899, height: 800, deviceScaleFactor: 2});
+		await page.setViewport({ width: 899, height: 800, deviceScaleFactor: 2 });
 		const rect = await visualDiff.getRect(page, '#dismiss');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});
 
 	it('mobile-viewport', async function() {
-		await page.setViewport({width: 524, height: 800, deviceScaleFactor: 2});
+		await page.setViewport({ width: 524, height: 800, deviceScaleFactor: 2 });
 		const rect = await visualDiff.getRect(page, '#mobile-viewport');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});
 
 	it('dismiss-mobile-viewport', async function() {
-		await page.setViewport({width: 524, height: 800, deviceScaleFactor: 2});
+		await page.setViewport({ width: 524, height: 800, deviceScaleFactor: 2 });
 		const rect = await visualDiff.getRect(page, '#dismiss');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});
 
 	it('dismiss-dropdown-publish-disabled', async function() {
-		await page.setViewport({width: 900, height: 800, deviceScaleFactor: 2});
+		await page.setViewport({ width: 900, height: 800, deviceScaleFactor: 2 });
 		page.hover('#dismiss d2l-quick-eval-activity-card');
 		await page.waitFor(2000);
 		await page.evaluate(() => {
@@ -89,7 +89,7 @@ describe('d2l-quick-eval-activity-card', function() {
 	});
 
 	it('dismiss-dropdown-publish-enabled', async function() {
-		await page.setViewport({width: 900, height: 800, deviceScaleFactor: 2});
+		await page.setViewport({ width: 900, height: 800, deviceScaleFactor: 2 });
 		page.hover('#dismiss-with-publish d2l-quick-eval-activity-card');
 		await page.waitFor(2000);
 		await page.evaluate(() => {

--- a/test/d2l-quick-eval/perceptual/d2l-quick-eval-dismissed-activities-list.visual-diff.js
+++ b/test/d2l-quick-eval/perceptual/d2l-quick-eval-dismissed-activities-list.visual-diff.js
@@ -10,8 +10,8 @@ describe('d2l-quick-eval-dismissed-activities-list', function() {
 	before(async() => {
 		browser = await puppeteer.launch();
 		page = await browser.newPage();
-		await page.setViewport({width: 900, height: 800, deviceScaleFactor: 2});
-		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-dismissed-activities-list.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
+		await page.setViewport({ width: 900, height: 800, deviceScaleFactor: 2 });
+		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-dismissed-activities-list.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
 		await page.bringToFront();
 	});
 

--- a/test/d2l-quick-eval/perceptual/d2l-quick-eval-ellipsis-dismiss-dialog.visual-diff.js
+++ b/test/d2l-quick-eval/perceptual/d2l-quick-eval-ellipsis-dismiss-dialog.visual-diff.js
@@ -10,8 +10,8 @@ describe.skip('d2l-quick-eval-ellipsis-dialog', function() {
 	before(async() => {
 		browser = await puppeteer.launch();
 		page = await browser.newPage();
-		await page.setViewport({width: 900, height: 800, deviceScaleFactor: 2});
-		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-ellipsis-dismiss-dialog.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
+		await page.setViewport({ width: 900, height: 800, deviceScaleFactor: 2 });
+		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-ellipsis-dismiss-dialog.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
 		await page.bringToFront();
 	});
 

--- a/test/d2l-quick-eval/perceptual/d2l-quick-eval-ellipsis-menu.visual-diff.js
+++ b/test/d2l-quick-eval/perceptual/d2l-quick-eval-ellipsis-menu.visual-diff.js
@@ -10,8 +10,8 @@ describe('d2l-quick-eval-ellipsis-menu', function() {
 	before(async() => {
 		browser = await puppeteer.launch();
 		page = await browser.newPage();
-		await page.setViewport({width: 900, height: 800, deviceScaleFactor: 2});
-		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-ellipsis-menu.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
+		await page.setViewport({ width: 900, height: 800, deviceScaleFactor: 2 });
+		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-ellipsis-menu.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
 		await page.bringToFront();
 	});
 

--- a/test/d2l-quick-eval/perceptual/d2l-quick-eval-no-submissions-text.visual-diff.js
+++ b/test/d2l-quick-eval/perceptual/d2l-quick-eval-no-submissions-text.visual-diff.js
@@ -10,8 +10,8 @@ describe('d2l-quick-eval-no-submissions-text', function() {
 	before(async() => {
 		browser = await puppeteer.launch();
 		page = await browser.newPage();
-		await page.setViewport({width: 900, height: 800, deviceScaleFactor: 2});
-		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-no-submissions-text.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
+		await page.setViewport({ width: 900, height: 800, deviceScaleFactor: 2 });
+		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-no-submissions-text.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
 		await page.bringToFront();
 	});
 

--- a/test/d2l-quick-eval/perceptual/d2l-quick-eval-search-results-summary-container.visual-diff.js
+++ b/test/d2l-quick-eval/perceptual/d2l-quick-eval-search-results-summary-container.visual-diff.js
@@ -10,8 +10,8 @@ describe('d2l-quick-eval-search-results-summary-container', function() {
 	before(async() => {
 		browser = await puppeteer.launch();
 		page = await browser.newPage();
-		await page.setViewport({width: 800, height: 800, deviceScaleFactor: 2});
-		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-search-results-summary-container.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
+		await page.setViewport({ width: 800, height: 800, deviceScaleFactor: 2 });
+		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-search-results-summary-container.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
 		await page.bringToFront();
 	});
 

--- a/test/d2l-quick-eval/perceptual/d2l-quick-eval-submissions-table.visual-diff.js
+++ b/test/d2l-quick-eval/perceptual/d2l-quick-eval-submissions-table.visual-diff.js
@@ -10,8 +10,8 @@ describe.skip('d2l-quick-eval-submissions-table', function() {
 	before(async() => {
 		browser = await puppeteer.launch();
 		page = await browser.newPage();
-		await page.setViewport({width: 900, height: 800, deviceScaleFactor: 2});
-		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-submissions-table.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
+		await page.setViewport({ width: 900, height: 800, deviceScaleFactor: 2 });
+		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-submissions-table.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
 		await page.bringToFront();
 	});
 

--- a/test/d2l-quick-eval/perceptual/d2l-quick-eval-view-toggle-button.visual-diff.js
+++ b/test/d2l-quick-eval/perceptual/d2l-quick-eval-view-toggle-button.visual-diff.js
@@ -10,8 +10,8 @@ describe('d2l-quick-eval-view-toggle-button', function() {
 	beforeEach(async() => {
 		browser = await puppeteer.launch();
 		page = await browser.newPage();
-		await page.setViewport({width: 900, height: 800, deviceScaleFactor: 2});
-		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-view-toggle-button.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
+		await page.setViewport({ width: 900, height: 800, deviceScaleFactor: 2 });
+		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-view-toggle-button.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
 		await page.bringToFront();
 	});
 

--- a/test/d2l-quick-eval/perceptual/d2l-quick-eval-view-toggle.visual-diff.js
+++ b/test/d2l-quick-eval/perceptual/d2l-quick-eval-view-toggle.visual-diff.js
@@ -10,8 +10,8 @@ describe('d2l-quick-eval-view-toggle', function() {
 	before(async() => {
 		browser = await puppeteer.launch();
 		page = await browser.newPage();
-		await page.setViewport({width: 900, height: 800, deviceScaleFactor: 2});
-		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-view-toggle.visual-diff.html`, {waitUntil: ['networkidle0', 'load']});
+		await page.setViewport({ width: 900, height: 800, deviceScaleFactor: 2 });
+		await page.goto(`${visualDiff.getBaseUrl()}/test/d2l-quick-eval/perceptual/d2l-quick-eval-view-toggle.visual-diff.html`, { waitUntil: ['networkidle0', 'load'] });
 		await page.bringToFront();
 	});
 

--- a/test/d2l-quick-eval/quick-eval-logging-test-component.js
+++ b/test/d2l-quick-eval/quick-eval-logging-test-component.js
@@ -1,5 +1,5 @@
-import {PolymerElement} from '@polymer/polymer/polymer-element.js';
-import {QuickEvalLogging} from '../../components/d2l-quick-eval/QuickEvalLogging.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { QuickEvalLogging } from '../../components/d2l-quick-eval/QuickEvalLogging.js';
 
 class QuickEvalLoggingTestComponent extends QuickEvalLogging(PolymerElement) {
 	static get is() { return 'quick-eval-logging-test-component'; }


### PR DESCRIPTION
# Overview
This PR is to correct numerous linting errors identified from the eslint-config-brightspace dependency. Many errors involve spacing and ordering.

## Automated from dependabot

Bumps [eslint-config-brightspace](https://github.com/Brightspace/eslint-config-brightspace) from 0.7.0 to 0.10.0.
- [Release notes](https://github.com/Brightspace/eslint-config-brightspace/releases)
- [Commits](https://github.com/Brightspace/eslint-config-brightspace/compare/v0.7.0...v0.10.0)

Signed-off-by: dependabot[bot] <support@github.com>

## Steps taken in this PR
### Step 1
Running `npm run lint` returns:
```shell
...
✖ 1660 problems (1660 errors, 0 warnings)
  1660 errors and 0 warnings potentially fixable with the `--fix` option.
```

### Step 2 - First commit
eslint is run locally with the fix option to autocorrect as many issues as possible
```shell
npx eslint --fix . --ext .js,.html test/**/*.js test/**/*.html demo/**/*.html > "C:\tmp\eslint_fix_stdout1.txt" 
```

A total of 1379 errors corrected in this commit
Full terminal stdout can be seen here: 
[eslint_fix_stdout1.txt](https://github.com/BrightspaceHypermediaComponents/activities/files/5097525/eslint_fix_stdout1.txt)

### Step 3 - Second commit
```shell
npx eslint --fix . --ext .js,.html test/**/*.js test/**/*.html demo/**/*.html > "C:\tmp\eslint_fix_stdout2.txt" 
```
Corrected 219 errors
[eslint_fix_stdout2.txt](https://github.com/BrightspaceHypermediaComponents/activities/files/5097527/eslint_fix_stdout2.txt)

### Step 4 - Third commit
```shell
npx eslint --fix . --ext .js,.html test/**/*.js test/**/*.html demo/**/*.html > "C:\tmp\eslint_fix_stdout3.txt" 
```
Corrected 51 errors
[eslint_fix_stdout3.txt](https://github.com/BrightspaceHypermediaComponents/activities/files/5097528/eslint_fix_stdout3.txt)

### Step 5 - Final commit
```shell
npx eslint --fix . --ext .js,.html test/**/*.js test/**/*.html demo/**/*.html" 
```
Corrected all remaining errors (11).

### Step 6
Running `npm run lint` one last time:
```shell
> d2l-activities@3.53.4 lint C:\D2L\offstack\activities
> npm run lint:style && npm run lint:wc && npm run lint:js


> d2l-activities@3.53.4 lint:style C:\D2L\offstack\activities
> stylelint "**/*.js"


> d2l-activities@3.53.4 lint:wc C:\D2L\offstack\activities
> polymer lint -i "./*" "components" "demo" "test"


> d2l-activities@3.53.4 lint:js C:\D2L\offstack\activities
> eslint . --ext .js,.html test/**/*.js test/**/*.html demo/**/*.html
```
No errors 😄

**EDIT:** I had issues with merging conflicts from pulling master in after the lint fixes, so I reset back to the start of the branch, pulled first and then fixed the linting errors.