### PR TITLE
updated remove button to read course name by screen reader

### DIFF
--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -673,8 +673,8 @@ class CollectionEditor extends LocalizeActivityCollectionEditor(EntityMixinLit(L
 					<div slot="secondary">${item.hasClass(organizationClasses.courseOffering) ? this.localize('course') : null}</div>
 					<d2l-menu-item
 						slot="secondary-action"
-						text="${this.localize('removeActivity', 'activityName', '')}"
-						aria-label="${this.localize('removeActivity', 'activityName', item.name())}"
+						text="${this.localize('removeActivity')}"
+						aria-label="${this.localize('removeActivityAria', 'activityName', item.name())}"
 						@keydown=${(e) => (e.keyCode === spaceKeyDown || e.keyCode === spaceKeyEnter) && item.removeItem()}
 						@click=${item.removeItem}>
 					</d2l-menu-item>

--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -673,7 +673,8 @@ class CollectionEditor extends LocalizeActivityCollectionEditor(EntityMixinLit(L
 					<div slot="secondary">${item.hasClass(organizationClasses.courseOffering) ? this.localize('course') : null}</div>
 					<d2l-menu-item
 						slot="secondary-action"
-						text="${this.localize('removeActivity')}"
+						text="${this.localize('removeActivity', 'activityName', '')}"
+						aria-label="${this.localize('removeActivity', 'activityName', item.name())}"
 						@keydown=${(e) => (e.keyCode === spaceKeyDown || e.keyCode === spaceKeyEnter) && item.removeItem()}
 						@click=${item.removeItem}>
 					</d2l-menu-item>

--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -673,8 +673,8 @@ class CollectionEditor extends LocalizeActivityCollectionEditor(EntityMixinLit(L
 					<div slot="secondary">${item.hasClass(organizationClasses.courseOffering) ? this.localize('course') : null}</div>
 					<d2l-menu-item
 						slot="secondary-action"
-						text="${this.localize('removeActivity')}"
-						aria-label="${this.localize('removeActivityAria', 'activityName', item.name())}"
+						text="${this.localize('removeActivity', 'activityName', '')}"
+						aria-label="${this.localize('removeActivity', 'activityName', item.name())}"
 						@keydown=${(e) => (e.keyCode === spaceKeyDown || e.keyCode === spaceKeyEnter) && item.removeItem()}
 						@click=${item.removeItem}>
 					</d2l-menu-item>

--- a/components/d2l-activity-collection-editor/lang/en.js
+++ b/components/d2l-activity-collection-editor/lang/en.js
@@ -16,7 +16,8 @@ export default {
 	noActivitiesInLearningPath: "There are no activities in this learning path.", // Displayed when the learning path is loaded and contains no activities
 	noActivitiesFound: "There were no activities found using your search term.", // Displayed when the learning path has no activities while in the screen that allows you to add them.
 	numberOfActivities: "{count, plural, =1 {1 Activity} other {{count} Activities}}", // The number of learning tasks currently in the list.
-	removeActivity: "Remove {activityName}", // An action to remove a learning task from a list of tasks that are related
+	removeActivity: "Remove", // An action to remove a learning task from a list of tasks that are related
+	removeActivityAria: "Remove {activityName}", // An action to remove a learning task from a list of tasks that are related with the activity name
 	search: "Search", // When adding activities to the learning path, this is where you can search for potential activities to add.
 	searchPlaceholder: "Search...", // Placeholder text for the search input to search the list of potential activities.
 	selected: "{count} selected.", // When adding activities (bulk add) to a learning path this is the number of activities that will be added to the list.

--- a/components/d2l-activity-collection-editor/lang/en.js
+++ b/components/d2l-activity-collection-editor/lang/en.js
@@ -16,7 +16,7 @@ export default {
 	noActivitiesInLearningPath: "There are no activities in this learning path.", // Displayed when the learning path is loaded and contains no activities
 	noActivitiesFound: "There were no activities found using your search term.", // Displayed when the learning path has no activities while in the screen that allows you to add them.
 	numberOfActivities: "{count, plural, =1 {1 Activity} other {{count} Activities}}", // The number of learning tasks currently in the list.
-	removeActivity: "Remove", // An action to remove a learning task from a list of tasks that are related
+	removeActivity: "Remove {activityName}", // An action to remove a learning task from a list of tasks that are related
 	search: "Search", // When adding activities to the learning path, this is where you can search for potential activities to add.
 	searchPlaceholder: "Search...", // Placeholder text for the search input to search the list of potential activities.
 	selected: "{count} selected.", // When adding activities (bulk add) to a learning path this is the number of activities that will be added to the list.

--- a/components/d2l-activity-collection-editor/lang/en.js
+++ b/components/d2l-activity-collection-editor/lang/en.js
@@ -16,7 +16,8 @@ export default {
 	noActivitiesInLearningPath: "There are no activities in this learning path.", // Displayed when the learning path is loaded and contains no activities
 	noActivitiesFound: "There were no activities found using your search term.", // Displayed when the learning path has no activities while in the screen that allows you to add them.
 	numberOfActivities: "{count, plural, =1 {1 Activity} other {{count} Activities}}", // The number of learning tasks currently in the list.
-	removeActivity: "Remove {activityName}", // An action to remove a learning task from a list of tasks that are related
+	removeActivity: "Remove", // An action to remove a learning task from a list of tasks that are related
+	removeActivityAria: "Remove {activityName}", // Remove action described for aria with course name
 	search: "Search", // When adding activities to the learning path, this is where you can search for potential activities to add.
 	searchPlaceholder: "Search...", // Placeholder text for the search input to search the list of potential activities.
 	selected: "{count} selected.", // When adding activities (bulk add) to a learning path this is the number of activities that will be added to the list.

--- a/components/d2l-activity-collection-editor/lang/en.js
+++ b/components/d2l-activity-collection-editor/lang/en.js
@@ -16,8 +16,7 @@ export default {
 	noActivitiesInLearningPath: "There are no activities in this learning path.", // Displayed when the learning path is loaded and contains no activities
 	noActivitiesFound: "There were no activities found using your search term.", // Displayed when the learning path has no activities while in the screen that allows you to add them.
 	numberOfActivities: "{count, plural, =1 {1 Activity} other {{count} Activities}}", // The number of learning tasks currently in the list.
-	removeActivity: "Remove", // An action to remove a learning task from a list of tasks that are related
-	removeActivityAria: "Remove {activityName}", // An action to remove a learning task from a list of tasks that are related with the activity name
+	removeActivity: "Remove {activityName}", // An action to remove a learning task from a list of tasks that are related
 	search: "Search", // When adding activities to the learning path, this is where you can search for potential activities to add.
 	searchPlaceholder: "Search...", // Placeholder text for the search input to search the list of potential activities.
 	selected: "{count} selected.", // When adding activities (bulk add) to a learning path this is the number of activities that will be added to the list.


### PR DESCRIPTION
Context:
DE39907 - https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fdefect%2F407158647016
Remove in context menu for a course in a learning path does not read course name in screen readers.
Went from `Remove` to `Remove <name>`.

Testing:
Tested locally with Chrome and Windows Narrator.
