### PR TITLE
US120109 - skeletize instructions

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -142,14 +142,16 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(AsyncContainerMixin(Skel
 			</div>
 
 			<div id="assignment-instructions-container">
-				<label class="d2l-label-text">${this.localize('instructions')}</label>
-				<d2l-activity-text-editor
-					.value="${instructions}"
-					.richtextEditorConfig="${instructionsRichTextEditorConfig}"
-					@d2l-activity-text-editor-change="${this._saveInstructionsOnChange}"
-					ariaLabel="${this.localize('instructions')}"
-					?disabled="${!canEditInstructions}">
-				</d2l-activity-text-editor>
+				<label class="d2l-label-text d2l-skeletize">${this.localize('instructions')}</label>
+				<div class="d2l-skeletize">
+					<d2l-activity-text-editor
+						.value="${instructions}"
+						.richtextEditorConfig="${instructionsRichTextEditorConfig}"
+						@d2l-activity-text-editor-change="${this._saveInstructionsOnChange}"
+						ariaLabel="${this.localize('instructions')}"
+						?disabled="${!canEditInstructions}">
+					</d2l-activity-text-editor>
+				</div>
 			</div>
 
 			<div id="assignment-attachments-editor-container" ?hidden="${!attachmentsHref}">


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F423713964720

I'm having trouble seeing the issue below, but this change may result in the issue below, where...
> the skeleton is initially being rendered before tinymce has initialized the div we provide to it to create it's contenteditable. That div is initially only about 42px and then when tinymce intializes it grows maybe because we set minrows or something on tinymce.

We shall see how this performs on QUAD.