### PR TITLE
Add key identifier for component to update

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-html-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-editor.js
@@ -14,6 +14,7 @@ class ActivityHtmlEditor extends LocalizeActivityEditorMixin(LitElement) {
 			value: { type: String },
 			ariaLabel: { type: String },
 			disabled: { type: Boolean },
+			key: { type: String },
 			_htmlEditorUniqueId: { type: String }
 		};
 	}
@@ -98,7 +99,7 @@ class ActivityHtmlEditor extends LocalizeActivityEditorMixin(LitElement) {
 			}
 		}
 
-		if (changedProperties.has('value') && typeof changedProperties.get('value') === 'undefined') {
+		if ((changedProperties.has('value') && typeof changedProperties.get('value') === 'undefined') || changedProperties.has('key')) {
 			const editorContainer = this.shadowRoot.querySelector('d2l-html-editor > .d2l-html-editor-container');
 			if (editorContainer) {
 				editorContainer.innerHTML = this.value;

--- a/components/d2l-activity-editor/d2l-activity-text-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-text-editor.js
@@ -10,6 +10,7 @@ class ActivityTextEditor extends LitElement {
 			richtextEditorConfig: { type: Object },
 			disabled: { type: Boolean },
 			ariaLabel: { type: String },
+			key: { type: String },
 		};
 	}
 
@@ -28,6 +29,7 @@ class ActivityTextEditor extends LitElement {
 			return html`
 				<d2l-activity-html-editor
 					ariaLabel="${this.ariaLabel}"
+					.key="${this.key}"
 					.value="${this.value}"
 					?disabled="${this.disabled}"
 					@d2l-activity-html-editor-change="${this._onRichtextChange}"


### PR DESCRIPTION
Related to [US120640](https://rally1.rallydev.com/#/388869855380d/dashboard?detail=%2Fuserstory%2F436813346276)

`d2l-activity-text-editor` does not respond to value changes because the html editor maintains it's own state. 
With the addition of the unique `key` property, we can use it to track whether the component should be updated or not.