### PR TITLE
Integrate content editor with activity store to get visibility and availability features for free

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-availability-editor.js
@@ -1,3 +1,5 @@
+import '../d2l-activity-availability-dates-summary.js';
+import '../d2l-activity-availability-dates-editor.js';
 import '@brightspace-ui-labs/accordion/accordion-collapse.js';
 import { bodySmallStyles, heading3Styles, heading4Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
@@ -81,8 +83,11 @@ class ContentAvailabilityEditor extends LocalizeActivityEditorMixin(RtlMixin(Lit
 	_renderAvailabilityDatesEditor() {
 
 		return html`
-			<div>
-				TODO - add availability dates editor
+			<div class="d2l-editor">
+				<d2l-activity-availability-dates-editor
+					href="${this.href}"
+					.token="${this.token}">
+				</d2l-activity-availability-dates-editor>
 			</div>
 		`;
 	}
@@ -90,9 +95,10 @@ class ContentAvailabilityEditor extends LocalizeActivityEditorMixin(RtlMixin(Lit
 	_renderAvailabilityDatesSummary() {
 
 		return html`
-			<div>
-				TODO - add availability dates summary
-			</div>
+			<d2l-activity-availability-dates-summary
+				href="${this.href}"
+				.token="${this.token}">
+			</d2l-activity-availability-dates-summary>
 		`;
 	}
 }

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-footer.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-footer.js
@@ -37,7 +37,8 @@ class ContentEditorFooter extends SaveStatusMixin(RtlMixin(LitElement)) {
 		return html`
 			<div class="d2l-activity-content-editor-footer-left">
 				<d2l-activity-editor-buttons></d2l-activity-editor-buttons>
-				<!-- TODO: more work/investigation is needed to get visibility editor working -->
+				<!-- TODO: figure out how to set activity usage entity "canEditDraft" property to true -->
+				<!-- so that we can properly toggle the visibility of the entity -->
 				<d2l-activity-visibility-editor
 					.href="${this.href}"
 					.token="${this.token}">

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
@@ -7,6 +7,7 @@ import '@brightspace-ui/core/components/colors/colors.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorContainerMixin } from '../mixins/d2l-activity-editor-container-mixin.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
+import { shared as activityStore } from '../state/activity-store.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { shared as store } from './state/content-store.js';
@@ -68,6 +69,7 @@ class ContentEditor extends ActivityEditorContainerMixin(RtlMixin(ActivityEditor
 		if ((changedProperties.has('href') || changedProperties.has('token')) &&
 			this.href && this.token) {
 			super._fetch(() => store.fetchContentActivity(this.href, this.token));
+			super._fetch(() => activityStore.fetch(this.href, this.token));
 		}
 	}
 

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -113,5 +113,5 @@ export default {
 	"content.name": "Name", // Text label for name input field
 	"content.emptyNameField": "Name is required", // Error text that appears below name field when it is left empty
 	"content.description": "Description", // Text label for description input field
-	"content.availabilityHeader": "Availability Dates & Conditions", // availability header
+	"content.availabilityHeader": "Availability Dates", // availability header
 };

--- a/components/d2l-activity-editor/state/activity-score-grade.js
+++ b/components/d2l-activity-editor/state/activity-score-grade.js
@@ -6,7 +6,7 @@ configureMobx({ enforceActions: 'observed' });
 export class ActivityScoreGrade {
 
 	constructor(entity, token) {
-		this.scoreOutOf = entity.scoreOutOf()?.toString();
+		this.scoreOutOf = entity.scoreOutOf() ? entity.scoreOutOf().toString() : undefined;
 		this.scoreOutOfError = null;
 		this.token = token;
 		this.inGrades = entity.inGrades();

--- a/components/d2l-activity-editor/state/activity-score-grade.js
+++ b/components/d2l-activity-editor/state/activity-score-grade.js
@@ -6,7 +6,7 @@ configureMobx({ enforceActions: 'observed' });
 export class ActivityScoreGrade {
 
 	constructor(entity, token) {
-		this.scoreOutOf = entity.scoreOutOf() ? entity.scoreOutOf().toString() : null;
+		this.scoreOutOf = entity.scoreOutOf() ? entity.scoreOutOf().toString() : undefined;
 		this.scoreOutOfError = null;
 		this.token = token;
 		this.inGrades = entity.inGrades();

--- a/components/d2l-activity-editor/state/activity-score-grade.js
+++ b/components/d2l-activity-editor/state/activity-score-grade.js
@@ -6,7 +6,7 @@ configureMobx({ enforceActions: 'observed' });
 export class ActivityScoreGrade {
 
 	constructor(entity, token) {
-		this.scoreOutOf = entity.scoreOutOf() ? entity.scoreOutOf().toString() : undefined;
+		this.scoreOutOf = entity.scoreOutOf()?.toString();
 		this.scoreOutOfError = null;
 		this.token = token;
 		this.inGrades = entity.inGrades();

--- a/components/d2l-activity-editor/state/activity-score-grade.js
+++ b/components/d2l-activity-editor/state/activity-score-grade.js
@@ -6,7 +6,7 @@ configureMobx({ enforceActions: 'observed' });
 export class ActivityScoreGrade {
 
 	constructor(entity, token) {
-		this.scoreOutOf = entity.scoreOutOf().toString();
+		this.scoreOutOf = entity.scoreOutOf() ? entity.scoreOutOf().toString() : null;
 		this.scoreOutOfError = null;
 		this.token = token;
 		this.inGrades = entity.inGrades();


### PR DESCRIPTION
Integrating our content editor with `activity-store.js`. This file/store gives us boilerplate access to standard `activity-usage` properties in the store so that we can integrate with shared components like `d2l-activity-availability-dates-editor` and `2l-activity-availability-dates-summary`. These components integrate with `activity-store.js` to both access and set values on the activity usage entity. Gives us a lot of functionality with doing almost no work! 

**Note** had to fix an error being thrown when loading a new `activity-usage` into the store that naively assumed the `activity-usage` entity would always have score/grade information. This needed to be fixed for the `ObjectStore` to properly load the entity into state so that other components could access it. I know this is confusing to follow without having worked in these files so let me know if you have questions.

**EDIT** some work needed in `siren-sdk` repo as well. Similar issue with assuming `scoreOutOf` exists and `toString()` fails. Related [PR here](https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/217).

Screenshot with new visibility and availability components:
![visibility + availability integration](https://user-images.githubusercontent.com/64804046/94170229-ca706a80-fe5d-11ea-90e2-68115aace5a2.PNG)

 