### PR TITLE
Strings that are too long for a card now wrap

### DIFF
--- a/components/d2l-activity-card/d2l-activity-card.js
+++ b/components/d2l-activity-card/d2l-activity-card.js
@@ -44,6 +44,7 @@ class D2lActivityCard extends ActivityCardLocalize(PolymerElement) {
 
 				.d2l-activity-card-content-organization-info {
 					display: block;
+					word-break: break-word;
 				}
 
 				.d2l-activity-card-activity-information {


### PR DESCRIPTION
For DE39598

https://rally1.rallydev.com/#/357252275780d/custom/367300408400?detail=%2Fdefect%2F399579266472

Card Metadata now centers because the overflow caused by long strings now was solved by wrapping the content to the next line.

See difference below

Before:
![Before](https://user-images.githubusercontent.com/71081906/93618571-74a34a80-f9a5-11ea-9f0c-ce14c846f400.PNG)

After:
![After](https://user-images.githubusercontent.com/71081906/93618424-3efe6180-f9a5-11ea-8059-fd470b03e6b9.PNG)
