### PR TITLE
US118988 Disable assignment loading shim to see skeleton loading

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -41,6 +41,13 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 			<div id="editor-container">
 				<slot name="editor"></slot>
 			</div>
+			<d2l-backdrop
+				for-target="editor-container"
+				?shown="${this._backdropShown}"
+				no-animate-hide
+				delay-transition
+				slow-transition>
+			</d2l-backdrop>
 		`;
 	}
 	update(changedProperties) {

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -38,17 +38,9 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 
 	render() {
 		return html`
-			<div ?hidden="${this.asyncState === asyncStates.complete}" class="d2l-activity-editor-loading">${this.localize('editor.loading')}</div>
-			<div id="editor-container" ?hidden="${this.asyncState !== asyncStates.complete}">
+			<div id="editor-container">
 				<slot name="editor"></slot>
 			</div>
-			<d2l-backdrop
-				for-target="editor-container"
-				?shown="${this._backdropShown}"
-				no-animate-hide
-				delay-transition
-				slow-transition>
-			</d2l-backdrop>
 		`;
 	}
 	update(changedProperties) {


### PR DESCRIPTION
https://rally1.rallydev.com/#/detail/userstory/408693111172?fdp=true

**This removes the logic that shows the "Loading..." text and shim** to observe the `skeleton` behaviour