### PR TITLE
- Adding read only property to d2l-activity-attachments-editor

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
@@ -10,10 +10,10 @@ class ActivityAttachmentsEditor extends ActivityEditorMixin(SkeletonMixin(MobxLi
 	static get properties() {
 		return {
 			readOnly : {
-				attribute: "read-only", 
-				type: Boolean 
+				attribute: 'read-only',
+				type: Boolean
 			},
-			_canAddAttachments: { 
+			_canAddAttachments: {
 				type: Boolean
 			}
 		};

--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-editor.js
@@ -9,7 +9,13 @@ import { shared as store } from './state/attachment-collections-store.js';
 class ActivityAttachmentsEditor extends ActivityEditorMixin(SkeletonMixin(MobxLitElement)) {
 	static get properties() {
 		return {
-			_canAddAttachments: { type: Boolean },
+			readOnly : {
+				attribute: "read-only", 
+				type: Boolean 
+			},
+			_canAddAttachments: { 
+				type: Boolean
+			}
 		};
 	}
 
@@ -23,6 +29,7 @@ class ActivityAttachmentsEditor extends ActivityEditorMixin(SkeletonMixin(MobxLi
 
 	constructor() {
 		super(store);
+		this.readOnly = false;
 	}
 
 	render() {
@@ -40,7 +47,7 @@ class ActivityAttachmentsEditor extends ActivityEditorMixin(SkeletonMixin(MobxLi
 			href="${this.href}"
 			.token="${this.token}">
 		</d2l-activity-attachments-list>
-			${canAddAttachments || this.skeleton ? html`
+			${(canAddAttachments || this.skeleton) && !this.readOnly ? html`
 		<d2l-activity-attachments-picker
 			?skeleton="${this.skeleton}"
 			href="${this.href}"


### PR DESCRIPTION
Hello! I am looking for a way to make this component readonly, basically we need to see the list of current attachments, but not allow the user to upload anymore.  I tried to use the `_canAddAttachments` but it looks private to me as well is looks to be reset in the renderer based upon the collection - let me know if you think there is a better way to do this! 