### PR TITLE
Override scroll property in content-editor so we don't get unnecessary scroll bar

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
@@ -47,6 +47,8 @@ class ContentEditor extends ActivityEditorContainerMixin(RtlMixin(ActivityEditor
 
 	constructor() {
 		super(store);
+		// Override the 'scroll' property set by the page to remove the scrollbar
+		document.body.style.overflow = 'hidden';
 	}
 
 	render() {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
@@ -47,7 +47,7 @@ class ContentEditor extends ActivityEditorContainerMixin(RtlMixin(ActivityEditor
 
 	constructor() {
 		super(store);
-		// Override the 'scroll' property set by the page to remove the scrollbar
+		// Override the 'scroll' property set by the page to remove the unnecessary scrollbar
 		document.body.style.overflow = 'hidden';
 	}
 


### PR DESCRIPTION
Same thing we did in LX [here](https://github.com/BrightspaceHypermediaComponents/sequences/pull/271), just applying similar logic to new face content editor.