### PR TITLE
US120115 Refactor AssignmentEditorDetail

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -82,10 +82,9 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(Localize
 			canEditName,
 			instructions,
 			canEditInstructions,
+			attachmentsHref,
 			instructionsRichTextEditorConfig,
 		} = assignment;
-
-		const attachmentsHref = assignment._entity.attachmentsCollectionHref();
 
 		return html`
 			<div id="assignment-name-container">
@@ -162,6 +161,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(Localize
 		}
 	}
 	addLinks(links) {
+		const attachmentsHref = store.getAssignment(this.href).attachmentsHref;
 		const collection = attachmentCollectionStore.get(attachmentsHref);
 		links = links || [];
 		links.forEach(element => {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -30,7 +30,8 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 		return {
 			_nameError: { type: String },
 			_attachmentsHref: { type: String },
-			_linksProcessor: { type: Object }
+			_linksProcessor: { type: Object },
+			activityUsageHref: { type: String, attribute: 'activity-usage-href' },
 		};
 	}
 
@@ -87,7 +88,6 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 			instructions,
 			canEditInstructions,
 			instructionsRichTextEditorConfig,
-			activityUsageHref
 		} = assignment;
 
 		return html`
@@ -114,16 +114,16 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 								and so it cannot be plugged into Dropbox to check Assignment permissions.
 				*/ html`
 					<d2l-activity-outcomes
-						href="${activityUsageHref}"
+						href="${this.activityUsageHref}"
 						.token="${this.token}">
 					</d2l-activity-outcomes>
-				` : null }
+				` : null}
 
 			<div id="score-and-duedate-container">
 				<div id="score-container">
 					<label class="d2l-label-text">${this.localize('scoreOutOf')}</label>
 					<d2l-activity-score-editor
-						.href="${activityUsageHref}"
+						.href="${this.activityUsageHref}"
 						.token="${this.token}"
 						.activityName="${name}">
 					</d2l-activity-score-editor>
@@ -131,7 +131,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(SaveStatusMixin(EntityMi
 
 				<div id="duedate-container">
 					<d2l-activity-due-date-editor
-						.href="${activityUsageHref}"
+						.href="${this.activityUsageHref}"
 						.token="${this.token}">
 					</d2l-activity-due-date-editor>
 				</div>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -202,7 +202,7 @@ class AssignmentEditor extends ActivityEditorContainerMixin(RtlMixin(LocalizeAct
 						</div>
 					</d2l-alert>
 					<d2l-activity-assignment-editor-detail
-						activity-usage-href=${activity.href}
+						activity-usage-href=${this.href}
 						.href="${assignmentHref}"
 						.token="${this.token}">
 					</d2l-activity-assignment-editor-detail>
@@ -327,7 +327,7 @@ class AssignmentEditor extends ActivityEditorContainerMixin(RtlMixin(LocalizeAct
 						options
 					);
 				}).then(filteredContent => {
-					const matchSrc = function (str) {
+					const matchSrc = function(str) {
 						// excludes matching query string as filterHtml may modify the query string
 						return str.match(/src=["']([^?"']+)/i);
 					};

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -202,6 +202,7 @@ class AssignmentEditor extends ActivityEditorContainerMixin(RtlMixin(LocalizeAct
 						</div>
 					</d2l-alert>
 					<d2l-activity-assignment-editor-detail
+						activity-usage-href=${activity.href}
 						.href="${assignmentHref}"
 						.token="${this.token}">
 					</d2l-activity-assignment-editor-detail>
@@ -326,7 +327,7 @@ class AssignmentEditor extends ActivityEditorContainerMixin(RtlMixin(LocalizeAct
 						options
 					);
 				}).then(filteredContent => {
-					const matchSrc = function(str) {
+					const matchSrc = function (str) {
 						// excludes matching query string as filterHtml may modify the query string
 						return str.match(/src=["']([^?"']+)/i);
 					};

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -52,6 +52,7 @@ export class Assignment {
 		this.instructions = entity.canEditInstructions() ? entity.instructionsEditorHtml() : entity.instructionsHtml();
 		this.canEditInstructions = entity.canEditInstructions();
 		this.instructionsRichTextEditorConfig = entity.instructionsRichTextEditorConfig();
+		this.attachmentsHref = entity.attachmentsCollectionHref();
 		this.canEditAnnotations = entity.canEditAnnotations();
 		this.annotationToolsAvailable = entity.getAvailableAnnotationTools();
 		this.activityUsageHref = entity.activityUsageHref();
@@ -208,6 +209,7 @@ decorate(Assignment, {
 	instructions: observable,
 	canEditInstructions: observable,
 	instructionsRichTextEditorConfig: observable,
+	attachmentsHref: observable,
 	canEditAnnotations: observable,
 	annotationToolsAvailable: observable,
 	activityUsageHref: observable,

--- a/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
@@ -27,6 +27,7 @@ describe('Assignment ', function() {
 				instructionsEditorHtml: () => 'These are your instructions',
 				canEditInstructions: () => true,
 				canEditTurnitin: () => undefined,
+				attachmentsCollectionHref: () => 'http://attachmentsCollectionHref/1',
 				editTurnitinUrl: () => undefined,
 				isOriginalityCheckEnabled: () => undefined,
 				isGradeMarkEnabled: () => undefined,


### PR DESCRIPTION
[US120115](https://rally1.rallydev.com/#/detail/userstory/423726609188?fdp=true): Refactor AssignmentEditorDetail to use activity usage href and remove EntityMixinLit

~Todo:~ Done:
✔️ `attachmentsHref` should be added to the Assignment MobX state
✔️ fix the no undeclared var usage on line 165 of `d2l-activity-assignment-editor-detail.js`

https://rally1.rallydev.com/#/detail/userstory/423726609188/tasks?fdp=true