### PR TITLE
US120104 Add async skeleton handling to detail/secondary/footer components

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-footer.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-footer.js
@@ -1,16 +1,17 @@
 import '../d2l-activity-editor-buttons.js';
 import '../d2l-activity-visibility-editor.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { SaveStatusMixin } from '../save-status-mixin.js';
 import { SkeletizeMixin } from '../mixins/d2l-skeletize-mixin';
 
-class AssignmentEditorFooter extends SkeletizeMixin(SaveStatusMixin(ActivityEditorMixin(RtlMixin(LocalizeActivityAssignmentEditorMixin(LitElement))))) {
+class AssignmentEditorFooter extends SkeletizeMixin(AsyncContainerMixin(SaveStatusMixin(ActivityEditorMixin(RtlMixin(LocalizeActivityAssignmentEditorMixin(LitElement)))))) {
 
 	static get properties() {
-		return { skeleton: super.properties.skeleton };
+		return { ...super.properties };
 	}
 
 	static get styles() {
@@ -55,6 +56,14 @@ class AssignmentEditorFooter extends SkeletizeMixin(SaveStatusMixin(ActivityEdit
 				<slot name="save-status"></slot>
 			</div>
 		`;
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
+
+		if (changedProperties.has('asyncState')) {
+			this.skeleton = this.asyncState !== asyncStates.complete;
+		}
 	}
 }
 customElements.define('d2l-activity-assignment-editor-footer', AssignmentEditorFooter);

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-secondary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-secondary.js
@@ -3,21 +3,25 @@ import './d2l-activity-assignment-evaluation-editor.js';
 import './d2l-activity-assignment-editor-submission-and-completion.js';
 import '@brightspace-ui/core/components/colors/colors.js';
 import { ActivityEditorFeaturesMixin, Milestones } from '../mixins/d2l-activity-editor-features-mixin.js';
+import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
+import { SkeletizeMixin } from '../mixins/d2l-skeletize-mixin';
 
-class AssignmentEditorSecondary extends ActivityEditorFeaturesMixin(RtlMixin(LocalizeActivityAssignmentEditorMixin(LitElement))) {
+class AssignmentEditorSecondary extends ActivityEditorFeaturesMixin(AsyncContainerMixin(SkeletizeMixin(RtlMixin(LocalizeActivityAssignmentEditorMixin(LitElement))))) {
 
 	static get properties() {
 		return {
-			activityUsageHref: { type: String, attribute: 'activity-usage-href' }
+			activityUsageHref: { type: String, attribute: 'activity-usage-href' },
+			...super.properties
 		};
 	}
 
 	static get styles() {
 		return [
+			super.styles,
 			labelStyles,
 			css`
 				:host {
@@ -48,7 +52,7 @@ class AssignmentEditorSecondary extends ActivityEditorFeaturesMixin(RtlMixin(Loc
 		const showEvaluationAccordian = this._isMilestoneEnabled(Milestones.M2) || this._isMilestoneEnabled(Milestones.M3Competencies);
 
 		const availabilityAccordian = html`
-			<d2l-activity-assignment-availability-editor
+			<d2l-activity-assignment-availability-editor class="d2l-skeletize"
 				.href="${this.activityUsageHref}"
 				.token="${this.token}">
 			</d2l-activity-assignment-availability-editor>
@@ -56,14 +60,16 @@ class AssignmentEditorSecondary extends ActivityEditorFeaturesMixin(RtlMixin(Loc
 
 		const submissionCompletionCategorizationAccordian = showSubmissionCompletionAccordian ? html`
 			<d2l-activity-assignment-editor-submission-and-completion-editor
-				href="${this.href}"
+				class="d2l-skeletize"
+				.href="${this.href}"
 				.token="${this.token}">
 			</d2l-activity-assignment-editor-submission-and-completion-editor>
 		` : null;
 
 		const evaluationAccordian = showEvaluationAccordian ? html`
 			<d2l-activity-assignment-evaluation-editor
-				href="${this.href}"
+				class="d2l-skeletize"
+				.href="${this.href}"
 				.token="${this.token}"
 				.activityUsageHref=${this.activityUsageHref}>
 			</d2l-activity-assignment-evaluation-editor>
@@ -75,6 +81,14 @@ class AssignmentEditorSecondary extends ActivityEditorFeaturesMixin(RtlMixin(Loc
 			${evaluationAccordian}
 		`;
 
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
+
+		if (changedProperties.has('asyncState')) {
+			this.skeleton = this.asyncState !== asyncStates.complete;
+		}
 	}
 
 }

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -38,10 +38,13 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 
 	render() {
 		return html`
+			<!--
 			<div ?hidden="${this.asyncState === asyncStates.complete}" class="d2l-activity-editor-loading">${this.localize('editor.loading')}</div>
-			<div id="editor-container" ?hidden="${this.asyncState !== asyncStates.complete}">
+			-->
+			<div id="editor-container">
 				<slot name="editor"></slot>
 			</div>
+			<!--
 			<d2l-backdrop
 				for-target="editor-container"
 				?shown="${this._backdropShown}"
@@ -49,6 +52,7 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 				delay-transition
 				slow-transition>
 			</d2l-backdrop>
+			-->
 		`;
 	}
 	update(changedProperties) {


### PR DESCRIPTION
https://rally1.rallydev.com/#/detail/userstory/423713247156?fdp=true

## Experimentation with _skeletizing_ components

### Initial problems:

1. Height of some elements & containers (label, dueDate) isn't correct
2. `d2l-activity-assignment-editor-detail` needs some MobX state data to be available to render child components and so skeletize behaviour won't appear until `store.getAssignment(this.href)` completes

### Lint issues:

The ordering rule for imports wants `multiple` import statements to preceed `single` import statements but this tends to conflict with the `alphabetical` imports rule.

### Todo:
- [ ] Initialize the skeleton property to `true` in their constructors instead of using the `SkeletizeMixin`'s default value of `true`