### PR TITLE
Mobx refactor bugfix

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-editor.js
@@ -79,8 +79,8 @@ class ActivityAssignmentAnonymousMarkingEditor
 			</d2l-input-checkbox>
 			<d2l-input-checkbox-spacer
 				class="d2l-body-small"
-				?hidden="${!entity.anonymousMarkingHelpText}">
-				${entity.anonymousMarkingHelpText}
+				?hidden="${!entity.anonymousMarkingProps.anonymousMarkingHelpText}">
+				${entity.anonymousMarkingProps.anonymousMarkingHelpText}
 			</d2l-input-checkbox-spacer>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -188,7 +188,7 @@ class AssignmentEditor extends ActivityEditorContainerMixin(RtlMixin(LocalizeAct
 		} = activity;
 
 		const assignment = store.getAssignment(activity.assignmentHref);
-		const hasSubmissions = assignment && assignment.assignmentHasSubmissions;
+		const hasSubmissions = assignment && assignment.submissionAndCompletionProps.assignmentHasSubmissions;
 
 		return html`
 			<d2l-template-primary-secondary slot="editor" width-type="${this.widthType}">

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-anonymous-marking.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-anonymous-marking.js
@@ -7,7 +7,7 @@ export class AnonymousMarkingProps {
 	constructor(entity) {
 		this.isAnonymousMarkingEnabled = entity.isAnonymousMarkingEnabled;
 		this.canEditAnonymousMarking = entity.canEditAnonymousMarking;
-		this.anonymousMarkingHelpText = entity.getAnonymousMarkingHelpText;
+		this.anonymousMarkingHelpText = entity.anonymousMarkingHelpText;
 		this.entityAnonymousMarkingAvailable = entity.isAnonymousMarkingAvailable;
 		this.isAnonymousMarkingAvailable = this.entityAnonymousMarkingAvailable;
 


### PR DESCRIPTION
Two bugfixes for stuff that got missed when I moved things into their own classes (found these as I was adding tests).

I did a search through the code for any usages of `.property` to make sure there were not any others left like this (so they were all prefixed with the prop object, for example `submissionAndCompletionProps.assignmentHasSubmissions`)