### PR TITLE
Improve test stability for d2l-activity-availability-dates-editor

### DIFF
--- a/test/d2l-activity-editor/d2l-activity-availability-dates-editor.test.js
+++ b/test/d2l-activity-editor/d2l-activity-availability-dates-editor.test.js
@@ -1,5 +1,5 @@
 import '../../components/d2l-activity-editor/d2l-activity-availability-dates-editor';
-import { elementUpdated, expect, fixture, html, nextFrame } from '@open-wc/testing';
+import { elementUpdated, expect, fixture, html, nextFrame, waitUntil } from '@open-wc/testing';
 import { ActivityDates } from '../../components/d2l-activity-editor/state/activity-dates';
 import { ActivityUsage } from '../../components/d2l-activity-editor/state/activity-usage.js';
 import { shared as store } from '../../components/d2l-activity-editor/state/activity-store.js';
@@ -78,24 +78,19 @@ describe('d2l-activity-availability-dates-editor', function() {
 	describe('invalid state', function() {
 		it('sets start date to be invalid for given error', async() => {
 			dates.setErrorLangTerms('start-after-due-date-error');
-			await nextFrame();
-			await elementUpdated(el);
 
-			expect(startDateInput.invalid).to.be.true;
+			await waitUntil(() => startDateInput.invalid, 'Start date did not become invalid');
 			expect(endDateInput.invalid).to.be.false;
 		});
 		it('sets end date to be invalid for given error', async() => {
 			dates.setErrorLangTerms('end-before-due-date-error');
-			await nextFrame();
-			await elementUpdated(el);
 
+			await waitUntil(() => endDateInput.invalid, 'End date did not become invalid');
 			expect(startDateInput.invalid).to.be.false;
-			expect(endDateInput.invalid).to.be.true;
 		});
 		it('sets start and end date to be invalid for given error', async() => {
 			dates.setErrorLangTerms('end-before-start-due-date-error');
 			await nextFrame();
-			await elementUpdated(el);
 
 			expect(startDateInput.invalid).to.be.true;
 			expect(endDateInput.invalid).to.be.true;
@@ -103,14 +98,12 @@ describe('d2l-activity-availability-dates-editor', function() {
 		it('clears invalid state', async() => {
 			dates.setErrorLangTerms('end-before-start-due-date-error');
 			await nextFrame();
-			await elementUpdated(el);
 
 			expect(startDateInput.invalid).to.be.true;
 			expect(endDateInput.invalid).to.be.true;
 
 			dates.setErrorLangTerms();
 			await nextFrame();
-			await elementUpdated(el);
 
 			expect(startDateInput.invalid).to.be.false;
 			expect(endDateInput.invalid).to.be.false;


### PR DESCRIPTION
I was noticing some test flakes on these tests which I introduced a few days ago. The extra `await elementUpdated(el);` were not helping after all, but using the `waitUntil(successPredicate, failText)` helper seems to do the trick for the problematic tests.