### PR TITLE
Set date inputs default time to be end-of-day

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -1,9 +1,9 @@
 import '@brightspace-ui/core/components/button/button';
 import '@brightspace-ui/core/components/colors/colors';
-import 'd2l-tooltip/d2l-tooltip';
-import 'd2l-menu/d2l-menu.js';
-import 'd2l-dropdown/d2l-dropdown.js';
-import 'd2l-dropdown/d2l-dropdown-menu.js';
+import '@brightspace-ui/core/components/dropdown/dropdown';
+import '@brightspace-ui/core/components/dropdown/dropdown-menu';
+import '@brightspace-ui/core/components/tooltip/tooltip';
+import '@brightspace-ui/core/components/menu/menu';
 
 import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';

--- a/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
@@ -41,6 +41,7 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeActiv
 			<d2l-input-date-time
 				id="start-date-input"
 				label="${this.localize('editor.startDate')}"
+				time-default-value="endOfDay"
 				value="${startDate}"
 				@change="${this._onStartDatetimeChanged}">
 			</d2l-input-date-time>
@@ -52,6 +53,7 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeActiv
 			<d2l-input-date-time
 				id="end-date-input"
 				label="${this.localize('editor.endDate')}"
+				time-default-value="endOfDay"
 				value="${endDate}"
 				@change="${this._onEndDatetimeChanged}">
 			</d2l-input-date-time>

--- a/components/d2l-activity-editor/d2l-activity-conditions-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-conditions-editor.js
@@ -1,7 +1,7 @@
 import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/icons/icon.js';
-import 'd2l-dropdown/d2l-dropdown-button-subtle.js';
-import 'd2l-dropdown/d2l-dropdown-menu.js';
+import '@brightspace-ui/core/components/dropdown/dropdown-button-subtle.js';
+import '@brightspace-ui/core/components/dropdown/dropdown-menu.js';
 import '@brightspace-ui/core/components/menu/menu.js';
 import '@brightspace-ui/core/components/menu/menu-item.js';
 import { bodyCompactStyles, bodySmallStyles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';

--- a/components/d2l-activity-editor/d2l-activity-due-date-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-due-date-editor.js
@@ -36,6 +36,7 @@ class ActivityDueDateEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 			<d2l-input-date-time
 				id="due-date-input"
 				label="${this.localize('editor.dueDate')}"
+				time-default-value="endOfDay"
 				value="${dueDate}"
 				@change="${this._onDatetimeChanged}">
 			</d2l-input-date-time>

--- a/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-action-button-more.js
+++ b/components/d2l-quick-eval/activity-card/d2l-quick-eval-activity-card-action-button-more.js
@@ -1,8 +1,8 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { LitQuickEvalLocalize } from '../LitQuickEvalLocalize.js';
-import 'd2l-dropdown/d2l-dropdown.js';
-import 'd2l-dropdown/d2l-dropdown-menu.js';
-import 'd2l-menu/d2l-menu.js';
+import '@brightspace-ui/core/components/dropdown/dropdown.js';
+import '@brightspace-ui/core/components/dropdown/dropdown-menu.js';
+import '@brightspace-ui/core/components/menu/menu.js';
 import './d2l-quick-eval-activity-card-action-button.js';
 
 class D2LQuickEvalActivityCardActionButtonMore extends LitQuickEvalLocalize(LitElement) {
@@ -25,7 +25,7 @@ class D2LQuickEvalActivityCardActionButtonMore extends LitQuickEvalLocalize(LitE
 	render() {
 		return html`
 			<d2l-dropdown text="${this.localize('moreActions')}">
-				<d2l-quick-eval-activity-card-action-button 
+				<d2l-quick-eval-activity-card-action-button
 					icon-full-name="tier1:more"
 					text="${this.localize('moreActions')}"
 					class="d2l-dropdown-opener"

--- a/components/d2l-quick-eval/dismiss/d2l-quick-eval-ellipsis-menu.js
+++ b/components/d2l-quick-eval/dismiss/d2l-quick-eval-ellipsis-menu.js
@@ -1,9 +1,9 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { LitQuickEvalLocalize } from '../LitQuickEvalLocalize.js';
-import 'd2l-dropdown/d2l-dropdown-more.js';
-import 'd2l-dropdown/d2l-dropdown-menu.js';
-import 'd2l-menu/d2l-menu.js';
-import 'd2l-menu/d2l-menu-item.js';
+import '@brightspace-ui/core/components/dropdown/dropdown-more.js';
+import '@brightspace-ui/core/components/dropdown/dropdown-menu.js';
+import '@brightspace-ui/core/components/menu/menu.js';
+import '@brightspace-ui/core/components/menu/menu-item.js';
 import './d2l-quick-eval-dismissed-activities.js';
 
 class D2LQuickEvalEllipsisMenu extends LitQuickEvalLocalize(LitElement) {


### PR DESCRIPTION
Uses new attribute on `input-date-time` to set the default time to 11:59 PM. Also cleaned up some legacy imports that were flying around.