### PR TITLE
Enable immediate render of assignment editor for skeleton behaviour

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -187,15 +187,11 @@ class AssignmentEditor extends ActivityEditorContainerMixin(AsyncContainerMixin(
 	}
 	get _editorTemplate() {
 		const activity = store.getActivity(this.href);
-		if (!activity) {
-			return html``;
-		}
-
 		const {
 			assignmentHref
-		} = activity;
+		} = activity || {};
 
-		const assignment = store.getAssignment(activity.assignmentHref);
+		const assignment = store.getAssignment(assignmentHref);
 		const hasSubmissions = assignment && assignment.submissionAndCompletionProps.assignmentHasSubmissions;
 
 		return html`


### PR DESCRIPTION
Allow immediate rendering of editor before any data has loaded.
https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F423713959428
