### PR TITLE
US120110 skeletize attachments

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -156,7 +156,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(AsyncContainerMixin(Skel
 
 			<div id="assignment-attachments-editor-container" ?hidden="${!attachmentsHref}">
 				<d2l-activity-attachments-editor
-					.skeleton="${this.skeleton}"
+					?skeleton="${this.skeleton}"
 					href="${attachmentsHref}"
 					.token="${this.token}">
 				</d2l-activity-attachments-editor>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -153,6 +153,7 @@ class AssignmentEditorDetail extends ErrorHandlingMixin(AsyncContainerMixin(Skel
 
 			<div id="assignment-attachments-editor-container" ?hidden="${!attachmentsHref}">
 				<d2l-activity-attachments-editor
+					.skeleton="${this.skeleton}"
 					href="${attachmentsHref}"
 					.token="${this.token}">
 				</d2l-activity-attachments-editor>

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
@@ -3,13 +3,13 @@ import './d2l-activity-attachments-picker';
 import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
+import { SkeletizeMixin } from '../mixins/d2l-skeletize-mixin';
 import { shared as store } from './state/attachment-collections-store.js';
 
-class ActivityAttachmentsEditor extends ActivityEditorMixin(MobxLitElement) {
+class ActivityAttachmentsEditor extends ActivityEditorMixin(SkeletizeMixin(MobxLitElement)) {
 	static get properties() {
 		return {
 			_canAddAttachments: { type: Boolean },
-			skeleton: { type: Boolean }
 		};
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
@@ -26,7 +26,6 @@ class ActivityAttachmentsEditor extends ActivityEditorMixin(SkeletizeMixin(MobxL
 	}
 
 	render() {
-		console.log("Rendering in ActivityAttachmentsEditor. this.skeleton", this.skeleton);
 		const collection = store.get(this.href);
 		if (!collection) {
 			return html``;
@@ -45,6 +44,7 @@ class ActivityAttachmentsEditor extends ActivityEditorMixin(SkeletizeMixin(MobxL
 		</d2l-activity-attachments-list>
 			${canAddAttachments ? html`
 		<d2l-activity-attachments-picker
+			?skeleton="${this.skeleton}"
 			href="${this.href}"
 			.token="${this.token}"
 		>

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
@@ -35,22 +35,20 @@ class ActivityAttachmentsEditor extends ActivityEditorMixin(MobxLitElement) {
 			canAddAttachments,
 		} = collection;
 
-		return html`${!this.skeleton ?
-			html`<d2l-activity-attachments-list
-				href="${this.href}"
-				.token="${this.token}">
-			</d2l-activity-attachments-list>`
-			: html``}
-
+		return html`<d2l-activity-attachments-list
+			?hidden="${this.skeleton}"
+			href="${this.href}"
+			.token="${this.token}">
+		</d2l-activity-attachments-list>
 			${canAddAttachments ? html`
-				<d2l-activity-attachments-picker
-					href="${this.href}"
-					.token="${this.token}"
-					.skeleton="${this.skeleton}"
-				>
-				</d2l-activity-attachments-picker>
-			` : html``}
-		`;
+		<d2l-activity-attachments-picker
+			href="${this.href}"
+			.token="${this.token}"
+			.skeleton="${this.skeleton}"
+		>
+		</d2l-activity-attachments-picker>
+	` : html``}
+`;
 	}
 
 	hasPendingChanges() {

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
@@ -8,7 +8,8 @@ import { shared as store } from './state/attachment-collections-store.js';
 class ActivityAttachmentsEditor extends ActivityEditorMixin(MobxLitElement) {
 	static get properties() {
 		return {
-			_canAddAttachments: { type: Boolean }
+			_canAddAttachments: { type: Boolean },
+			skeleton: { type: Boolean }
 		};
 	}
 
@@ -34,19 +35,20 @@ class ActivityAttachmentsEditor extends ActivityEditorMixin(MobxLitElement) {
 			canAddAttachments,
 		} = collection;
 
-		return html`
-			<d2l-activity-attachments-list
+		return html`${!this.skeleton ?
+			html`<d2l-activity-attachments-list
 				href="${this.href}"
 				.token="${this.token}">
-			</d2l-activity-attachments-list>
+			</d2l-activity-attachments-list>`
+			: html``}
 
-			${canAddAttachments	?	html`
+			${canAddAttachments ? html`
 				<d2l-activity-attachments-picker
 					href="${this.href}"
 					.token="${this.token}"
 				>
 				</d2l-activity-attachments-picker>
-			` :	html``}
+			` : html``}
 		`;
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
@@ -26,6 +26,7 @@ class ActivityAttachmentsEditor extends ActivityEditorMixin(SkeletizeMixin(MobxL
 	}
 
 	render() {
+		console.log("Rendering in ActivityAttachmentsEditor. this.skeleton", this.skeleton);
 		const collection = store.get(this.href);
 		if (!collection) {
 			return html``;
@@ -33,7 +34,9 @@ class ActivityAttachmentsEditor extends ActivityEditorMixin(SkeletizeMixin(MobxL
 
 		const {
 			canAddAttachments,
-		} = collection;
+		} = collection || {
+			canAddAttachments: true
+		};
 
 		return html`<d2l-activity-attachments-list
 			?hidden="${this.skeleton}"
@@ -44,7 +47,6 @@ class ActivityAttachmentsEditor extends ActivityEditorMixin(SkeletizeMixin(MobxL
 		<d2l-activity-attachments-picker
 			href="${this.href}"
 			.token="${this.token}"
-			.skeleton="${this.skeleton}"
 		>
 		</d2l-activity-attachments-picker>
 	` : html``}

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
@@ -46,6 +46,7 @@ class ActivityAttachmentsEditor extends ActivityEditorMixin(MobxLitElement) {
 				<d2l-activity-attachments-picker
 					href="${this.href}"
 					.token="${this.token}"
+					.skeleton="${this.skeleton}"
 				>
 				</d2l-activity-attachments-picker>
 			` : html``}

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-list.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-list.js
@@ -38,7 +38,7 @@ class ActivityAttachmentsList extends ActivityEditorMixin(MobxLitElement) {
 		} = collection;
 
 		return html`
-			<d2l-labs-attachment-list ?editing="${canAddAttachments}" ?hidden="${this.skeleton}">
+			<d2l-labs-attachment-list ?editing="${canAddAttachments}">
 				${repeat(attachments, href => href, href => html`
 					<li slot="attachment" class="panel">
 						<d2l-activity-attachment

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-list.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-list.js
@@ -16,6 +16,9 @@ class ActivityAttachmentsList extends ActivityEditorMixin(MobxLitElement) {
 			d2l-activity-attachment {
 				margin-bottom: 20px;
 			}
+			:host([hidden]) {
+				display: none;
+			}
 		`;
 	}
 
@@ -35,7 +38,7 @@ class ActivityAttachmentsList extends ActivityEditorMixin(MobxLitElement) {
 		} = collection;
 
 		return html`
-			<d2l-labs-attachment-list ?editing="${canAddAttachments}">
+			<d2l-labs-attachment-list ?editing="${canAddAttachments}" ?hidden="${this.skeleton}">
 				${repeat(attachments, href => href, href => html`
 					<li slot="attachment" class="panel">
 						<d2l-activity-attachment

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -14,7 +14,7 @@ import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin';
 import { SkeletizeMixin } from '../mixins/d2l-skeletize-mixin';
 import { shared as store } from './state/attachment-collections-store.js';
 
-class ActivityAttachmentsPicker extends SkeletizeMixin(ActivityEditorMixin(LocalizeActivityEditorMixin(RtlMixin(MobxLitElement)))) {
+class ActivityAttachmentsPicker extends ActivityEditorMixin(SkeletizeMixin(LocalizeActivityEditorMixin(RtlMixin(MobxLitElement)))) {
 
 	static get styles() {
 		return [super.styles, css`
@@ -88,7 +88,7 @@ class ActivityAttachmentsPicker extends SkeletizeMixin(ActivityEditorMixin(Local
 			}));
 		};
 		// Referenced by the server-side ActivitiesView renderer
-		D2L.ActivityEditor.RecordVideoDialogCallback = async(file) => {
+		D2L.ActivityEditor.RecordVideoDialogCallback = async (file) => {
 			const collection = store.get(this.href);
 			const previewUrl = await collection.getPreviewUrl(file.FileSystemType, file.FileId);
 			this._addToCollection(attachmentStore.createVideo(file.FileName, file.FileSystemType, file.FileId, previewUrl));
@@ -98,7 +98,7 @@ class ActivityAttachmentsPicker extends SkeletizeMixin(ActivityEditorMixin(Local
 			}));
 		};
 		// Referenced by the server-side ActivitiesView renderer
-		D2L.ActivityEditor.RecordAudioDialogCallback = async(file) => {
+		D2L.ActivityEditor.RecordAudioDialogCallback = async (file) => {
 			const collection = store.get(this.href);
 			const previewUrl = await collection.getPreviewUrl(file.FileSystemType, file.FileId);
 			this._addToCollection(attachmentStore.createAudio(file.FileName, file.FileSystemType, file.FileId, previewUrl));
@@ -110,6 +110,7 @@ class ActivityAttachmentsPicker extends SkeletizeMixin(ActivityEditorMixin(Local
 	}
 
 	render() {
+		console.log("Rendering in ActivityAttachmentsPicker. this.skeleton = ", this.skeleton);
 		const collection = store.get(this.href);
 		if (!collection) {
 			return html``;

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -31,8 +31,8 @@ class ActivityAttachmentsPicker extends SkeletizeMixin(ActivityEditorMixin(Local
 			.d2l-button-container {
 				display: flex;
 				flex-direction: row;
-				width: 100%;
 				padding: 12px;
+				width: 100%;
 			}
 
 			.d2l-button-container-right {
@@ -88,7 +88,7 @@ class ActivityAttachmentsPicker extends SkeletizeMixin(ActivityEditorMixin(Local
 			}));
 		};
 		// Referenced by the server-side ActivitiesView renderer
-		D2L.ActivityEditor.RecordVideoDialogCallback = async(file) => {
+		D2L.ActivityEditor.RecordVideoDialogCallback = async (file) => {
 			const collection = store.get(this.href);
 			const previewUrl = await collection.getPreviewUrl(file.FileSystemType, file.FileId);
 			this._addToCollection(attachmentStore.createVideo(file.FileName, file.FileSystemType, file.FileId, previewUrl));
@@ -98,7 +98,7 @@ class ActivityAttachmentsPicker extends SkeletizeMixin(ActivityEditorMixin(Local
 			}));
 		};
 		// Referenced by the server-side ActivitiesView renderer
-		D2L.ActivityEditor.RecordAudioDialogCallback = async(file) => {
+		D2L.ActivityEditor.RecordAudioDialogCallback = async (file) => {
 			const collection = store.get(this.href);
 			const previewUrl = await collection.getPreviewUrl(file.FileSystemType, file.FileId);
 			this._addToCollection(attachmentStore.createAudio(file.FileName, file.FileSystemType, file.FileId, previewUrl));

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -11,12 +11,13 @@ import { shared as attachmentStore } from './state/attachment-store.js';
 import { LocalizeActivityEditorMixin } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin';
+import { SkeletizeMixin } from '../mixins/d2l-skeletize-mixin';
 import { shared as store } from './state/attachment-collections-store.js';
 
-class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeActivityEditorMixin(RtlMixin(MobxLitElement))) {
+class ActivityAttachmentsPicker extends SkeletizeMixin(ActivityEditorMixin(LocalizeActivityEditorMixin(RtlMixin(MobxLitElement)))) {
 
 	static get styles() {
-		return css`
+		return [super.styles, css`
 			:host {
 				align-items: center;
 				background: var(--d2l-color-regolith);
@@ -25,13 +26,13 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeActivityEdit
 				display: flex;
 				flex-direction: row;
 				justify-content: space-between;
-				padding: 12px;
 			}
 
 			.d2l-button-container {
 				display: flex;
 				flex-direction: row;
 				width: 100%;
+				padding: 12px;
 			}
 
 			.d2l-button-container-right {
@@ -63,11 +64,12 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeActivityEdit
 					display: block;
 				}
 			}
-		`;
+		`];
 	}
 
 	constructor() {
 		super(store);
+		this.skeleton = true;
 
 		D2L.ActivityEditor = D2L.ActivityEditor || {};
 		// Referenced by the server-side ActivitiesView renderer
@@ -124,7 +126,7 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(LocalizeActivityEdit
 		} = collection;
 
 		return html`
-			<div class="d2l-button-container">
+			<div class="d2l-button-container d2l-skeletize">
 				<d2l-button-icon
 					id="add-file-button"
 					icon="d2l-tier1:upload"

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -69,7 +69,6 @@ class ActivityAttachmentsPicker extends SkeletizeMixin(ActivityEditorMixin(Local
 
 	constructor() {
 		super(store);
-		this.skeleton = true;
 
 		D2L.ActivityEditor = D2L.ActivityEditor || {};
 		// Referenced by the server-side ActivitiesView renderer

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -88,7 +88,7 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(SkeletizeMixin(Local
 			}));
 		};
 		// Referenced by the server-side ActivitiesView renderer
-		D2L.ActivityEditor.RecordVideoDialogCallback = async (file) => {
+		D2L.ActivityEditor.RecordVideoDialogCallback = async(file) => {
 			const collection = store.get(this.href);
 			const previewUrl = await collection.getPreviewUrl(file.FileSystemType, file.FileId);
 			this._addToCollection(attachmentStore.createVideo(file.FileName, file.FileSystemType, file.FileId, previewUrl));
@@ -98,7 +98,7 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(SkeletizeMixin(Local
 			}));
 		};
 		// Referenced by the server-side ActivitiesView renderer
-		D2L.ActivityEditor.RecordAudioDialogCallback = async (file) => {
+		D2L.ActivityEditor.RecordAudioDialogCallback = async(file) => {
 			const collection = store.get(this.href);
 			const previewUrl = await collection.getPreviewUrl(file.FileSystemType, file.FileId);
 			this._addToCollection(attachmentStore.createAudio(file.FileName, file.FileSystemType, file.FileId, previewUrl));
@@ -110,7 +110,6 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(SkeletizeMixin(Local
 	}
 
 	render() {
-		console.log("Rendering in ActivityAttachmentsPicker. this.skeleton = ", this.skeleton);
 		const collection = store.get(this.href);
 		if (!collection) {
 			return html``;

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -88,7 +88,7 @@ class ActivityAttachmentsPicker extends SkeletizeMixin(ActivityEditorMixin(Local
 			}));
 		};
 		// Referenced by the server-side ActivitiesView renderer
-		D2L.ActivityEditor.RecordVideoDialogCallback = async (file) => {
+		D2L.ActivityEditor.RecordVideoDialogCallback = async(file) => {
 			const collection = store.get(this.href);
 			const previewUrl = await collection.getPreviewUrl(file.FileSystemType, file.FileId);
 			this._addToCollection(attachmentStore.createVideo(file.FileName, file.FileSystemType, file.FileId, previewUrl));
@@ -98,7 +98,7 @@ class ActivityAttachmentsPicker extends SkeletizeMixin(ActivityEditorMixin(Local
 			}));
 		};
 		// Referenced by the server-side ActivitiesView renderer
-		D2L.ActivityEditor.RecordAudioDialogCallback = async (file) => {
+		D2L.ActivityEditor.RecordAudioDialogCallback = async(file) => {
 			const collection = store.get(this.href);
 			const previewUrl = await collection.getPreviewUrl(file.FileSystemType, file.FileId);
 			this._addToCollection(attachmentStore.createAudio(file.FileName, file.FileSystemType, file.FileId, previewUrl));

--- a/components/d2l-activity-editor/mixins/d2l-skeletize-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-skeletize-mixin.js
@@ -26,7 +26,7 @@ export const SkeletizeMixin = superclass => class extends superclass {
 			position: absolute;
 			right: 0;
 			top: 0;
-			z-index: 2000;
+			z-index: 1;
 		}
 		:host([skeleton]) .d2l-skeletize {
 			border: none;


### PR DESCRIPTION
- Based on comments in the [user story ](https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F423713966144), I made `<d2l-activity-attachments-list>` display conditionally depending on the value of `this.skeleton`. 

- In `<d2l-activity-attachments-picker>` I had to move the padding from :host to `.d2l-button-container` to get the skeleton view to take up all of the attachments container

