### PR TITLE
US121067 use d2l-input-text for scoreOutOf with built-in label, even …

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -119,9 +119,6 @@ class AssignmentEditorDetail extends AsyncContainerMixin(SkeletonMixin(SaveStatu
 
 			<div id="score-and-duedate-container">
 				<div id="score-container">
-					<div class="d2l-activity-label-container">
-						<label class="d2l-label-text d2l-skeletize">${this.localize('scoreOutOf')}</label>
-					</div>
 					<d2l-activity-score-editor
 						?skeleton="${this.skeleton}"
 						.href="${this.activityUsageHref}"

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ar.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ar.js
@@ -24,7 +24,6 @@ export default {
 	"submissionType": "نوع الإرسال", // Label for the submission type field when creating/editing an assignment
 	"annotationTools": "أدوات التعليق التوضيحي", // Label for enabling/disabling Annotation Tools when creating/editing an assignment
 	"annotationToolDescription": "توفير أدوات التعليق التوضيحي للتقييم", //Description next to the checkbox for annotation tools when creating/editing an assignment
-	"scoreOutOf": "مجموع الدرجات من أصل", // Label for the score-out-of field when creating/editing an activity
 	"anonymousGradingEnabled": "وضع علامة كمجهول", // Summary message for accordion when anonymous grading is enabled
 	"evaluationAndFeedback": "التقييم والملاحظات", // Header text for the evaluation and feedback summarizer
 	"txtAssignmentType": "نوع الفرض", // Label for assignment type

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/cy-gb.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/cy-gb.js
@@ -24,7 +24,6 @@ export default {
 	"submissionType": "Math o Gyflwyniad", // Label for the submission type field when creating/editing an assignment
 	"annotationTools": "Dulliau Gwneud Nodiadau", // Label for enabling/disabling Annotation Tools when creating/editing an assignment
 	"annotationToolDescription": "Gwneud dulliau o wneud nodiadau’n hygyrch ar gyfer asesiad", //Description next to the checkbox for annotation tools when creating/editing an assignment
-	"scoreOutOf": "Sgôr Allan O", // Label for the score-out-of field when creating/editing an activity
 	"anonymousGradingEnabled": "Wrthi’n marcio’n ddienw", // Summary message for accordion when anonymous grading is enabled
 	"evaluationAndFeedback": "Gwerthuso ac Adborth", // Header text for the evaluation and feedback summarizer
 	"txtAssignmentType": "Math o Aseiniad", // Label for assignment type

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/da-dk.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/da-dk.js
@@ -24,7 +24,6 @@ export default {
 	"submissionType": "Submission Type", // Label for the submission type field when creating/editing an assignment
 	"annotationTools": "Annotation Tools", // Label for enabling/disabling Annotation Tools when creating/editing an assignment
 	"annotationToolDescription": "Make annotation tools available for assessment", //Description next to the checkbox for annotation tools when creating/editing an assignment
-	"scoreOutOf": "Score Out Of", // Label for the score-out-of field when creating/editing an activity
 	"anonymousGradingEnabled": "Anonym markering", // Summary message for accordion when anonymous grading is enabled
 	"evaluationAndFeedback": "Evaluering og feedback", // Header text for the evaluation and feedback summarizer
 	"txtAssignmentType": "Opgavetype", // Label for assignment type

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/de.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/de.js
@@ -24,7 +24,6 @@ export default {
 	"submissionType": "Abgabetyp", // Label for the submission type field when creating/editing an assignment
 	"annotationTools": "Anmerkungstools", // Label for enabling/disabling Annotation Tools when creating/editing an assignment
 	"annotationToolDescription": "Anmerkungstools für die Beurteilung zur Verfügung stellen", //Description next to the checkbox for annotation tools when creating/editing an assignment
-	"scoreOutOf": "Punktzahl von", // Label for the score-out-of field when creating/editing an activity
 	"anonymousGradingEnabled": "Anonyme Markierung", // Summary message for accordion when anonymous grading is enabled
 	"evaluationAndFeedback": "Bewertung und Feedback", // Header text for the evaluation and feedback summarizer
 	"txtAssignmentType": "Übungstyp", // Label for assignment type

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
@@ -24,7 +24,6 @@ export default {
 	"submissionType": "Submission Type", // Label for the submission type field when creating/editing an assignment
 	"annotationTools": "Annotation Tools", // Label for enabling/disabling Annotation Tools when creating/editing an assignment
 	"annotationToolDescription": "Make annotation tools available for assessment", //Description next to the checkbox for annotation tools when creating/editing an assignment
-	"scoreOutOf": "Score Out Of", // Label for the score-out-of field when creating/editing an activity
 	"anonymousGradingEnabled": "Anonymous marking", // Summary message for accordion when anonymous grading is enabled
 	"evaluationAndFeedback": "Evaluation & Feedback", // Header text for the evaluation and feedback summarizer
 	"txtAssignmentType": "Assignment Type", // Label for assignment type

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/es-es.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/es-es.js
@@ -24,7 +24,6 @@ export default {
 	"submissionType": "Tipo de envío", // Label for the submission type field when creating/editing an assignment
 	"annotationTools": "Herramientas de anotación", // Label for enabling/disabling Annotation Tools when creating/editing an assignment
 	"annotationToolDescription": "Dejar las herramientas de anotación disponibles para la evaluación", //Description next to the checkbox for annotation tools when creating/editing an assignment
-	"scoreOutOf": "Puntuación sobre", // Label for the score-out-of field when creating/editing an activity
 	"anonymousGradingEnabled": "Marca de anónimo", // Summary message for accordion when anonymous grading is enabled
 	"evaluationAndFeedback": "Evaluación y comentarios", // Header text for the evaluation and feedback summarizer
 	"txtAssignmentType": "Tipo de tarea", // Label for assignment type

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/es.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/es.js
@@ -24,7 +24,6 @@ export default {
 	"submissionType": "Tipo de material enviado", // Label for the submission type field when creating/editing an assignment
 	"annotationTools": "Herramientas de anotación", // Label for enabling/disabling Annotation Tools when creating/editing an assignment
 	"annotationToolDescription": "Dejar las herramientas de anotación disponibles para la evaluación", //Description next to the checkbox for annotation tools when creating/editing an assignment
-	"scoreOutOf": "Puntuación sobre", // Label for the score-out-of field when creating/editing an activity
 	"anonymousGradingEnabled": "Marca de anónimo", // Summary message for accordion when anonymous grading is enabled
 	"evaluationAndFeedback": "Evaluación y comentarios", // Header text for the evaluation and feedback summarizer
 	"txtAssignmentType": "Tipo de asignación", // Label for assignment type

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/fr-fr.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/fr-fr.js
@@ -24,7 +24,6 @@ export default {
 	"submissionType": "Type de soumission", // Label for the submission type field when creating/editing an assignment
 	"annotationTools": "Outils d’annotation", // Label for enabling/disabling Annotation Tools when creating/editing an assignment
 	"annotationToolDescription": "Rendre les outils d’annotation disponibles pour l’évaluation", //Description next to the checkbox for annotation tools when creating/editing an assignment
-	"scoreOutOf": "Note sur", // Label for the score-out-of field when creating/editing an activity
 	"anonymousGradingEnabled": "Anonymat des copies", // Summary message for accordion when anonymous grading is enabled
 	"evaluationAndFeedback": "Évaluation et réactions", // Header text for the evaluation and feedback summarizer
 	"txtAssignmentType": "Type de devoir", // Label for assignment type

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/fr.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/fr.js
@@ -24,7 +24,6 @@ export default {
 	"submissionType": "Type de soumission", // Label for the submission type field when creating/editing an assignment
 	"annotationTools": "Outils d’annotation", // Label for enabling/disabling Annotation Tools when creating/editing an assignment
 	"annotationToolDescription": "Rendre les outils d’annotation disponibles pour l’évaluation", //Description next to the checkbox for annotation tools when creating/editing an assignment
-	"scoreOutOf": "Note sur", // Label for the score-out-of field when creating/editing an activity
 	"anonymousGradingEnabled": "Attribution anonyme d\'état", // Summary message for accordion when anonymous grading is enabled
 	"evaluationAndFeedback": "Évaluation et rétroaction", // Header text for the evaluation and feedback summarizer
 	"txtAssignmentType": "Type de travail", // Label for assignment type

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ja.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ja.js
@@ -24,7 +24,6 @@ export default {
 	"submissionType": "ドロップボックス送信のタイプ", // Label for the submission type field when creating/editing an assignment
 	"annotationTools": "注釈ツール", // Label for enabling/disabling Annotation Tools when creating/editing an assignment
 	"annotationToolDescription": "注釈ツールを評価に使用できるようにする", //Description next to the checkbox for annotation tools when creating/editing an assignment
-	"scoreOutOf": "満点スコア", // Label for the score-out-of field when creating/editing an activity
 	"anonymousGradingEnabled": "匿名マーキング", // Summary message for accordion when anonymous grading is enabled
 	"evaluationAndFeedback": "評価とフィードバック", // Header text for the evaluation and feedback summarizer
 	"txtAssignmentType": "課題タイプ", // Label for assignment type

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ko.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ko.js
@@ -24,7 +24,6 @@ export default {
 	"submissionType": "제출 유형", // Label for the submission type field when creating/editing an assignment
 	"annotationTools": "주석 도구", // Label for enabling/disabling Annotation Tools when creating/editing an assignment
 	"annotationToolDescription": "주석 도구를 평가에 사용할 수 있게 함", //Description next to the checkbox for annotation tools when creating/editing an assignment
-	"scoreOutOf": "기준 만점 점수", // Label for the score-out-of field when creating/editing an activity
 	"anonymousGradingEnabled": "익명 표시", // Summary message for accordion when anonymous grading is enabled
 	"evaluationAndFeedback": "평가 및 피드백", // Header text for the evaluation and feedback summarizer
 	"txtAssignmentType": "과제 유형", // Label for assignment type

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/nl.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/nl.js
@@ -24,7 +24,6 @@ export default {
 	"submissionType": "Type indiening", // Label for the submission type field when creating/editing an assignment
 	"annotationTools": "Annotatiehulpmiddelen", // Label for enabling/disabling Annotation Tools when creating/editing an assignment
 	"annotationToolDescription": "Annotatiehulpmiddelen beschikbaar maken voor beoordeling", //Description next to the checkbox for annotation tools when creating/editing an assignment
-	"scoreOutOf": "Score uit", // Label for the score-out-of field when creating/editing an activity
 	"anonymousGradingEnabled": "Anonieme beoordeling", // Summary message for accordion when anonymous grading is enabled
 	"evaluationAndFeedback": "Evaluatie en feedback", // Header text for the evaluation and feedback summarizer
 	"txtAssignmentType": "Type opdracht", // Label for assignment type

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/pt.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/pt.js
@@ -24,7 +24,6 @@ export default {
 	"submissionType": "Tipo de Envio", // Label for the submission type field when creating/editing an assignment
 	"annotationTools": "Ferramentas de Anotação", // Label for enabling/disabling Annotation Tools when creating/editing an assignment
 	"annotationToolDescription": "Disponibilizar ferramentas de anotação para avaliação", //Description next to the checkbox for annotation tools when creating/editing an assignment
-	"scoreOutOf": "Pontuação de", // Label for the score-out-of field when creating/editing an activity
 	"anonymousGradingEnabled": "Marcação anônima", // Summary message for accordion when anonymous grading is enabled
 	"evaluationAndFeedback": "Avaliação e Comentários", // Header text for the evaluation and feedback summarizer
 	"txtAssignmentType": "Tipo de Atividade", // Label for assignment type

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/sv.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/sv.js
@@ -24,7 +24,6 @@ export default {
 	"submissionType": "Inlämningstyp", // Label for the submission type field when creating/editing an assignment
 	"annotationTools": "Kommentarsverktyg", // Label for enabling/disabling Annotation Tools when creating/editing an assignment
 	"annotationToolDescription": "Gör kommentarsverktygen tillgängliga för bedömning", //Description next to the checkbox for annotation tools when creating/editing an assignment
-	"scoreOutOf": "Resultat av totalt", // Label for the score-out-of field when creating/editing an activity
 	"anonymousGradingEnabled": "Anonym märkning", // Summary message for accordion when anonymous grading is enabled
 	"evaluationAndFeedback": "Utvärdering och återkoppling", // Header text for the evaluation and feedback summarizer
 	"txtAssignmentType": "Typ av uppgift", // Label for assignment type

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/tr.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/tr.js
@@ -24,7 +24,6 @@ export default {
 	"submissionType": "Gönderim Türü", // Label for the submission type field when creating/editing an assignment
 	"annotationTools": "Açıklama Araçları", // Label for enabling/disabling Annotation Tools when creating/editing an assignment
 	"annotationToolDescription": "Açıklama araçlarını değerlendirme için etkinleştirin", //Description next to the checkbox for annotation tools when creating/editing an assignment
-	"scoreOutOf": "Maksimum Puan", // Label for the score-out-of field when creating/editing an activity
 	"anonymousGradingEnabled": "Anonim işaretleme", // Summary message for accordion when anonymous grading is enabled
 	"evaluationAndFeedback": "Değerlendirme ve geri bildirim", // Header text for the evaluation and feedback summarizer
 	"txtAssignmentType": "Ödev Türü", // Label for assignment type

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/zh-tw.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/zh-tw.js
@@ -24,7 +24,6 @@ export default {
 	"submissionType": "交件匣提交類型", // Label for the submission type field when creating/editing an assignment
 	"annotationTools": "註解工具", // Label for enabling/disabling Annotation Tools when creating/editing an assignment
 	"annotationToolDescription": "讓註解工具可在評量時使用", //Description next to the checkbox for annotation tools when creating/editing an assignment
-	"scoreOutOf": "總分", // Label for the score-out-of field when creating/editing an activity
 	"anonymousGradingEnabled": "匿名標記", // Summary message for accordion when anonymous grading is enabled
 	"evaluationAndFeedback": "評估與意見反應", // Header text for the evaluation and feedback summarizer
 	"txtAssignmentType": "作業類型", // Label for assignment type

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/zh.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/zh.js
@@ -24,7 +24,6 @@ export default {
 	"submissionType": "提交类型", // Label for the submission type field when creating/editing an assignment
 	"annotationTools": "批注工具", // Label for enabling/disabling Annotation Tools when creating/editing an assignment
 	"annotationToolDescription": "使批注工具可用于评估", //Description next to the checkbox for annotation tools when creating/editing an assignment
-	"scoreOutOf": "总分", // Label for the score-out-of field when creating/editing an activity
 	"anonymousGradingEnabled": "匿名标记", // Summary message for accordion when anonymous grading is enabled
 	"evaluationAndFeedback": "评估和反馈", // Header text for the evaluation and feedback summarizer
 	"txtAssignmentType": "作业类型", // Label for assignment type

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -45,47 +45,31 @@ class ActivityScoreEditor extends SkeletonMixin(ActivityEditorMixin(LocalizeActi
 			[hidden] {
 				display: none !important;
 			}
-			d2l-input-text,
-			#ungraded {
+			d2l-input-text {
 				width: auto;
 			}
-			#ungraded {
-				--d2l-input-padding: 0.4rem 1.65rem 0.4rem 0.75rem;
-				--d2l-input-padding-focus: calc(0.4rem - 1px) calc(1.65rem - 1px) calc(0.4rem - 1px) calc(0.75rem - 1px);
-				cursor: pointer;
-			}
-			:host([dir="rtl"]) #ungraded {
-				--d2l-input-padding: 0.4rem 0.75rem 0.4rem 1.65rem;
-				--d2l-input-padding-focus: calc(0.4rem - 1px) calc(0.75rem - 1px) calc(0.4rem - 1px) calc(1.65rem - 1px);
-			}
-			#ungraded:disabled,
 			.d2l-grade-info:disabled {
 				cursor: default;
 				opacity: 0.5;
 			}
 			#score-info-container,
-			#score-out-of-container,
 			#grade-info-container {
 				display: flex;
 			}
 			#score-info-container {
-				-webkit-align-items: center;
-				align-items: center;
+				-webkit-align-items: flex-end;
+				align-items: flex-end;
 				flex-wrap: wrap;
-			}
-			#score-out-of-container {
-				-webkit-align-items: baseline;
-				align-items: baseline;
 			}
 			#grade-info-container {
 				-webkit-align-items: center;
 				align-items: center;
 			}
 			.d2l-grade-type-text {
-				margin: 0 0.75rem 0 0.6rem;
+				margin: 0 0.75rem 0.5rem 0.6rem;
 			}
 			:host([dir="rtl"]) .d2l-grade-type-text {
-				margin: 0 0.6rem 0 0.75rem;
+				margin: 0 0.6rem 0.5rem 0.75rem;
 			}
 			#divider {
 				border-left: solid 1px var(--d2l-color-galena);
@@ -178,45 +162,34 @@ class ActivityScoreEditor extends SkeletonMixin(ActivityEditorMixin(LocalizeActi
 
 		this._focusUngraded = isUngraded;
 
-		return isUngraded || this.skeleton ? html`
-			<div id="ungraded-button-container" class="d2l-skeletize">
-				<button id="ungraded" class="d2l-input"
-					@click="${this._setGraded}"
-					aria-label="${this.localize('editor.addAGrade')}"
-					?disabled="${!canEditScoreOutOf}"
-				>
-					${this.localize('editor.ungraded')}
-				</button>
-			</div>
-		` : html`
+		return html`
 			<div id="score-info-container">
-				<div id="score-out-of-container">
-					<d2l-input-text
-						id="score-out-of"
-						label="${this.localize('editor.scoreOutOf')}"
-						label-hidden
-						value="${scoreOutOf}"
-						size=4
-						@change="${this._onScoreOutOfChanged}"
-						@blur="${this._onScoreOutOfChanged}"
-						aria-invalid="${scoreOutOfError ? 'true' : ''}"
-						?disabled="${!canEditScoreOutOf}"
-						novalidate
-					></d2l-input-text>
-					${scoreOutOfError ? html`
-						<d2l-tooltip
-							id="score-tooltip"
-							for="score-out-of"
-							position="bottom"
-							showing
-							align="start"
-						>
-							${scoreOutOfError ? html`<span>${this.localize(`editor.${scoreOutOfError}`)}</span>` : null}
-						</d2l-tooltip>
-					` : null}
-					<div class="d2l-body-compact d2l-grade-type-text">${gradeType}</div>
-				</div>
-				${canSeeGrades ? html`
+				<d2l-input-text
+					?skeleton="${this.skeleton}"
+					id="score-out-of"
+					label="${this.localize('editor.scoreOutOf')}"
+					value="${isUngraded ? this.localize('editor.ungraded') : scoreOutOf}"
+					size=${isUngraded ? 10 : 4}
+					@change="${this._onScoreOutOfChanged}"
+					@blur="${this._onScoreOutOfChanged}"
+					@click="${isUngraded ? this._setGraded : null}"
+					aria-invalid="${scoreOutOfError ? 'true' : ''}"
+					?disabled="${!canEditScoreOutOf}"
+					novalidate
+				></d2l-input-text>
+				${scoreOutOfError ? html`
+					<d2l-tooltip
+						id="score-tooltip"
+						for="score-out-of"
+						position="bottom"
+						showing
+						align="start"
+					>
+						${scoreOutOfError ? html`<span>${this.localize(`editor.${scoreOutOfError}`)}</span>` : null}
+					</d2l-tooltip>
+				` : null}
+				${!isUngraded ? html`<div class="d2l-body-compact d2l-grade-type-text">${gradeType}</div>` : null}
+				${canSeeGrades && !isUngraded ? html`
 					<div id="grade-info-container">
 						<div id="divider"></div>
 						<d2l-dropdown ?disabled="${!canEditScoreOutOf}">
@@ -262,9 +235,7 @@ class ActivityScoreEditor extends SkeletonMixin(ActivityEditorMixin(LocalizeActi
 
 		changedProperties.forEach((oldValue, propName) => {
 			if (propName === '_focusUngraded' && typeof oldValue !== 'undefined') {
-				const toFocus = this._focusUngraded ?
-					this.shadowRoot.querySelector('#ungraded') :
-					this.shadowRoot.querySelector('#score-out-of');
+				const toFocus = this.shadowRoot.querySelector('#score-out-of');
 				toFocus.focus();
 			} else if (propName === 'activityName') {
 				this._setNewGradeName(this.activityName);

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -21,7 +21,7 @@ import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
 import { shared as store } from './state/activity-store.js';
-
+/* eslint no-console: 0 */
 class ActivityScoreEditor extends SkeletonMixin(ActivityEditorMixin(LocalizeActivityEditorMixin(RtlMixin(MobxLitElement)))) {
 
 	static get properties() {
@@ -160,6 +160,8 @@ class ActivityScoreEditor extends SkeletonMixin(ActivityEditorMixin(LocalizeActi
 			canSeeGrades
 		} = activity && activity.scoreAndGrade || {};
 
+		console.log('scoreOutOf', scoreOutOf);
+
 		this._focusUngraded = isUngraded;
 
 		return html`
@@ -241,6 +243,7 @@ class ActivityScoreEditor extends SkeletonMixin(ActivityEditorMixin(LocalizeActi
 				this._setNewGradeName(this.activityName);
 			}
 		});
+		console.log('updated');
 	}
 
 	_addOrRemoveMenuItem() {

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -267,7 +267,11 @@ class ActivityScoreEditor extends SkeletonMixin(ActivityEditorMixin(LocalizeActi
 		}
 	}
 	_onScoreOutOfChanged() {
-		const scoreAndGrade = store.get(this.href).scoreAndGrade;
+		const activity = store.get(this.href);
+		if( activity == undefined) {
+			return;
+		}
+		const scoreAndGrade = activity.scoreAndGrade;
 		const scoreOutOf = this.shadowRoot.querySelector('#score-out-of').value;
 		if (scoreOutOf === scoreAndGrade.scoreOutOf) {
 			return;

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -267,10 +267,6 @@ class ActivityScoreEditor extends SkeletonMixin(ActivityEditorMixin(LocalizeActi
 		}
 	}
 	_onScoreOutOfChanged() {
-		console.log('********************** this.href', this.href);
-		console.log('********************** store', store);
-		console.log('********************** store.get(this.href)', store.get(this.href));
-		console.log('********************** store.get(this.href).scoreAndGrade', store.get(this.href).scoreAndGrade);
 		const scoreAndGrade = store.get(this.href).scoreAndGrade;
 		const scoreOutOf = this.shadowRoot.querySelector('#score-out-of').value;
 		if (scoreOutOf === scoreAndGrade.scoreOutOf) {

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -267,6 +267,10 @@ class ActivityScoreEditor extends SkeletonMixin(ActivityEditorMixin(LocalizeActi
 		}
 	}
 	_onScoreOutOfChanged() {
+		console.log('********************** this.href', this.href);
+		console.log('********************** store', store);
+		console.log('********************** store.get(this.href)', store.get(this.href));
+		console.log('********************** store.get(this.href).scoreAndGrade', store.get(this.href).scoreAndGrade);
 		const scoreAndGrade = store.get(this.href).scoreAndGrade;
 		const scoreOutOf = this.shadowRoot.querySelector('#score-out-of').value;
 		if (scoreOutOf === scoreAndGrade.scoreOutOf) {

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -21,7 +21,7 @@ import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
 import { shared as store } from './state/activity-store.js';
-/* eslint no-console: 0 */
+
 class ActivityScoreEditor extends SkeletonMixin(ActivityEditorMixin(LocalizeActivityEditorMixin(RtlMixin(MobxLitElement)))) {
 
 	static get properties() {
@@ -160,8 +160,6 @@ class ActivityScoreEditor extends SkeletonMixin(ActivityEditorMixin(LocalizeActi
 			canSeeGrades
 		} = activity && activity.scoreAndGrade || {};
 
-		console.log('scoreOutOf', scoreOutOf);
-
 		this._focusUngraded = isUngraded;
 
 		return html`
@@ -243,7 +241,6 @@ class ActivityScoreEditor extends SkeletonMixin(ActivityEditorMixin(LocalizeActi
 				this._setNewGradeName(this.activityName);
 			}
 		});
-		console.log('updated');
 	}
 
 	_addOrRemoveMenuItem() {

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -268,9 +268,10 @@ class ActivityScoreEditor extends SkeletonMixin(ActivityEditorMixin(LocalizeActi
 	}
 	_onScoreOutOfChanged() {
 		const activity = store.get(this.href);
-		if( activity == undefined) {
+		if (activity === undefined) {
 			return;
 		}
+
 		const scoreAndGrade = activity.scoreAndGrade;
 		const scoreOutOf = this.shadowRoot.querySelector('#score-out-of').value;
 		if (scoreOutOf === scoreAndGrade.scoreOutOf) {

--- a/components/d2l-activity-editor/state/activity-score-grade.js
+++ b/components/d2l-activity-editor/state/activity-score-grade.js
@@ -1,12 +1,12 @@
 import { action, configure as configureMobx, decorate, observable } from 'mobx';
 import { GradeCandidateCollection } from '../d2l-activity-grades/state/grade-candidate-collection.js';
-
+/* eslint no-console: 0 */
 configureMobx({ enforceActions: 'observed' });
 
 export class ActivityScoreGrade {
 
 	constructor(entity, token) {
-		this.scoreOutOf = entity.scoreOutOf() ? entity.scoreOutOf().toString() : undefined;
+		this.scoreOutOf = entity.scoreOutOf() ? entity.scoreOutOf().toString() : '';
 		this.scoreOutOfError = null;
 		this.token = token;
 		this.inGrades = entity.inGrades();
@@ -107,6 +107,7 @@ export class ActivityScoreGrade {
 		this.inGrades = false;
 		this.isUngraded = true;
 		this.setScoreOutOf('');
+		console.log('set ungraded');
 	}
 
 	validate() {

--- a/components/d2l-activity-editor/state/activity-score-grade.js
+++ b/components/d2l-activity-editor/state/activity-score-grade.js
@@ -1,6 +1,6 @@
 import { action, configure as configureMobx, decorate, observable } from 'mobx';
 import { GradeCandidateCollection } from '../d2l-activity-grades/state/grade-candidate-collection.js';
-/* eslint no-console: 0 */
+
 configureMobx({ enforceActions: 'observed' });
 
 export class ActivityScoreGrade {
@@ -107,7 +107,6 @@ export class ActivityScoreGrade {
 		this.inGrades = false;
 		this.isUngraded = true;
 		this.setScoreOutOf('');
-		console.log('set ungraded');
 	}
 
 	validate() {

--- a/test/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/test/d2l-activity-editor/d2l-activity-score-editor.js
@@ -12,7 +12,7 @@ function dispatchEvent(elem, eventType, composed) {
 	elem.dispatchEvent(e);
 }
 
-describe.skip('d2l-activity-score-editor', function() {
+describe('d2l-activity-score-editor', function() {
 
 	let el, href, activity, score;
 
@@ -102,7 +102,7 @@ describe.skip('d2l-activity-score-editor', function() {
 		});
 	});
 
-	describe('events', () => {
+	describe.only('events', () => {
 		it('updates score out of', async() => {
 			const input = el.shadowRoot.querySelector('#score-out-of');
 			input.value = '15';

--- a/test/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/test/d2l-activity-editor/d2l-activity-score-editor.js
@@ -76,7 +76,7 @@ describe('d2l-activity-score-editor', function() {
 			await expect(el).to.be.accessible();
 		});
 
-		it('renders score out of input with Ungraded text', async() => {
+		it.skip('renders score out of input with Ungraded text', async() => {
 			setTimeout(() => {
 				expect(el.shadowRoot.querySelectorAll('#score-out-of')).to.exist;
 				const input = el.shadowRoot.querySelector('#score-out-of');

--- a/test/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/test/d2l-activity-editor/d2l-activity-score-editor.js
@@ -77,9 +77,11 @@ describe('d2l-activity-score-editor', function() {
 		});
 
 		it('renders score out of input with Ungraded text', async() => {
-			expect(el.shadowRoot.querySelectorAll('#score-out-of')).to.exist;
-			const input = el.shadowRoot.querySelector('#score-out-of');
-			expect(input.value).to.equal('Ungraded');
+			setTimeout(() => {
+				expect(el.shadowRoot.querySelectorAll('#score-out-of')).to.exist;
+				const input = el.shadowRoot.querySelector('#score-out-of');
+				expect(input.value).to.equal('Ungraded');
+			}, 30);
 		});
 
 		it('does not render grade menu', async() => {

--- a/test/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/test/d2l-activity-editor/d2l-activity-score-editor.js
@@ -112,20 +112,18 @@ describe('d2l-activity-score-editor', function() {
 			expect(score.scoreOutOf).to.equal('15');
 		});
 
-		it('sets ungraded', async(done) => {
+		it('sets ungraded', async() => {
 			const menu = el.shadowRoot.querySelectorAll('d2l-menu-item')[2];
 			dispatchEvent(menu, 'd2l-menu-item-select', true);
 
 			expect(score.isUngraded).to.be.true;
-			done();
 		});
 
-		it('removes from grades', async(done) => {
+		it('removes from grades', async() => {
 			const menu = el.shadowRoot.querySelectorAll('d2l-menu-item')[1];
 			dispatchEvent(menu, 'd2l-menu-item-select', true);
 
 			expect(score.inGrades).to.be.false;
-			done();
 		});
 
 		it('adds to grades', async() => {

--- a/test/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/test/d2l-activity-editor/d2l-activity-score-editor.js
@@ -44,7 +44,7 @@ describe('d2l-activity-score-editor', function() {
 		store.clear();
 	});
 
-	describe.skip('graded', () => {
+	describe('graded', () => {
 		it('passes accessibility test', async() => {
 			await expect(el).to.be.accessible();
 		});
@@ -89,7 +89,7 @@ describe('d2l-activity-score-editor', function() {
 		});
 	});
 
-	describe('errors', () => {
+	describe.skip('errors', () => {
 		beforeEach(async() => {
 			score.setScoreOutOf('abc');
 			await elementUpdated(el);

--- a/test/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/test/d2l-activity-editor/d2l-activity-score-editor.js
@@ -76,8 +76,10 @@ describe('d2l-activity-score-editor', function() {
 			await expect(el).to.be.accessible();
 		});
 
-		it('renders ungraded button', async() => {
-			expect(el.shadowRoot.querySelectorAll('#ungraded')).to.exist;
+		it('renders score out of input with Ungraded text', async() => {
+			expect(el.shadowRoot.querySelectorAll('#score-out-of')).to.exist;
+			const input = el.shadowRoot.querySelector('#score-out-of');
+			expect(input.value).to.equal('Ungraded');
 		});
 
 		it('does not render grade menu', async() => {

--- a/test/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/test/d2l-activity-editor/d2l-activity-score-editor.js
@@ -44,7 +44,7 @@ describe('d2l-activity-score-editor', function() {
 		store.clear();
 	});
 
-	describe('graded', () => {
+	describe.skip('graded', () => {
 		it('passes accessibility test', async() => {
 			await expect(el).to.be.accessible();
 		});
@@ -66,7 +66,7 @@ describe('d2l-activity-score-editor', function() {
 		});
 	});
 
-	describe.skip('ungraded', () => {
+	describe('ungraded', () => {
 		beforeEach(async() => {
 			score.setUngraded();
 			await elementUpdated(el);

--- a/test/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/test/d2l-activity-editor/d2l-activity-score-editor.js
@@ -3,7 +3,7 @@ import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import { ActivityScoreGrade } from '../../components/d2l-activity-editor/state/activity-score-grade.js';
 import { ActivityUsage } from '../../components/d2l-activity-editor/state/activity-usage.js';
 import { shared as store } from '../../components/d2l-activity-editor/state/activity-store.js';
-
+/* eslint no-console: 0 */
 function dispatchEvent(elem, eventType, composed) {
 	const e = new Event(
 		eventType,
@@ -12,11 +12,12 @@ function dispatchEvent(elem, eventType, composed) {
 	elem.dispatchEvent(e);
 }
 
-describe('d2l-activity-score-editor', function() {
+describe.only('d2l-activity-score-editor', function() {
 
 	let el, href, activity, score;
 
 	beforeEach(async() => {
+		console.log('first beforeEach');
 		score = new ActivityScoreGrade({
 			scoreOutOf: () => 50,
 			inGrades: () => true,
@@ -66,17 +67,19 @@ describe('d2l-activity-score-editor', function() {
 		});
 	});
 
-	describe('ungraded', () => {
+	describe.only('ungraded', () => {
 		beforeEach(async() => {
+			console.log('second beforeEach');
 			score.setUngraded();
 			await elementUpdated(el);
+			console.log('end of second beforeEach');
 		});
 
 		it('passes accessibility test', async() => {
 			await expect(el).to.be.accessible();
 		});
 
-		it('renders score out of input with Ungraded text', async() => {
+		it.only('renders score out of input with Ungraded text', async() => {
 			expect(el.shadowRoot.querySelectorAll('#score-out-of')).to.exist;
 			const input = el.shadowRoot.querySelector('#score-out-of');
 			expect(input.value).to.equal('Ungraded');
@@ -89,7 +92,7 @@ describe('d2l-activity-score-editor', function() {
 
 	describe('errors', () => {
 		beforeEach(async() => {
-			score.setScoreOutOf('abc');
+			await score.setScoreOutOf('abc');
 			await elementUpdated(el);
 		});
 

--- a/test/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/test/d2l-activity-editor/d2l-activity-score-editor.js
@@ -66,7 +66,7 @@ describe('d2l-activity-score-editor', function() {
 		});
 	});
 
-	describe('ungraded', () => {
+	describe.skip('ungraded', () => {
 		beforeEach(async() => {
 			score.setUngraded();
 			await elementUpdated(el);
@@ -76,7 +76,7 @@ describe('d2l-activity-score-editor', function() {
 			await expect(el).to.be.accessible();
 		});
 
-		it.skip('renders score out of input with Ungraded text', async() => {
+		it('renders score out of input with Ungraded text', async() => {
 			setTimeout(() => {
 				expect(el.shadowRoot.querySelectorAll('#score-out-of')).to.exist;
 				const input = el.shadowRoot.querySelector('#score-out-of');

--- a/test/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/test/d2l-activity-editor/d2l-activity-score-editor.js
@@ -89,7 +89,7 @@ describe('d2l-activity-score-editor', function() {
 		});
 	});
 
-	describe.skip('errors', () => {
+	describe('errors', () => {
 		beforeEach(async() => {
 			score.setScoreOutOf('abc');
 			await elementUpdated(el);
@@ -104,7 +104,7 @@ describe('d2l-activity-score-editor', function() {
 		});
 	});
 
-	describe('events', () => {
+	describe.skip('events', () => {
 		it('updates score out of', async() => {
 			const input = el.shadowRoot.querySelector('#score-out-of');
 			input.value = '15';

--- a/test/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/test/d2l-activity-editor/d2l-activity-score-editor.js
@@ -12,7 +12,7 @@ function dispatchEvent(elem, eventType, composed) {
 	elem.dispatchEvent(e);
 }
 
-describe('d2l-activity-score-editor', function() {
+describe.skip('d2l-activity-score-editor', function() {
 
 	let el, href, activity, score;
 
@@ -77,11 +77,9 @@ describe('d2l-activity-score-editor', function() {
 		});
 
 		it('renders score out of input with Ungraded text', async() => {
-			setTimeout(() => {
-				expect(el.shadowRoot.querySelectorAll('#score-out-of')).to.exist;
-				const input = el.shadowRoot.querySelector('#score-out-of');
-				expect(input.value).to.equal('Ungraded');
-			}, 30);
+			expect(el.shadowRoot.querySelectorAll('#score-out-of')).to.exist;
+			const input = el.shadowRoot.querySelector('#score-out-of');
+			expect(input.value).to.equal('Ungraded');
 		});
 
 		it('does not render grade menu', async() => {
@@ -104,7 +102,7 @@ describe('d2l-activity-score-editor', function() {
 		});
 	});
 
-	describe.skip('events', () => {
+	describe('events', () => {
 		it('updates score out of', async() => {
 			const input = el.shadowRoot.querySelector('#score-out-of');
 			input.value = '15';

--- a/test/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/test/d2l-activity-editor/d2l-activity-score-editor.js
@@ -3,7 +3,7 @@ import { elementUpdated, expect, fixture, html } from '@open-wc/testing';
 import { ActivityScoreGrade } from '../../components/d2l-activity-editor/state/activity-score-grade.js';
 import { ActivityUsage } from '../../components/d2l-activity-editor/state/activity-usage.js';
 import { shared as store } from '../../components/d2l-activity-editor/state/activity-store.js';
-/* eslint no-console: 0 */
+
 function dispatchEvent(elem, eventType, composed) {
 	const e = new Event(
 		eventType,
@@ -12,12 +12,11 @@ function dispatchEvent(elem, eventType, composed) {
 	elem.dispatchEvent(e);
 }
 
-describe.only('d2l-activity-score-editor', function() {
+describe('d2l-activity-score-editor', function() {
 
 	let el, href, activity, score;
 
 	beforeEach(async() => {
-		console.log('first beforeEach');
 		score = new ActivityScoreGrade({
 			scoreOutOf: () => 50,
 			inGrades: () => true,
@@ -67,19 +66,17 @@ describe.only('d2l-activity-score-editor', function() {
 		});
 	});
 
-	describe.only('ungraded', () => {
+	describe('ungraded', () => {
 		beforeEach(async() => {
-			console.log('second beforeEach');
 			score.setUngraded();
 			await elementUpdated(el);
-			console.log('end of second beforeEach');
 		});
 
 		it('passes accessibility test', async() => {
 			await expect(el).to.be.accessible();
 		});
 
-		it.only('renders score out of input with Ungraded text', async() => {
+		it('renders score out of input with Ungraded text', async() => {
 			expect(el.shadowRoot.querySelectorAll('#score-out-of')).to.exist;
 			const input = el.shadowRoot.querySelector('#score-out-of');
 			expect(input.value).to.equal('Ungraded');
@@ -92,7 +89,7 @@ describe.only('d2l-activity-score-editor', function() {
 
 	describe('errors', () => {
 		beforeEach(async() => {
-			await score.setScoreOutOf('abc');
+			score.setScoreOutOf('abc');
 			await elementUpdated(el);
 		});
 

--- a/test/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/test/d2l-activity-editor/d2l-activity-score-editor.js
@@ -102,7 +102,7 @@ describe('d2l-activity-score-editor', function() {
 		});
 	});
 
-	describe.only('events', () => {
+	describe('events', () => {
 		it('updates score out of', async() => {
 			const input = el.shadowRoot.querySelector('#score-out-of');
 			input.value = '15';
@@ -112,18 +112,20 @@ describe('d2l-activity-score-editor', function() {
 			expect(score.scoreOutOf).to.equal('15');
 		});
 
-		it('sets ungraded', async() => {
+		it('sets ungraded', async(done) => {
 			const menu = el.shadowRoot.querySelectorAll('d2l-menu-item')[2];
 			dispatchEvent(menu, 'd2l-menu-item-select', true);
 
 			expect(score.isUngraded).to.be.true;
+			done();
 		});
 
-		it('removes from grades', async() => {
+		it('removes from grades', async(done) => {
 			const menu = el.shadowRoot.querySelectorAll('d2l-menu-item')[1];
 			dispatchEvent(menu, 'd2l-menu-item-select', true);
 
 			expect(score.inGrades).to.be.false;
+			done();
 		});
 
 		it('adds to grades', async() => {


### PR DESCRIPTION
…if ungraded
Replaces button with d2l-input-text, so internal label is used with both ungraded and graded input views.
![scoreOutOfFix](https://user-images.githubusercontent.com/1471557/94982229-cb546c80-04ed-11eb-921f-c24bceecb3f6.gif)

@dbatiste I think the reason we had the ungraded view as a button before is because clicking it triggers an action (i.e. showing the "points" and "In Grades" info). Do you think using a d2l-input-text here instead is OK accessibility-wise, even though clicking into it triggers this view change?

Note: I will still investigate using `input-number` instead of `input-text` as well as internal error handling - to come in subsequent PRs.