### PR TITLE
DE39907 Add drag-handle-text to list-item-accumulator

### DIFF
--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -658,7 +658,7 @@ class CollectionEditor extends LocalizeActivityCollectionEditor(EntityMixinLit(L
 
 		const items = repeat(this._items, (item) => item.id, item => {
 			return html`
-				<d2l-labs-list-item-accumulator key="${item.id}" draggable>
+				<d2l-labs-list-item-accumulator key="${item.id}" drag-handle-text="${item.name()}" draggable>
 					<div slot="illustration" class="d2l-activitiy-collection-list-item-illustration">
 						${this._renderCourseImageSkeleton()}
 						<d2l-organization-image


### PR DESCRIPTION
Context: 
DE39907 - https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fdefect%2F407158647016
https://github.com/BrightspaceUI/core/pull/815/files#diff-92c305760d9314097acce5f7b54b292bR75 adds `drag-handle-text` to get the item's name. 

Quality:
Tested locally with demo page.
<img width="995" alt="Screen Shot 2020-09-08 at 2 59 08 PM" src="https://user-images.githubusercontent.com/16407009/92517197-4aeb6600-f1e4-11ea-8779-cedaf7bbfffc.png">