### PR TITLE
US120338 - Group filter, sort and search extra params inside one single query string param

### DIFF
--- a/components/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
+++ b/components/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
@@ -90,7 +90,7 @@ D2L.PolymerBehaviors.Siren.D2LSirenHelperBehaviorImpl = {
 			extraParams.push(
 				{
 					name: 'collectionSearch',
-					value: searchVal
+					value: window.btoa(searchVal)	// base64 encoding of the search text
 				}
 			);
 		}

--- a/components/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
+++ b/components/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
@@ -106,9 +106,13 @@ D2L.PolymerBehaviors.Siren.D2LSirenHelperBehaviorImpl = {
 		const parsedUrl = new window.URL(url, 'https://notused.com');
 		const searchParams = GetQueryStringParams(parsedUrl.search);
 
+		let extraInfo = '';
 		extraParams.forEach(param => {
-			searchParams[param.name] = param.value;
+			extraInfo += '-' + param.name + '_' + param.value;
 		});
+
+		searchParams['cfi'] = extraInfo.substring(1);
+
 		return parsedUrl.pathname + DictToQueryString(searchParams);
 	},
 

--- a/test/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
+++ b/test/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
@@ -234,6 +234,19 @@
 				const evalLink = component._buildRelativeUri(url, params);
 				assert.equal(evalLink, url);
 			});
+			test('when creating a link, if there is an extra param, return correct link', () => {
+				const url = '/d2l/lms/tool/mark.d2l?ou=122041&db=1004';
+				const params = [
+					{
+						name: 'sort',
+						value: 'Y3Rpb24iOjB9'
+					}
+				];
+				const expectedEvalLink = url + '&cfi=sort_Y3Rpb24iOjB9';
+
+				const evalLink = component._buildRelativeUri(url, params);
+				assert.equal(evalLink, expectedEvalLink);
+			});
 			test('when creating a link, if there are extra params, return correct link', () => {
 				const url = '/d2l/lms/tool/mark.d2l?ou=122041&db=1004';
 				const params = [
@@ -246,7 +259,7 @@
 						value: 'Y3Rpb24iOjB9'
 					}
 				];
-				const expectedEvalLink = url + '&filter=96W3siU29ydCI6eyJJ&sort=Y3Rpb24iOjB9';
+				const expectedEvalLink = url + '&cfi=filter_96W3siU29ydCI6eyJJ-sort_Y3Rpb24iOjB9';
 
 				const evalLink = component._buildRelativeUri(url, params);
 				assert.equal(evalLink, expectedEvalLink);
@@ -263,7 +276,7 @@
 						value: 'Y3Rpb24iOjB9'
 					}
 				];
-				const expectedEvalLink = url + '?filter=96W3siU29ydCI6eyJJ&sort=Y3Rpb24iOjB9';
+				const expectedEvalLink = url + '?cfi=filter_96W3siU29ydCI6eyJJ-sort_Y3Rpb24iOjB9';
 
 				const evalLink = component._buildRelativeUri(url, params);
 				assert.equal(evalLink, expectedEvalLink);

--- a/test/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
+++ b/test/d2l-quick-eval/behaviors/d2l-siren-helper-behavior.js
@@ -177,7 +177,7 @@
 					},
 					{
 						name: 'collectionSearch',
-						value: 'arthas'
+						value: window.btoa('arthas')
 					}
 				];
 				assert.deepEqual(params, expectedParams);
@@ -220,7 +220,7 @@
 				const expectedParams = [
 					{
 						name: 'collectionSearch',
-						value: 'ragnaros'
+						value: window.btoa('ragnaros')
 					}
 				];
 				assert.deepEqual(params, expectedParams);


### PR DESCRIPTION
This changes affects the information that is send back from the evaluation pages when they return to Quick Eval, allowing Quick Eval to maintain the previous selected sort, filter and search.

It will allow the new evaluation routes to handle query string params easily.

Before:
?filter=eyJmMmIzMmYwMy01NTZ&sort=eyJTb3J0cyI6W3s0&collectionSearch=eddie

After
?cfi=filter_eyJmMmIzMmYwMy01NTZ-sort_eyJTb3J0cyI6W3s0-collectionSearch_eddie

Legacy LMS pages are been changed at the same time to handle the new single param