### PR TITLE
Remove references to var keyword

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -326,7 +326,7 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 						this._updateSearchResultsCount(this._data.length);
 					}
 				} catch (e) {
-				// Unable to load more activities from entity.
+					console.error('Unable to load more activities from entity.');
 					throw e;
 				} finally {
 					this._loadingMore = false;

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "chai": "^4.2.0",
     "chai-a11y-axe": "^1.2.2",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^5.1.0",
+    "eslint": "^7.9.0",
     "eslint-config-brightspace": "^0.10.0",
     "eslint-plugin-html": "^6.0.0",
     "eslint-plugin-lit": "^1.2.0",

--- a/scripts/remove_attest_from_project.js
+++ b/scripts/remove_attest_from_project.js
@@ -1,10 +1,9 @@
-/* global require */
-const fs = require('fs');
+import { readFileSync, writeFileSync } from 'fs';
 //read in the package file
-const file_contents = JSON.parse(fs.readFileSync('package.json'));
+const file_contents = JSON.parse(readFileSync('package.json'));
 if ('dependencies' in file_contents) {
 	if ('attest' in file_contents.dependencies) {
 		delete file_contents.dependencies.attest;
 	}
 }
-fs.writeFileSync('package.json', JSON.stringify(file_contents, null, '\t'));
+writeFileSync('package.json', JSON.stringify(file_contents, null, '\t'));

--- a/test/d2l-activity-card/d2l-activity-card-test.js
+++ b/test/d2l-activity-card/d2l-activity-card-test.js
@@ -1,7 +1,7 @@
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 describe('d2l-activity-card', () => {
 
-	var component,
+	let component,
 		fetchStub,
 		sandbox,
 		activityEntity,

--- a/test/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.js
+++ b/test/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon-base.js
@@ -15,7 +15,7 @@
 		test('activity evaluation without any attribute does not display an icon', function(done) {
 			flush(function() {
 
-				var icon = invalidEvaluation.shadowRoot.querySelector('d2l-icon');
+				const icon = invalidEvaluation.shadowRoot.querySelector('d2l-icon');
 				assert.equal(null, icon);
 
 				done();
@@ -25,11 +25,11 @@
 		test('activity evaluation with draft attribute displayed draft icon with tooltip', function(done) {
 			flush(function() {
 
-				var draftIcon = draftEvaluation.shadowRoot.querySelector('d2l-icon');
-				var draftIconName = draftIcon.getAttribute('icon');
+				const draftIcon = draftEvaluation.shadowRoot.querySelector('d2l-icon');
+				const draftIconName = draftIcon.getAttribute('icon');
 				assert.equal('d2l-tier1:draft', draftIconName);
 
-				var draftIconToolTip = draftEvaluation.shadowRoot.querySelector('d2l-tooltip');
+				const draftIconToolTip = draftEvaluation.shadowRoot.querySelector('d2l-tooltip');
 				assert.equal('bottom', draftIconToolTip.getAttribute('position'));
 				assert.equal('15', draftIconToolTip.getAttribute('offset'));
 

--- a/test/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon.js
+++ b/test/d2l-activity-evaluation-icon/d2l-activity-evaluation-icon.js
@@ -1,13 +1,13 @@
 (function() {
 
 	async function loadPromise(url, activityEvaluationIconComponent) {
-		var entity = await window.D2L.Siren.EntityStore.fetch(url, '');
+		const entity = await window.D2L.Siren.EntityStore.fetch(url, '');
 		await activityEvaluationIconComponent._configureBase(entity.entity);
 		return activityEvaluationIconComponent;
 	}
 
 	suite('d2l-activity-evaluation-icon', function() {
-		var evaluationIcon;
+		let evaluationIcon;
 
 		setup(function() {
 			window.D2L.Siren.WhitelistBehavior._testMode(true);
@@ -21,7 +21,7 @@
 		test('base configured as draft when data indicates evaluation in draft state', function(done) {
 			loadPromise('data/activity-draft.json', evaluationIcon)
 				.then(function(configuredEvaluationIcon) {
-					var baseIcon = configuredEvaluationIcon.shadowRoot.querySelector('d2l-activity-evaluation-icon-base');
+					const baseIcon = configuredEvaluationIcon.shadowRoot.querySelector('d2l-activity-evaluation-icon-base');
 					assert.equal(true, baseIcon.hasAttribute('draft'));
 					done();
 				});
@@ -32,7 +32,7 @@
 			loadPromise('data/activity-no-evaluation.json', evaluationIcon)
 				.then(function(configuredEvaluationIcon) {
 
-					var baseIcon = configuredEvaluationIcon.shadowRoot.querySelector('d2l-activity-evaluation-icon-base');
+					const baseIcon = configuredEvaluationIcon.shadowRoot.querySelector('d2l-activity-evaluation-icon-base');
 					assert.equal(false, baseIcon.hasAttribute('draft'));
 					done();
 				});

--- a/test/d2l-activity-list-item/d2l-activity-list-item-test.js
+++ b/test/d2l-activity-list-item/d2l-activity-list-item-test.js
@@ -1,7 +1,7 @@
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 describe('d2l-activity-list-item', () => {
 
-	var component,
+	let component,
 		fetchStub,
 		sandbox,
 		activityEntity,
@@ -182,7 +182,7 @@ describe('d2l-activity-list-item', () => {
 			});
 			afterNextRender(component, () => {
 				expect(component._accessibilityData.organizationName).to.equal('Course name');
-				var accessibilityText = component.$$('.d2l-activity-list-item-link-text').innerHTML;
+				const accessibilityText = component.$$('.d2l-activity-list-item-link-text').innerHTML;
 				expect(accessibilityText).to.contain('Course name');
 				done();
 			});
@@ -194,7 +194,7 @@ describe('d2l-activity-list-item', () => {
 			component = fixture('d2l-activity-list-item-responsive-384-fixture');
 			afterNextRender(component, () => {
 				expect(component._showDescription).to.be.false;
-				var description = component.$$('#d2l-activity-list-item-description');
+				const description = component.$$('#d2l-activity-list-item-description');
 				expect(description.hasAttribute('hidden')).to.be.true;
 				done();
 			});
@@ -203,11 +203,11 @@ describe('d2l-activity-list-item', () => {
 		it('Description is not hidden at width 385', done => {
 			component = fixture('d2l-activity-list-item-responsive-385-fixture');
 			expect(component._showDescription).to.be.true;
-			var description = component.$$('#d2l-activity-list-item-description');
+			let description = component.$$('#d2l-activity-list-item-description');
 			expect(description.hasAttribute('hidden')).to.be.false;
 			afterNextRender(component, () => {
 				expect(component._showDescription).to.be.true;
-				var description = component.$$('#d2l-activity-list-item-description');
+				description = component.$$('#d2l-activity-list-item-description');
 				expect(description.hasAttribute('hidden')).to.be.false;
 				done();
 			});

--- a/test/d2l-quick-eval/behaviors/d2l-quick-eval-siren-helper-behavior.js
+++ b/test/d2l-quick-eval/behaviors/d2l-quick-eval-siren-helper-behavior.js
@@ -1,7 +1,7 @@
 import SirenParse from 'siren-parser';
 
 (function() {
-	var component;
+	let component;
 
 	suite('d2l-quick-eval-siren-helper-behavior', function() {
 		setup(function() {

--- a/test/d2l-quick-eval/behaviors/d2l-quick-eval-telemetry-behavior.js
+++ b/test/d2l-quick-eval/behaviors/d2l-quick-eval-telemetry-behavior.js
@@ -1,7 +1,6 @@
 import 'd2l-telemetry-browser-client/d2l-telemetry-browser-client.js';
 (function() {
-	var telemetryBehaviour;
-	let sandbox;
+	let sandbox, telemetryBehaviour;
 
 	suite('d2l-quick-eval-telemetry-behavior', function() {
 		setup(function() {

--- a/test/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
+++ b/test/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
@@ -1,5 +1,5 @@
 (function() {
-	var component;
+	let component;
 
 	suite('d2l-quick-eval-siren-helper-behavior', function() {
 		setup(function() {
@@ -152,18 +152,18 @@
 		suite('parsing url (_getExtraParams)', function() {
 			test('when parsing url for sort and filter params and url is null, return empty array', () => {
 
-				var params = component._getExtraParams('');
+				const params = component._getExtraParams('');
 				assert.equal(params.length, 0);
 			});
 			test('when parsing url for sort and filter params and url is null, return empty array', () => {
 
-				var params = component._getExtraParams(null);
+				const params = component._getExtraParams(null);
 				assert.equal(params.length, 0);
 			});
 			test('when parsing url for sort, filter, and collectionSearch params, if they are all present, return array with correct values', () => {
 				const url = 'https://www.example.com/?pageSize=20&filter=96W3siU29ydCI6eyJJ&sort=Y3Rpb24iOjB9&collectionSearch=arthas';
 
-				var params = component._getExtraParams(url);
+				const params = component._getExtraParams(url);
 				assert.equal(params.length, 3);
 
 				const expectedParams = [
@@ -185,7 +185,7 @@
 			test('when parsing url for sort and filter params, if only sort is present, return array with correct values', () => {
 				const url = 'https://www.example.com/?pageSize=20&sort=Y3Rpb24iOjB9';
 
-				var params = component._getExtraParams(url);
+				const params = component._getExtraParams(url);
 				assert.equal(params.length, 1);
 
 				const expectedParams = [
@@ -199,7 +199,7 @@
 			test('when parsing url for sort and filter params, if only filter is present, return array with correct values', () => {
 				const url = 'https://www.example.com/?pageSize=20&filter=96W3siU29ydCI6eyJJ';
 
-				var params = component._getExtraParams(url);
+				const params = component._getExtraParams(url);
 				assert.equal(params.length, 1);
 
 				const expectedParams = [
@@ -231,7 +231,7 @@
 				const url = '/d2l/lms/tool/mark.d2l?ou=122041&db=1004';
 				const params = [];
 
-				var evalLink = component._buildRelativeUri(url, params);
+				const evalLink = component._buildRelativeUri(url, params);
 				assert.equal(evalLink, url);
 			});
 			test('when creating a link, if there are extra params, return correct link', () => {
@@ -248,7 +248,7 @@
 				];
 				const expectedEvalLink = url + '&filter=96W3siU29ydCI6eyJJ&sort=Y3Rpb24iOjB9';
 
-				var evalLink = component._buildRelativeUri(url, params);
+				const evalLink = component._buildRelativeUri(url, params);
 				assert.equal(evalLink, expectedEvalLink);
 			});
 			test('when creating a, if there are extra params and url has no original params, return correct link', () => {
@@ -265,7 +265,7 @@
 				];
 				const expectedEvalLink = url + '?filter=96W3siU29ydCI6eyJJ&sort=Y3Rpb24iOjB9';
 
-				var evalLink = component._buildRelativeUri(url, params);
+				const evalLink = component._buildRelativeUri(url, params);
 				assert.equal(evalLink, expectedEvalLink);
 			});
 		});

--- a/test/d2l-quick-eval/d2l-quick-eval-activities.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-activities.js
@@ -169,7 +169,7 @@ suite('d2l-quick-eval-activities', function() {
 	});
 	test('if error, show alert', () => {
 		act._isError = true;
-		var alert = act.shadowRoot.querySelector('.d2l-quick-eval-activities-load-error-alert');
+		const alert = act.shadowRoot.querySelector('.d2l-quick-eval-activities-load-error-alert');
 		assert.equal(false, alert.hasAttribute('hidden'));
 	});
 });

--- a/test/d2l-quick-eval/d2l-quick-eval-submissions-table-sorting.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-submissions-table-sorting.js
@@ -157,7 +157,7 @@ suite('d2l-quick-eval-activities-list-sorting', () => {
 			];
 			testData.forEach(testCase => {
 				test(testCase.name, (done) => {
-					var stub = sinon.stub(list, '_applySortAndFetchData');
+					const stub = sinon.stub(list, '_applySortAndFetchData');
 					const e = {
 						detail: {
 							headerId: testCase.id

--- a/test/d2l-quick-eval/d2l-quick-eval-submissions-table.js
+++ b/test/d2l-quick-eval/d2l-quick-eval-submissions-table.js
@@ -1,22 +1,22 @@
 import '@polymer/iron-test-helpers/mock-interactions.js';
 
 (function() {
-	var list;
+	let list;
 
 	async function loadPromise(url) {
-		var entity = await window.D2L.Siren.EntityStore.fetch(url, '');
+		const entity = await window.D2L.Siren.EntityStore.fetch(url, '');
 		await list._loadData(entity.entity);
 	}
 
 	function createExpectedData(expectedData, includeMasterTeacher) {
-		var expectedActivities = [];
+		const expectedActivities = [];
 
 		expectedData.forEach(function(item) {
-			var expectedActivity = {
+			const expectedActivity = {
 				isDraft: item.isDraft
 			};
 
-			var activityColumns = [];
+			const activityColumns = [];
 
 			activityColumns.push({ text: item.displayName.defaultDisplayName, href: item.activityLink });
 			activityColumns.push({ href: item.activityNameHref });
@@ -40,14 +40,14 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 	}
 
 	function verifyData(expectedActivities, done) {
-		var data = list.shadowRoot.querySelectorAll('d2l-td');
+		const data = list.shadowRoot.querySelectorAll('d2l-td');
 
-		var expectedActivityData = [].concat.apply(
+		const expectedActivityData = [].concat.apply(
 			[], expectedActivities.map(function(expectedActivity) {
 				return expectedActivity.data;
 			}));
 
-		for (var i = 0; i < expectedActivityData.length; i++) {
+		for (let i = 0; i < expectedActivityData.length; i++) {
 			const link = data[i].querySelector('d2l-link');
 			const span = data[i].querySelector('span');
 			const activityName = data[i].querySelector('d2l-activity-name');
@@ -65,7 +65,7 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 		done();
 	}
 
-	var expectedData = [
+	const expectedData = [
 		{
 			displayName: { firstName: 'Special User', lastName: 'Name', defaultDisplayName: 'Special User Name' },
 			userHref: 'data/userUnique.json',
@@ -98,8 +98,8 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 		}
 	];
 
-	var expectedDataWithMasterTeacher = expectedData.map(function(x) {
-		var updatedExpectedData = {};
+	const expectedDataWithMasterTeacher = expectedData.map(function(x) {
+		const updatedExpectedData = {};
 
 		Object.keys(x).forEach(function(key) {
 			updatedExpectedData[ key ] = x[ key ];
@@ -109,7 +109,7 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 		return updatedExpectedData;
 	});
 
-	var expectedNextData = [
+	const expectedNextData = [
 		{
 			displayName: { firstName: 'User', lastName: 'Name', defaultDisplayName: 'User Name' },
 			userHref: 'data/user.json',
@@ -155,13 +155,13 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			assert.equal(true, alert.hasAttribute('hidden'));
 		});
 		test('showLoadingSkeleton is set to true, showLoadingSpinner is set to false before data is loaded, and loading-skeleton is present', () => {
-			var loadingskeleton = list.shadowRoot.querySelector('d2l-quick-eval-submissions-skeleton');
+			const loadingskeleton = list.shadowRoot.querySelector('d2l-quick-eval-submissions-skeleton');
 			assert.equal(loadingskeleton.hidden, false);
 			assert.isFalse(list.showLoadingSpinner);
 			assert.isTrue(list.showLoadingSkeleton);
 		});
 		test.skip('_fullListLoading and _loading is set to false after data is loaded and the loading skeleton is hidden', (done) => {
-			var loadingskeleton = list.shadowRoot.querySelector('d2l-quick-eval-submissions-skeleton');
+			const loadingskeleton = list.shadowRoot.querySelector('d2l-quick-eval-submissions-skeleton');
 
 			loadPromise('data/unassessedActivities.json').then(function() {
 				assert.equal(loadingskeleton.hidden, true);
@@ -171,7 +171,7 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			});
 		});
 		test.skip('setLoadingState lets consumers control the table loading', (done) => {
-			var loadingskeleton = list.shadowRoot.querySelector('d2l-quick-eval-submissions-skeleton');
+			const loadingskeleton = list.shadowRoot.querySelector('d2l-quick-eval-submissions-skeleton');
 
 			loadPromise('data/unassessedActivities.json').then(function() {
 				assert.equal(loadingskeleton.hidden, true);
@@ -189,7 +189,7 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 		});
 		test.skip('if _loading is true, the Load More button is hidden', (done) => {
 			loadPromise('data/unassessedActivities.json').then(function() {
-				var loadMore = list.shadowRoot.querySelector('.d2l-quick-eval-submissions-table-load-more-container');
+				const loadMore = list.shadowRoot.querySelector('.d2l-quick-eval-submissions-table-load-more-container');
 				assert.notEqual(loadMore.style.display, 'none');
 				list._loading = true;
 				requestAnimationFrame(function() {
@@ -199,22 +199,22 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			});
 		});
 		test('if _loading is true, d2l-quick-eval-no-submissions-image and d2l-quick-eval-no-submissions-image are not shown', () => {
-			var noSubmissionComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-submissions');
-			var noCriteriaResultsComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-criteria-results');
+			const noSubmissionComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-submissions');
+			const noCriteriaResultsComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-criteria-results');
 			assert.equal(noSubmissionComponent, null);
 			assert.equal(noCriteriaResultsComponent, null);
 			assert.isTrue(list.showLoadingSkeleton);
 		});
 		test.skip('if there is no data in the list, d2l-quick-eval-no-submissions-image is shown', (done) => {
 			loadPromise('data/emptyUnassessedActivities.json').then(function() {
-				var noSubmissionComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-submissions');
+				let noSubmissionComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-submissions');
 				assert.notEqual(noSubmissionComponent.style.display, 'none');
-				var noCriteriaResultsComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-criteria-results');
+				const noCriteriaResultsComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-criteria-results');
 				assert.equal(noCriteriaResultsComponent, null);
 				//This is here because of how dom-if works, we need to load activities once to ensure we actually
 				//render the d2l-quick-eval-no-submissions component and instantly hide it.
 				loadPromise('data/unassessedActivities.json').then(function() {
-					var noSubmissionComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-submissions');
+					noSubmissionComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-submissions');
 					assert.equal(noSubmissionComponent.style.display, 'none');
 					done();
 				});
@@ -224,14 +224,14 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			list.setAttribute('filter-applied', '');
 
 			loadPromise('data/emptyUnassessedActivities.json').then(function() {
-				var noCriteriaResultsComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-criteria-results');
+				let noCriteriaResultsComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-criteria-results');
 				assert.notEqual(noCriteriaResultsComponent.style.display, 'none');
-				var noSubmissionComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-submissions');
+				const noSubmissionComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-submissions');
 				assert.equal(noSubmissionComponent, null);
 				//This is here because of how dom-if works, we need to load activities once to ensure we actually
 				//render the d2l-quick-eval-no-criteria-results component and instantly hide it.
 				loadPromise('data/unassessedActivities.json').then(function() {
-					var noCriteriaResultsComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-criteria-results');
+					noCriteriaResultsComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-criteria-results');
 					assert.equal(noCriteriaResultsComponent.style.display, 'none');
 					done();
 				});
@@ -241,14 +241,14 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			list.setAttribute('search-applied', '');
 
 			loadPromise('data/emptyUnassessedActivities.json').then(function() {
-				var noCriteriaResultsComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-criteria-results');
+				let noCriteriaResultsComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-criteria-results');
 				assert.notEqual(noCriteriaResultsComponent.style.display, 'none');
-				var noSubmissionComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-submissions');
+				const noSubmissionComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-submissions');
 				assert.equal(noSubmissionComponent, null);
 				//This is here because of how dom-if works, we need to load activities once to ensure we actually
 				//render the d2l-quick-eval-no-criteria-results component and instantly hide it.
 				loadPromise('data/unassessedActivities.json').then(function() {
-					var noCriteriaResultsComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-criteria-results');
+					noCriteriaResultsComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-criteria-results');
 					assert.equal(noCriteriaResultsComponent.style.display, 'none');
 					done();
 				});
@@ -259,14 +259,14 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			list.setAttribute('search-applied', '');
 
 			loadPromise('data/emptyUnassessedActivities.json').then(function() {
-				var noCriteriaResultsComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-criteria-results');
+				let noCriteriaResultsComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-criteria-results');
 				assert.notEqual(noCriteriaResultsComponent.style.display, 'none');
-				var noSubmissionComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-submissions');
+				const noSubmissionComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-submissions');
 				assert.equal(noSubmissionComponent, null);
 				//This is here because of how dom-if works, we need to load activities once to ensure we actually
 				//render the d2l-quick-eval-no-criteria-results component and instantly hide it.
 				loadPromise('data/unassessedActivities.json').then(function() {
-					var noCriteriaResultsComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-criteria-results');
+					noCriteriaResultsComponent = list.shadowRoot.querySelector('.d2l-quick-eval-no-criteria-results');
 					assert.equal(noCriteriaResultsComponent.style.display, 'none');
 					done();
 				});
@@ -291,7 +291,7 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			});
 		});
 		test.skip('data displays correctly', (done) => {
-			var expected = createExpectedData(expectedData);
+			const expected = createExpectedData(expectedData);
 
 			loadPromise('data/unassessedActivities.json').then(function() {
 				flush(function() {
@@ -300,7 +300,7 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			});
 		});
 		test.skip('data displays correctly when master teacher toggled on', (done) => {
-			var expected = createExpectedDataWithMasterTeacher(expectedDataWithMasterTeacher);
+			const expected = createExpectedDataWithMasterTeacher(expectedDataWithMasterTeacher);
 
 			list.setAttribute('master-teacher', '');
 			flush(function() {
@@ -311,7 +311,7 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 		});
 		test.skip('the Load More button appears when there is a next link', (done) => {
 			loadPromise('data/unassessedActivities.json').then(function() {
-				var loadMore = list.shadowRoot.querySelector('.d2l-quick-eval-submissions-table-load-more');
+				const loadMore = list.shadowRoot.querySelector('.d2l-quick-eval-submissions-table-load-more');
 				assert.equal(loadMore.tagName.toLowerCase(), 'd2l-button');
 				assert.notEqual(loadMore.style.display, 'none');
 				assert.notEqual(loadMore.disabled, 'true');
@@ -319,12 +319,12 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			});
 		});
 		test.skip('clicking Load More adds the proper data, and the button is hidden when there is no more next link', (done) => {
-			var expectedNext = createExpectedData(expectedData.concat(expectedNextData));
+			const expectedNext = createExpectedData(expectedData.concat(expectedNextData));
 
 			loadPromise('data/unassessedActivities.json').then(function() {
-				var loadMore = list.shadowRoot.querySelector('.d2l-quick-eval-submissions-table-load-more');
-				var loadMoreContainer = list.shadowRoot.querySelector('.d2l-quick-eval-submissions-table-load-more-container');
-				var verify = function() {
+				const loadMore = list.shadowRoot.querySelector('.d2l-quick-eval-submissions-table-load-more');
+				const loadMoreContainer = list.shadowRoot.querySelector('.d2l-quick-eval-submissions-table-load-more-container');
+				const verify = function() {
 					if (!list._loading && loadMoreContainer.style.display === 'none') {
 						verifyData(expectedNext, done);
 					} else {
@@ -341,7 +341,7 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			list._health = { isHealthy: false, errorMessage: 'failedToLoadMore' };
 
 			flush(function() {
-				var alert = list.shadowRoot.querySelector('.list-alert');
+				const alert = list.shadowRoot.querySelector('.list-alert');
 				assert.equal(false, alert.hasAttribute('hidden'));
 
 				list._health = { isHealthy: true, errorMessage: '' };
@@ -356,7 +356,7 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 			list._health = { isHealthy: false, errorMessage: 'failedToLoadData' };
 
 			flush(function() {
-				var alert = list.shadowRoot.querySelector('.list-alert');
+				const alert = list.shadowRoot.querySelector('.list-alert');
 				assert.equal(false, alert.hasAttribute('hidden'));
 
 				list._health = { isHealthy: true, errorMessage: '' };
@@ -370,7 +370,7 @@ import '@polymer/iron-test-helpers/mock-interactions.js';
 		test('Ensure that focus is on the first name of the submissions table when returning to quick eval', (done) => {
 			list.returningToQuickEval = true;
 			flush(function() {
-				var firstName = list.shadowRoot.querySelector('.d2l-quick-eval-submissions-table-name-link');
+				const firstName = list.shadowRoot.querySelector('.d2l-quick-eval-submissions-table-name-link');
 				if (firstName) {
 					assert.equal(true, firstName.hasAttribute('autofocus'));
 				}

--- a/test/d2l-quick-eval/d2l-quick-eval.html
+++ b/test/d2l-quick-eval/d2l-quick-eval.html
@@ -60,7 +60,7 @@
 			const expectedFiltersWithMasterTeacher = expectedFilters.concat('Primary Facilitator');
 
 			function waitForList(callback) {
-				var firstDataCell = list.shadowRoot.querySelector('d2l-tbody > d2l-tr > d2l-td.d2l-table-cell-first');
+				const firstDataCell = list.shadowRoot.querySelector('d2l-tbody > d2l-tr > d2l-td.d2l-table-cell-first');
 
 				if (firstDataCell) {
 					callback(firstDataCell);
@@ -72,8 +72,8 @@
 			}
 
 			function waitForFilter(callback) {
-				var filterTabsContainer = filterDropdown.shadowRoot.querySelector('d2l-tabs');
-				var filterTabs = filterTabsContainer.shadowRoot.querySelectorAll('d2l-tab');
+				const filterTabsContainer = filterDropdown.shadowRoot.querySelector('d2l-tabs');
+				const filterTabs = filterTabsContainer.shadowRoot.querySelectorAll('d2l-tab');
 
 				if (filterTabs.length > 0) {
 					callback(filterTabs);
@@ -104,11 +104,11 @@
 				}
 			}
 
-			var clickFilter = function(filterOptionName) {
-				var firstFilterTab = filterDropdown.shadowRoot.querySelectorAll('d2l-filter-dropdown-page')[0];
-				var filterOptions = firstFilterTab.shadowRoot.querySelectorAll('d2l-menu-item-checkbox');
+			const clickFilter = function(filterOptionName) {
+				const firstFilterTab = filterDropdown.shadowRoot.querySelectorAll('d2l-filter-dropdown-page')[0];
+				const filterOptions = firstFilterTab.shadowRoot.querySelectorAll('d2l-menu-item-checkbox');
 
-				for (var i = 0; i < filterOptions.length; i++) {
+				for (let i = 0; i < filterOptions.length; i++) {
 					if (filterOptions[i].text === filterOptionName) {
 						MockInteractions.click(filterOptions[i]);
 					}
@@ -125,8 +125,8 @@
 				}
 			}
 
-			var clearFilter = function() {
-				var clearButton = filterDropdown.shadowRoot.querySelector('d2l-button-subtle');
+			const clearFilter = function() {
+				const clearButton = filterDropdown.shadowRoot.querySelector('d2l-button-subtle');
 				MockInteractions.click(clearButton);
 			};
 
@@ -244,21 +244,21 @@
 					assert.isNotNull(list);
 				});
 				test('the list loads data', function(done) {
-					var verifyDataLoads = function(firstCell) {
+					const verifyDataLoads = function(firstCell) {
 						assert.include(firstCell.innerHTML, expectedFirstCellData);
 						done();
 					};
 					waitForList(verifyDataLoads);
 				});
 				test('only the filters we want are shown (in order)', function(done) {
-					var verifyFilter = function(filterTabs) {
+					const verifyFilter = function(filterTabs) {
 						assert.deepEqual(Array.from(filterTabs).map(tab => tab.text), expectedFilters);
 						done();
 					};
 					waitForFilter(verifyFilter);
 				});
 				test('when the filters are loaded an event is fired and criteria state of the list is updated', function(done) {
-					var filtersSelected = 0;
+					let filtersSelected = 0;
 					quickEval.addEventListener('d2l-hm-filter-filters-loaded', function(e) {
 						assert.equal(e.detail.totalSelectedFilters, filtersSelected);
 						assert.equal(list.filterApplied, filtersSelected > 0);
@@ -271,7 +271,7 @@
 					waitForFilter(function() { filter.href = 'data/filters-on.json'; });
 				});
 				test('when a filter is selected an updating event is fired and the table is set to loading', function(done) {
-					var alert = quickEval.shadowRoot.querySelector('.d2l-quick-eval-filter-error-alert');
+					const alert = quickEval.shadowRoot.querySelector('.d2l-quick-eval-filter-error-alert');
 					quickEval.addEventListener('d2l-hm-filter-filters-updating', function() {
 						assert.equal(list._loading, true);
 						assert.equal(list._fullListLoading, true);
@@ -289,8 +289,8 @@
 					});
 				});
 				test('if there is an error when the filter is updating, the table is set back to not loading', function(done) {
-					var alert = quickEval.shadowRoot.querySelector('.d2l-quick-eval-filter-error-alert');
-					var filtersSelected = 0;
+					const alert = quickEval.shadowRoot.querySelector('.d2l-quick-eval-filter-error-alert');
+					let filtersSelected = 0;
 					quickEval.addEventListener('d2l-hm-filter-filters-loaded', function() {
 						assert.equal(list._loading, false);
 						assert.equal(list._fullListLoading, false);
@@ -321,10 +321,10 @@
 					});
 				});
 				test('applying and removing filters causes the count to update and events to fire', function(done) {
-					var add = 1;
+					let add = 1;
 
 					quickEval.addEventListener('d2l-hm-filter-filters-updated', function(e) {
-						var dropdownButton = filterDropdown.shadowRoot.querySelector('d2l-dropdown-button-subtle').shadowRoot.querySelector('d2l-button-subtle');
+						const dropdownButton = filterDropdown.shadowRoot.querySelector('d2l-dropdown-button-subtle').shadowRoot.querySelector('d2l-button-subtle');
 						assert.deepEqual(e.detail.filteredActivities, submissions.entity);
 						if (add === 1) {
 							assert.equal(dropdownButton.text, 'Filter: 1 Filter');
@@ -341,10 +341,10 @@
 					waitForFilter(function() { clickFilter('Assignment Name'); });
 				});
 				test('clearing filters causes event to fire', function(done) {
-					var add = 2;
+					let add = 2;
 
 					quickEval.addEventListener('d2l-hm-filter-filters-updated', function(e) {
-						var dropdownButton = filterDropdown.shadowRoot.querySelector('d2l-dropdown-button-subtle').shadowRoot.querySelector('d2l-button-subtle');
+						const dropdownButton = filterDropdown.shadowRoot.querySelector('d2l-dropdown-button-subtle').shadowRoot.querySelector('d2l-button-subtle');
 						assert.deepEqual(e.detail.filteredActivities, submissions.entity);
 						if (add === 2) {
 							assert.equal(dropdownButton.text, 'Filter: 1 Filter');
@@ -365,8 +365,8 @@
 					waitForFilter(function() { clickFilter('Assignment Name'); });
 				});
 				test('if there is an error with the filter, we catch an event and display an alert, and clear that after a successful filter action', function(done) {
-					var alert = quickEval.shadowRoot.querySelector('.d2l-quick-eval-filter-error-alert');
-					var filtersSelected = 0;
+					const alert = quickEval.shadowRoot.querySelector('.d2l-quick-eval-filter-error-alert');
+					let filtersSelected = 0;
 					quickEval.addEventListener('d2l-hm-filter-filters-loaded', function() {
 						assert.isFalse(quickEval._showFilterError);
 						assert.isTrue(alert.hidden);
@@ -494,7 +494,7 @@
 					assert.isTrue(quickEval.masterTeacher);
 				});
 				test('only the filters we want are shown', function(done) {
-					var verifyFilter = function(filterTabs) {
+					const verifyFilter = function(filterTabs) {
 						assert.deepEqual(Array.from(filterTabs).map(tab => tab.text), expectedFiltersWithMasterTeacher);
 						done();
 					};


### PR DESCRIPTION
`eslint` version is behind and Dependabot pull request  #1107 failed because of unnecessary `var` instantiations. These have been converted to `const` and `let`.