### PR TITLE
DE40535: Floating buttons not floating in rubrics

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -8,6 +8,8 @@ import '@brightspace-ui/core/components/dropdown/dropdown.js';
 import '@brightspace-ui/core/components/dropdown/dropdown-content.js';
 import '@brightspace-ui/core/components/menu/menu.js';
 import '@brightspace-ui/core/components/menu/menu-item.js';
+import '@brightspace-ui/core/components/button/floating-buttons.js';
+import '@brightspace-ui/core/components/button/button.js';
 import { ActivityEditorFeaturesMixin, Milestones } from '../mixins/d2l-activity-editor-features-mixin.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { heading4Styles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';


### PR DESCRIPTION
# Overview 
This PR closes:
> [DE40535](https://rally1.rallydev.com/#/detail/defect/435207584720?fdp=true): Floating buttons in rubric no longer float

There is a problem where after the 20.20.8 release the rubric buttons would not "float" and stick to the bottom of the page as you scroll. This issue was fixed by including the necessary imports for the components used.

# Before the change

1. Navigate to `Assignments > New Assignment > Add rubric > Create New`
2. Observe buttons are not visible.

![image](https://user-images.githubusercontent.com/33091324/94480844-ded99d80-01a4-11eb-9bb8-3a0389e0e508.png)

# After proposed change
1. Navigate to `Assignments > New Assignment > Add rubric > Create New`
2. Observe buttons are visible. Behaviour matches 20.20.7 behaviour

![image](https://user-images.githubusercontent.com/33091324/94481085-35df7280-01a5-11eb-8f0b-ca0dca602303.png)

# Background information and deeper investigation

Speaking with Dave Lockhart:

> Starting in 20.20.8, BSI builds went unbundled. Before that, we built all our components together and producing just a few very large (~700 KB) files that our poor users downloaded, parsed and executed on every page. This meant that almost every web component was included in the bundle that was included on every page.
With unbundling, we included nothing by default and rely instead of JavaScript imports (import 'blah.js';) to let the browser only download the things that are actually needed on each page.
The problem you ran into is that you weren’t actually importing all the things that your component needed. In a bundled world, chances are buttons and floating buttons were already included in the bundle so you wouldn’t have noticed this unless you were using your component in isolation (not in a Brightspace page).
[3:19 PM] Lots more detail on that here:
https://blog.d2l.dev/2020/06/14/unbundled-bsi/


# Notes: 
- UI still has some noticeable issues
  - Floating button container does not extend fully to the left of the window.
  - Horizontal scroll bar appears because the right extent of the floating button container extends past the window
  - As soon as window is resized the left extent resizes and fills the full width, however, the scroll bar is still visible.
  - This may be addressed in a future PR (possibly by switching to [`d2l-dialog-fullscreen`](https://github.com/BrightspaceUI/core/tree/master/components/dialog#d2l-dialog-fullscreen))