### PR TITLE
Rfegan/us119463 fix back to quizzes btn

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -1,9 +1,8 @@
 import { html, LitElement } from 'lit-element/lit-element.js';
 import { ActivityEditorContainerMixin } from '../mixins/d2l-activity-editor-container-mixin';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
-import { LocalizeActivityAssignmentEditorMixin } from '../d2l-activity-assignment-editor/mixins/d2l-activity-assignment-lang-mixin';
 
-class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LocalizeActivityAssignmentEditorMixin(LitElement))) {
+class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LitElement)) {
 
 	static get properties() {
 		return {

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -1,9 +1,9 @@
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { ActivityEditorContainerMixin } from '../mixins/d2l-activity-editor-container-mixin';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeActivityAssignmentEditorMixin } from '../d2l-activity-assignment-editor/mixins/d2l-activity-assignment-lang-mixin';
 
-class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LocalizeMixin(LitElement))) {
+class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LocalizeActivityAssignmentEditorMixin(LitElement))) {
 
 	static get properties() {
 		return {
@@ -35,6 +35,11 @@ class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LocalizeMix
 				${this._editorTemplate}
 
 			</d2l-activity-editor>
+
+			<d2l-dialog-confirm title-text="${this.localize('discardChangesTitle')}" text=${this.localize('discardChangesQuestion')}>
+				<d2l-button slot="footer" primary dialog-action="confirm">${this.localize('yesLabel')}</d2l-button>
+				<d2l-button slot="footer" dialog-action="cancel">${this.localize('noLabel')}</d2l-button>
+			</d2l-dialog-confirm>
 		`;
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -26,11 +26,6 @@ class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LocalizeAct
 				${this._editorTemplate}
 
 			</d2l-activity-editor>
-
-			<d2l-dialog-confirm title-text="${this.localize('discardChangesTitle')}" text=${this.localize('discardChangesQuestion')}>
-				<d2l-button slot="footer" primary dialog-action="confirm">${this.localize('yesLabel')}</d2l-button>
-				<d2l-button slot="footer" dialog-action="cancel">${this.localize('noLabel')}</d2l-button>
-			</d2l-dialog-confirm>
 		`;
 	}
 

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
@@ -60,6 +60,11 @@ export const ActivityEditorContainerMixin = superclass => class extends Activity
 
 		if (editorsPendingChanges.some(Boolean)) {
 			const dialog = this.shadowRoot.querySelector('d2l-dialog-confirm');
+
+			if (!dialog) {
+				return this.dispatchEvent(this.cancelCompleteEvent);
+			}
+
 			const action = await dialog.open();
 			if (action === 'cancel' || action === 'abort') {
 				return;


### PR DESCRIPTION
As part of the AC for [US119463](https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=/userstory/413201069796) the "Back to manage quizzes" button should be working. 

Currently, the "back to manage <activity>" buttons rely on there being a dialog component available to trigger the confirmation flow. In this case, the confirmation dialog will be handled in a separate story and so I have added a check for when we have a non-existant dialog.

In this case if the dialog does not exist then we consider the "cancel" event to be completed and automatically redirect back to the manage page.