### PR TITLE
CanEditAssignmentType was always incorrectly being set to true

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-type.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-type.js
@@ -8,7 +8,7 @@ export class AssignmentTypeProps {
 		this.isGroupAssignmentTypeDisabled = entity.isGroupAssignmentTypeDisabled;
 		this.isIndividualAssignmentType = entity.isIndividualAssignmentType;
 		this.groupCategories = entity.groupCategories;
-		this.canEditAssignmentType = !entity.isAssignmentTypeReadOnly;
+		this.canEditAssignmentType = entity.canEditAssignmentType;
 		this.selectedGroupCategoryName = entity.selectedGroupCategoryName;
 
 		if (!this.isIndividualAssignmentType && this.groupCategories.length > 0) {


### PR DESCRIPTION
The `entity.isAssignmentTypeReadOnly` is always `undefined`, because it's supposed to reference `canEditAssignmentType` instead.
https://trello.com/c/IAuUOFA2/2-assignment-type-not-properly-disabled-when-submission-present-or-user-lacks-permission