### PR TITLE
US119264 OSLO: use name instead of the resource path in lang mixins

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/mixins/d2l-activity-assignment-lang-mixin.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/mixins/d2l-activity-assignment-lang-mixin.js
@@ -1,13 +1,12 @@
 import { getLocalizeOverrideResources } from '@brightspace-ui/core/helpers/getLocalizeResources.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
-import { resolveUrl } from '@polymer/polymer/lib/utils/resolve-url.js';
 
 export const LocalizeActivityAssignmentEditorMixin = superclass => class extends LocalizeMixin(superclass) {
 
 	static async getLocalizeResources(langs) {
 
 		function resolveOverridesFunc() {
-			return resolveUrl('../lang/overrides.js', import.meta.url);
+			return 'd2l-activities\\assignmentActivityEditor';
 		}
 
 		let translations;

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-lang-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-lang-mixin.js
@@ -1,13 +1,12 @@
 import { getLocalizeOverrideResources } from '@brightspace-ui/core/helpers/getLocalizeResources.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
-import { resolveUrl } from '@polymer/polymer/lib/utils/resolve-url.js';
 
 export const LocalizeActivityEditorMixin = superclass => class extends LocalizeMixin(superclass) {
 
 	static async getLocalizeResources(langs) {
 
 		function resolveOverridesFunc() {
-			return resolveUrl('../lang/overrides.js', import.meta.url);
+			return 'd2l-activities\\activityEditor';
 		}
 
 		let translations;


### PR DESCRIPTION
Update overrides resolver to use the name/collectionName for collections instead of the resource path
This helps with resolving the issue where the cache resource path includes the BSI version which causes multiple entries in CacheStorage when using different BSI versions.

Jordan is making change in the lms to use the name or collectionName when matching with these instead of what it does currently which is to match on the resource path