### PR TITLE
email notification error tooltip should not always be on top

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -65,6 +65,10 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends ActivityEditorFeat
 					margin-bottom: 2px;
 					margin-top: 10px;
 				}
+
+				#notification-email-tooltip {
+					z-index: auto;
+				}
 			`,
 			summarizerHeaderStyles,
 			summarizerSummaryStyles


### PR DESCRIPTION
https://trello.com/c/5lCEIcvV/13-face-email-validation-error-always-shows-on-top