### PR TITLE
Rfegan/us119463 add quiz editor component

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -13,6 +13,7 @@ import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
+import { secondarySlotStyles } from '../shared-styles';
 import { shared as store } from './state/assignment-store.js';
 
 class AssignmentEditor extends ActivityEditorContainerMixin(AsyncContainerMixin(RtlMixin(LocalizeActivityAssignmentEditorMixin(ActivityEditorMixin(MobxLitElement))))) {
@@ -75,7 +76,7 @@ class AssignmentEditor extends ActivityEditorContainerMixin(AsyncContainerMixin(
 	}
 
 	static get styles() {
-		return css`
+		return [secondarySlotStyles, css`
 			:host {
 				display: block;
 			}
@@ -92,10 +93,6 @@ class AssignmentEditor extends ActivityEditorContainerMixin(AsyncContainerMixin(
 			.d2l-activity-assignment-editor-secondary-panel {
 				padding: 10px;
 			}
-			div[slot="secondary"] {
-				background: var(--d2l-color-gypsum);
-				height: 100%;
-			}
 			.d2l-locked-alert {
 				align-items: baseline;
 				display: flex;
@@ -107,7 +104,7 @@ class AssignmentEditor extends ActivityEditorContainerMixin(AsyncContainerMixin(
 				padding-left: 1rem;
 				padding-right: 0;
 			}
-		`;
+		`];
 	}
 
 	constructor() {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -13,7 +13,6 @@ import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
-import { secondarySlotStyles } from '../shared-styles';
 import { shared as store } from './state/assignment-store.js';
 
 class AssignmentEditor extends ActivityEditorContainerMixin(AsyncContainerMixin(RtlMixin(LocalizeActivityAssignmentEditorMixin(ActivityEditorMixin(MobxLitElement))))) {
@@ -76,7 +75,7 @@ class AssignmentEditor extends ActivityEditorContainerMixin(AsyncContainerMixin(
 	}
 
 	static get styles() {
-		return [secondarySlotStyles, css`
+		return css`
 			:host {
 				display: block;
 			}
@@ -104,7 +103,7 @@ class AssignmentEditor extends ActivityEditorContainerMixin(AsyncContainerMixin(
 				padding-left: 1rem;
 				padding-right: 0;
 			}
-		`];
+		`;
 	}
 
 	constructor() {
@@ -192,7 +191,7 @@ class AssignmentEditor extends ActivityEditorContainerMixin(AsyncContainerMixin(
 		const hasSubmissions = assignment && assignment.submissionAndCompletionProps.assignmentHasSubmissions;
 
 		return html`
-			<d2l-template-primary-secondary slot="editor" width-type="${this.widthType}">
+			<d2l-template-primary-secondary background-shading="secondary" slot="editor" width-type="${this.widthType}">
 				<slot name="editor-nav" slot="header"></slot>
 				<div slot="primary" class="d2l-activity-assignment-editor-primary-panel">
 					<d2l-alert type="error" ?hidden=${!this.isError}>${this.localize('assignmentSaveError')}</d2l-alert>

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -21,18 +21,27 @@ class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LocalizeMix
 				telemetryId="assignments"
 				.href=${this.href}
 				.token=${this.token}
-				?is-saving=${this.isSaving}
-			>
-				<d2l-template-primary-secondary slot="editor" width-type="${this.widthType}">
-				<slot name="editor-nav" slot="header"></slot>
-				<d2l-activity-editor-footer
-					.href="${this.href}"
-					.token="${this.token}"
-					slot="footer"
-					class="d2l-activity-editor-footer">
-				</d2l-activity-editor-footer>
-				</d2l-template-primary-secondary>
+				?is-saving=${this.isSaving}>
+
+				${this._editorTemplate}
+
 			</d2l-activity-editor>
+		`;
+	}
+
+	get _editorTemplate() {
+		return html`
+			<d2l-template-primary-secondary slot="editor" width-type="${this.widthType}">
+			<slot name="editor-nav" slot="header"></slot>
+			<div slot="secondary">
+			</div>
+			<d2l-activity-editor-footer
+				.href="${this.href}"
+				.token="${this.token}"
+				slot="footer"
+				class="d2l-activity-editor-footer">
+			</d2l-activity-editor-footer>
+			</d2l-template-primary-secondary>
 		`;
 	}
 }

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -1,8 +1,9 @@
 import { html, LitElement } from 'lit-element/lit-element.js';
+import { ActivityEditorContainerMixin } from '../mixins/d2l-activity-editor-container-mixin'
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 
-class QuizEditor extends EntityMixinLit(LocalizeMixin(LitElement)) {
+class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LocalizeMixin(LitElement))) {
 
 	static get properties() {
 		return {
@@ -14,7 +15,6 @@ class QuizEditor extends EntityMixinLit(LocalizeMixin(LitElement)) {
 	}
 
 	render() {
-
 		return html`
 			<d2l-activity-editor
 				type="assignment"

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -1,0 +1,29 @@
+import { html, LitElement } from 'lit-element/lit-element.js';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+
+class QuizEditor extends EntityMixinLit(LocalizeMixin(LitElement)) {
+	render() {
+
+		return html`
+			<d2l-activity-editor
+				type="assignment"
+				telemetryId="assignments"
+				.href=${this.href}
+				.token=${this.token}
+				?is-saving=${this.isSaving}
+			>
+				<d2l-template-primary-secondary slot="editor" width-type="${this.widthType}">
+				<slot name="editor-nav" slot="header"></slot>
+				<d2l-activity-editor-footer
+					.href="${this.href}"
+					.token="${this.token}"
+					slot="footer"
+					class="d2l-activity-editor-footer">
+				</d2l-activity-editor-footer>
+				</d2l-template-primary-secondary>
+			</d2l-activity-editor>
+		`;
+	}
+}
+customElements.define('d2l-activity-quiz-editor', QuizEditor);

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -1,4 +1,4 @@
-import { html, LitElement } from 'lit-element/lit-element.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { ActivityEditorContainerMixin } from '../mixins/d2l-activity-editor-container-mixin'
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
@@ -12,6 +12,27 @@ class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LocalizeMix
 			*/
 			widthType: { type: String, attribute: 'width-type' }
 		};
+	}
+
+	static get styles() {
+		return css`
+			:host {
+				display: block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+			.d2l-activity-assignment-editor-primary-panel {
+				padding: 20px;
+			}
+			.d2l-activity-assignment-editor-secondary-panel {
+				padding: 10px;
+			}
+			div[slot="secondary"] {
+				background: var(--d2l-color-gypsum);
+				height: 100%;
+			}
+		`;
 	}
 
 	render() {

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -3,6 +3,16 @@ import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 
 class QuizEditor extends EntityMixinLit(LocalizeMixin(LitElement)) {
+
+	static get properties() {
+		return {
+			/**
+			* Set the WidthType on the template to constrain page width if necessary
+			*/
+			widthType: { type: String, attribute: 'width-type' }
+		};
+	}
+
 	render() {
 
 		return html`

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -2,7 +2,6 @@ import { html, LitElement } from 'lit-element/lit-element.js';
 import { ActivityEditorContainerMixin } from '../mixins/d2l-activity-editor-container-mixin';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { LocalizeActivityEditorMixin } from '../mixins/d2l-activity-editor-lang-mixin';
-import { secondarySlotStyles } from '../shared-styles';
 
 class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LocalizeActivityEditorMixin(LitElement))) {
 
@@ -15,9 +14,6 @@ class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LocalizeAct
 		};
 	}
 
-	static get styles() {
-		return secondarySlotStyles;
-	}
 
 	render() {
 		return html`
@@ -36,7 +32,7 @@ class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LocalizeAct
 
 	get _editorTemplate() {
 		return html`
-			<d2l-template-primary-secondary slot="editor" width-type="${this.widthType}">
+			<d2l-template-primary-secondary background-shading="secondary" slot="editor" width-type="${this.widthType}">
 				<slot name="editor-nav" slot="header"></slot>
 				<div slot="secondary"></div>
 				<d2l-activity-editor-footer

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -14,7 +14,6 @@ class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LocalizeAct
 		};
 	}
 
-
 	render() {
 		return html`
 			<d2l-activity-editor

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -1,5 +1,5 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
-import { ActivityEditorContainerMixin } from '../mixins/d2l-activity-editor-container-mixin'
+import { ActivityEditorContainerMixin } from '../mixins/d2l-activity-editor-container-mixin';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -1,9 +1,10 @@
-import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { html, LitElement } from 'lit-element/lit-element.js';
 import { ActivityEditorContainerMixin } from '../mixins/d2l-activity-editor-container-mixin';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityEditorMixin } from '../mixins/d2l-activity-editor-lang-mixin';
+import { secondarySlotStyles } from '../shared-styles';
 
-class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LocalizeMixin(LitElement))) {
+class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LocalizeActivityEditorMixin(LitElement))) {
 
 	static get properties() {
 		return {
@@ -15,12 +16,7 @@ class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LocalizeMix
 	}
 
 	static get styles() {
-		return css`
-			div[slot="secondary"] {
-				background: var(--d2l-color-gypsum);
-				height: 100%;
-			}
-		`;
+		return secondarySlotStyles;
 	}
 
 	render() {

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -41,15 +41,14 @@ class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LocalizeMix
 	get _editorTemplate() {
 		return html`
 			<d2l-template-primary-secondary slot="editor" width-type="${this.widthType}">
-			<slot name="editor-nav" slot="header"></slot>
-			<div slot="secondary">
-			</div>
-			<d2l-activity-editor-footer
-				.href="${this.href}"
-				.token="${this.token}"
-				slot="footer"
-				class="d2l-activity-editor-footer">
-			</d2l-activity-editor-footer>
+				<slot name="editor-nav" slot="header"></slot>
+				<div slot="secondary"></div>
+				<d2l-activity-editor-footer
+					.href="${this.href}"
+					.token="${this.token}"
+					slot="footer"
+					class="d2l-activity-editor-footer">
+				</d2l-activity-editor-footer>
 			</d2l-template-primary-secondary>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -16,18 +16,6 @@ class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LocalizeMix
 
 	static get styles() {
 		return css`
-			:host {
-				display: block;
-			}
-			:host([hidden]) {
-				display: none;
-			}
-			.d2l-activity-assignment-editor-primary-panel {
-				padding: 20px;
-			}
-			.d2l-activity-assignment-editor-secondary-panel {
-				padding: 10px;
-			}
 			div[slot="secondary"] {
 				background: var(--d2l-color-gypsum);
 				height: 100%;

--- a/components/d2l-activity-editor/shared-styles.js
+++ b/components/d2l-activity-editor/shared-styles.js
@@ -1,0 +1,8 @@
+import { css } from 'lit-element';
+
+export const secondarySlotStyles = css`
+	div[slot="secondary"] {
+		background: var(--d2l-color-gypsum);
+		height: 100%;
+	}
+`;

--- a/components/d2l-activity-editor/shared-styles.js
+++ b/components/d2l-activity-editor/shared-styles.js
@@ -1,8 +1,0 @@
-import { css } from 'lit-element';
-
-export const secondarySlotStyles = css`
-	div[slot="secondary"] {
-		background: var(--d2l-color-gypsum);
-		height: 100%;
-	}
-`;


### PR DESCRIPTION
New component based on [this story](https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=/userstory/413201069796).

The styling has been duplicated from `d2l-activity-assignment-editor` and there might be a better way to share styles between these 2 files.

It currently results in a view like this:

![face-quiz](https://user-images.githubusercontent.com/46040098/94751152-948b2480-033c-11eb-9d96-28437386bedd.jpg)
