### PR TITLE
Allow primary slot and body tag to scroll

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
@@ -28,7 +28,6 @@ class ContentEditor extends ActivityEditorContainerMixin(RtlMixin(ActivityEditor
 				display: block;
 			}
 			div[slot="primary"] {
-				height: calc(100% - 2 * var(--d2l-primary-padding));
 				padding: var(--d2l-primary-padding);
 			}
 			div[slot="secondary"] {
@@ -48,8 +47,8 @@ class ContentEditor extends ActivityEditorContainerMixin(RtlMixin(ActivityEditor
 
 	constructor() {
 		super(store);
-		// Override the 'scroll' property set by the page to remove the unnecessary scrollbar
-		document.body.style.overflow = 'hidden';
+		// Only show the scrollbar when necessary
+		document.body.style.overflow = 'auto';
 	}
 
 	render() {


### PR DESCRIPTION
Adjusting `css` so that the primary slot can scroll when description gets larger. Also setting `body.overflow` to `auto` so that when the window re-sizes and the `secondary` slot gets added below the `primary` slot, the user can scroll the body tag and still see all the content. If it was set to `hidden` the user would not be able to scroll and see any of the content in the `secondary` slot of the FACE template. (where the availability dates stuff is)

Related to [this issue](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F438541484248) where editing the description to make it very long hides the name field.

![content-scroll-bars](https://user-images.githubusercontent.com/64804046/94600396-ced2c400-025f-11eb-9b55-6bd087b0dc26.gif)
