### PR TITLE
[cert 20.20.10] DE40565 - handle callback after adding video or audio

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -89,9 +89,13 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(SkeletizeMixin(Local
 		};
 		// Referenced by the server-side ActivitiesView renderer
 		D2L.ActivityEditor.RecordVideoDialogCallback = async(file) => {
+			const fileId = file.GetId();
+			const fileName = file.GetName();
+			const fileSystemType = file.GetFileSystemType();
+
 			const collection = store.get(this.href);
-			const previewUrl = await collection.getPreviewUrl(file.FileSystemType, file.FileId);
-			this._addToCollection(attachmentStore.createVideo(file.FileName, file.FileSystemType, file.FileId, previewUrl));
+			const previewUrl = await collection.getPreviewUrl(fileSystemType, fileId);
+			this._addToCollection(attachmentStore.createVideo(fileName, fileSystemType, fileId, previewUrl));
 			this.dispatchEvent(new CustomEvent('d2l-activity-attachments-picker-video-uploaded', {
 				bubbles: true,
 				composed: true
@@ -99,9 +103,13 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(SkeletizeMixin(Local
 		};
 		// Referenced by the server-side ActivitiesView renderer
 		D2L.ActivityEditor.RecordAudioDialogCallback = async(file) => {
+			const fileId = file.GetId();
+			const fileName = file.GetName();
+			const fileSystemType = file.GetFileSystemType();
+
 			const collection = store.get(this.href);
-			const previewUrl = await collection.getPreviewUrl(file.FileSystemType, file.FileId);
-			this._addToCollection(attachmentStore.createAudio(file.FileName, file.FileSystemType, file.FileId, previewUrl));
+			const previewUrl = await collection.getPreviewUrl(fileSystemType, fileId);
+			this._addToCollection(attachmentStore.createAudio(fileName, fileSystemType, fileId, previewUrl));
 			this.dispatchEvent(new CustomEvent('d2l-activity-attachments-picker-audio-uploaded', {
 				bubbles: true,
 				composed: true


### PR DESCRIPTION
The file type returned is `D2L.LP.Web.UI.Files.File`.
The RecordVideoDialogCallback used to be `D2L.Files.FileInfo`.

(cherry picked from commit aa9cc591c15c06dafd57ae044da7b56f3b21c33e)