### PR TITLE
Fix date pickers not being focused on after error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 /test/**/screenshots/current/
 /test/**/screenshots/golden/
 .DS_Store
+debug.log

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
@@ -72,9 +72,10 @@ export const ActivityEditorContainerMixin = superclass => class extends Activity
 
 		this.dispatchEvent(this.cancelCompleteEvent);
 	}
-	_focusOnInvalid() {
+	async _focusOnInvalid() {
 		const isAriaInvalid = node => node.getAttribute('aria-invalid') === 'true' && node.getClientRects().length > 0 && !this._hasSkipAlertAncestor(node);
 		for (const editor of this._editors) {
+			await editor.updateComplete;
 			const el = getFirstFocusableDescendant(editor, true, isAriaInvalid);
 			if (el) {
 				el.focus();
@@ -110,7 +111,8 @@ export const ActivityEditorContainerMixin = superclass => class extends Activity
 		}
 
 		// Catch both client- and server-side validation errors
-		if (this._focusOnInvalid()) {
+		const isInvalid = await this._focusOnInvalid();
+		if (isInvalid) {
 			this.isError = true;
 			this.isSaving = false;
 			return;


### PR DESCRIPTION
https://trello.com/c/eaKbY60m/252-new-date-time-inputs-do-not-get-focus-on-validation-error

The new validation workflow delays the setting of the aria-invalid property by a little bit, so we need to wait for the editor to finish updating before checking the invalid state.