### PR TITLE
Fix defect DE40213 - Rubric buttons hidden behind face footer

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -59,6 +59,9 @@ class ActivityRubricsListContainer extends ActivityEditorFeaturesMixin(ActivityE
 				.d2l-rubric-heading-title {
 					flex-grow: 1;
 				}
+				d2l-simple-overlay {
+					--d2l-scrollable-height: calc(100vh - 225px);
+				}
 			`
 		];
 	}


### PR DESCRIPTION
# Update
PR closed as issue is dealt with here: https://github.com/BrightspaceUI/core/pull/806

# Overview
This PR is to fix a defect outlined here: 
- [DE40213](https://rally1.rallydev.com/#/detail/defect/416279793680?fdp=true): FACE > Rubrics > Create new rubric overlay buttons are hidden behind the FACE footer

This PR is related to PR https://github.com/Brightspace/simple-overlay/pull/34

## Setup
- Enable the FACE Feature flag and FACE config to on/opt in
- Run local BSI with the following repos
  - [d2l-activities](https://github.com/BrightspaceHypermediaComponents/activities)
  - [d2l-simple-overlay](https://github.com/Brightspace/simple-overlay)

## Recreate Defect
- Run above local repos on the master branch.
- Navigate to `Course > Assignments > New Assignment > Evaluation & Feedback > Add Rubric > Create New`
- Scroll to bottom of page and observe footer covers bottom of overlay
![see image](https://user-images.githubusercontent.com/33091324/91083563-800a8c80-e618-11ea-8d51-4b87f39495ce.png)

## Proposed Fix
- Change the height of the [`<div class="scrollable...`](https://github.com/Brightspace/simple-overlay/blob/62dd71f55cd17711afcc77471073e268186e260d/d2l-simple-overlay.js#L33)
  - From: `calc(100vh - 250px)`
  - To: `calc(100vh - 225px)`
- To prevent issues with other components that use `d2l-simple-overlay` a custom property is added to the component styling called `--d2l-scrollable-height`
  - The default value is set to the value set previous to this [PR 34](https://github.com/Brightspace/simple-overlay/pull/34/files)
- `--d2l-scrollable-height` is set by the [`d2l-activity-rubrics-list-container.js`](https://github.com/BrightspaceHypermediaComponents/activities/pull/1049/files) component in its styles

![Buttons Visible](https://user-images.githubusercontent.com/33091324/91093788-e8ad3580-e627-11ea-9d9d-24fd696705aa.png)

## Other considerations
- The "Attach Rubric" and "Cancel" buttons have no spacing between the footer below or accordion above
- Should "Save and Close" and "Cancel" from the assignment editor be visible? In my opinion this could cause confusion while editing and allow a user to close FACE editor by accident when meaning to close the rubric.
- The behaviour of the rubric buttons in FACE are different than in Rubrics
  - Rubrics detaches the buttons and allows them to follow up the screen.
  - ![bottom of rubrics](https://user-images.githubusercontent.com/33091324/91180084-5c495400-e6b5-11ea-8bc7-92382793d9a2.png)
  - ![middle of rubrics](https://user-images.githubusercontent.com/33091324/91180156-6e2af700-e6b5-11ea-91e8-aa415d46b529.png)
  - Should the behaviour be the same in FACE?

