### PR TITLE
Move MobX anonymous marking stuff into its own store

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-editor.js
@@ -67,7 +67,7 @@ class ActivityAssignmentAnonymousMarkingEditor
 			return html``;
 		}
 
-		const shouldRenderEditor = entity.isAnonymousMarkingAvailable;
+		const shouldRenderEditor = entity.anonymousMarkingProps.isAnonymousMarkingAvailable;
 		if (!shouldRenderEditor) {
 			return html``;
 		}
@@ -78,8 +78,8 @@ class ActivityAssignmentAnonymousMarkingEditor
 			</label>
 			<d2l-input-checkbox
 				@change="${this._saveAnonymousMarking}"
-				?checked="${entity.isAnonymousMarkingEnabled}"
-				?disabled="${!entity.canEditAnonymousMarking}"
+				?checked="${entity.anonymousMarkingProps.isAnonymousMarkingEnabled}"
+				?disabled="${!entity.anonymousMarkingProps.canEditAnonymousMarking}"
 				ariaLabel="${this.localize('chkAnonymousMarking')}">
 				${this.localize('chkAnonymousMarking')}
 			</d2l-input-checkbox>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-summary.js
@@ -28,11 +28,13 @@ class ActivityAssignmentAnonymousMarkingSummary
 	render() {
 
 		const entity = store.get(this.href);
-		if (!entity) {
+		if (!entity || !entity.anonymousMarkingProps) {
 			return html``;
 		}
 
-		const shouldRenderSummaryText = entity.isAnonymousMarkingAvailable && entity.isAnonymousMarkingEnabled;
+		const shouldRenderSummaryText =
+			entity.anonymousMarkingProps.isAnonymousMarkingAvailable &&
+			entity.anonymousMarkingProps.isAnonymousMarkingEnabled;
 		if (!shouldRenderSummaryText) {
 			return html``;
 		}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-anonymous-marking.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-anonymous-marking.js
@@ -1,0 +1,38 @@
+import {action, configure as configureMobx, decorate, observable } from 'mobx';
+
+configureMobx({ enforceActions: 'observed' });
+
+export class AnonymousMarkingProps {
+
+	constructor(entity) {
+		this.isAnonymousMarkingEnabled = entity.isAnonymousMarkingEnabled;
+		this.canEditAnonymousMarking = entity.canEditAnonymousMarking;
+		this.anonymousMarkingHelpText = entity.getAnonymousMarkingHelpText;
+		this.entityAnonymousMarkingAvailable = entity.isAnonymousMarkingAvailable;
+		this.isAnonymousMarkingAvailable = this.entityAnonymousMarkingAvailable;
+
+		this.setIsAnonymousMarkingAvailableForSubmissionType(entity.submissionType);
+	}
+
+	setAnonymousMarking(value) {
+		this.isAnonymousMarkingEnabled = value;
+	}
+
+	setIsAnonymousMarkingAvailableForSubmissionType(submissionType) {
+		this.isAnonymousMarkingAvailable =
+			this.entityAnonymousMarkingAvailable && this._isSubmissionTypeWithAnonMarking(submissionType);
+	}
+
+	_isSubmissionTypeWithAnonMarking(submissionType) {
+		// only file (0) and text (1) submissions can have anonymous marking, see https://docs.valence.desire2learn.com/res/dropbox.html#attributes
+		return ['0', '1'].includes(submissionType);
+	}
+}
+
+decorate(AnonymousMarkingProps, {
+	isAnonymousMarkingAvailable: observable,
+	isAnonymousMarkingEnabled: observable,
+	canEditAnonymousMarking: observable,
+	anonymousMarkingHelpText: observable,
+	setAnonymousMarking: action
+});

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-anonymous-marking.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-anonymous-marking.js
@@ -20,10 +20,10 @@ export class AnonymousMarkingProps {
 
 	setIsAnonymousMarkingAvailableForSubmissionType(submissionType) {
 		this.isAnonymousMarkingAvailable =
-			this.entityAnonymousMarkingAvailable && this._isSubmissionTypeWithAnonMarking(submissionType);
+			this.entityAnonymousMarkingAvailable && this.isSubmissionTypeWithAnonMarking(submissionType);
 	}
 
-	_isSubmissionTypeWithAnonMarking(submissionType) {
+	isSubmissionTypeWithAnonMarking(submissionType) {
 		// only file (0) and text (1) submissions can have anonymous marking, see https://docs.valence.desire2learn.com/res/dropbox.html#attributes
 		return ['0', '1'].includes(submissionType);
 	}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-submission-and-completion.js
@@ -4,8 +4,7 @@ configureMobx({ enforceActions: 'observed' });
 
 export class SubmissionAndCompletionProps {
 
-	constructor(entity, token) {
-		this.token = token;
+	constructor(entity) {
 		this.submissionTypeOptions = entity.submissionTypeOptions;
 		this.submissionType = String(entity.submissionType);
 		this.canEditSubmissionType = entity.canEditSubmissionType;

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -175,7 +175,7 @@ export class Assignment {
 			groupTypeId: this.selectedGroupCategoryId,
 			defaultScoringRubricId: this.defaultScoringRubricId
 		};
-		if (this._isSubmissionTypeWithAnonMarking()) {
+		if (this.anonymousMarkingProps.isSubmissionTypeWithAnonMarking(this.SubmissionAndCompletionProps.submissionType)) {
 			data.isAnonymous = this.anonymousMarkingProps.isAnonymousMarkingEnabled;
 		}
 		if (this.canEditInstructions) {

--- a/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
@@ -32,9 +32,9 @@ describe('Assignment ', function() {
 				isGradeMarkEnabled: () => undefined,
 				instructionsRichTextEditorConfig: () => {},
 				isAnonymousMarkingAvailable: () => true,
-				isAnonymousMarkingEnabled: () => undefined,
-				canEditAnonymousMarking: () => undefined,
-				getAnonymousMarkingHelpText: () => undefined,
+				isAnonymousMarkingEnabled: () => true,
+				canEditAnonymousMarking: () => true,
+				getAnonymousMarkingHelpText: () => 'Anonymous marking help text',
 				canEditAnnotations: () => undefined,
 				getAvailableAnnotationTools: () => undefined,
 				activityUsageHref: () => 'http://activity/1',
@@ -136,7 +136,7 @@ describe('Assignment ', function() {
 		expect(assignment.submissionAndCompletionProps.canEditCompletionType).to.equal(true);
 		expect(assignment.submissionAndCompletionProps.submissionType).to.equal('2');
 		expect(assignment.submissionAndCompletionProps.completionType).to.equal('2');
-		expect(assignment.isAnonymousMarkingAvailable).to.equal(false);
+		expect(assignment.anonymousMarkingProps.isAnonymousMarkingAvailable).to.equal(false);
 
 		expect(fetchEntity.mock.calls.length).to.equal(1);
 		expect(AssignmentEntity.mock.calls[0][0]).to.equal(sirenEntity);
@@ -146,27 +146,27 @@ describe('Assignment ', function() {
 	it('setSubmissionType when new submission type has completion types', async() => {
 		const assignment = new Assignment('http://assignment/1', 'token');
 		await assignment.fetch();
-		assignment.submissionType = '1';
+		assignment.submissionAndCompletionProps.submissionType = '1';
 		assignment.submissionAndCompletionProps.completionType = null;
 		assignment.setSubmissionType('3');
 
 		expect(assignment.submissionAndCompletionProps.submissionType).to.equal('3');
 		expect(assignment.submissionAndCompletionProps.completionType).to.equal('3');
 		expect(assignment.submissionAndCompletionProps.canEditCompletionType).to.equal(true);
-		expect(assignment.isAnonymousMarkingAvailable).to.equal(false);
+		expect(assignment.anonymousMarkingProps.isAnonymousMarkingAvailable).to.equal(false);
 	});
 
 	it('setSubmissionType when new submission type does not have completion types', async() => {
 		const assignment = new Assignment('http://assignment/1', 'token');
 		await assignment.fetch();
-		assignment.submissionType = '3';
+		assignment.submissionAndCompletionProps.submissionType = '3';
 		assignment.submissionAndCompletionProps.completionType = '3';
 		assignment.setSubmissionType('1');
 
 		expect(assignment.submissionAndCompletionProps.submissionType).to.equal('1');
 		expect(assignment.submissionAndCompletionProps.completionType).to.equal(null);
 		expect(assignment.submissionAndCompletionProps.canEditCompletionType).to.equal(true);
-		expect(assignment.isAnonymousMarkingAvailable).to.equal(true);
+		expect(assignment.anonymousMarkingProps.isAnonymousMarkingAvailable).to.equal(true);
 	});
 
 	it('setSubmissionType when current completion type is valid', async() => {


### PR DESCRIPTION
Continuing the work from https://github.com/BrightspaceHypermediaComponents/activities/pull/1042 this PR moves the anonymous marking stuff into its own store. I'm feeling much better with how simple the assignment store has gotten after this work, its gonna be good once we can test the UI too.