### PR TITLE
Added values for telemetry performance

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -13,11 +13,17 @@ class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LitElement)
 		};
 	}
 
+	constructor() {
+		super();
+		this.type = 'quiz';
+		this.telemetryId = 'quiz';
+	}
+
 	render() {
 		return html`
 			<d2l-activity-editor
-				type="assignment"
-				telemetryId="assignments"
+				type="${this.type}"
+				telemetryId="${this.telemetryId}"
 				.href=${this.href}
 				.token=${this.token}
 				?is-saving=${this.isSaving}>


### PR DESCRIPTION
Based on [US119464](https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F413205972020). `ActivityEditorTelemetryMixin ` is already implemented in` d2l-activity-editor` so it seems to just be a matter of passing through type/telemetryId.

Tested the endpoint manually on postman with the following payload (received 201 response which matches response on quad assignments):

`{
	"EventType": "PerformanceEvent",
	"SourceId": "quiz",
	"Date": "2020-10-07T20:04:06.088Z",
	"EventBody": {
		"EventTypeGuid": "02a00ca0-e67d-4a6c-908b-ee80b8a61eec",
		"Action": "LoadView",
		"Object": {
			"Id":
				"https://beb93036-1642-437f-8460-2db5fbdf1e65.activities.api.dev.brightspace.com/activities/6606_51000_231/usages/6606",
			"Type": "quiz"
		},
		"UserTiming": [
			{
				"name": "d2l-activity-quiz-editor.page.rendered",
				"entryType": "measure",
				"startTime": 0,
				"duration": 9814.585000043735
			}
		]
	},
	"name": "LoadView",
	"ts": 1602101046
}`

![Postman](https://user-images.githubusercontent.com/46040098/95385945-817bd580-08a3-11eb-9be2-dd3ec7e79612.jpg)

Payload screenshot from Chrome which should match AC:

![payload](https://user-images.githubusercontent.com/46040098/95272764-11634600-07f6-11eb-8b0e-47faa76ec05f.jpg)
