### PR TITLE
Refactor the relationship between root editors, the d2l-activity-edit…

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -73,6 +73,7 @@ class AssignmentEditorDetail extends AsyncContainerMixin(SkeletonMixin(SaveStatu
 		this._debounceJobs = {};
 		this._linksProcessor = new LinksInMessageProcessor();
 		this.skeleton = true;
+		this.saveOrder = 2000;
 	}
 
 	render() {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -180,6 +180,29 @@ class AssignmentEditorDetail extends AsyncContainerMixin(SkeletonMixin(SaveStatu
 		});
 	}
 
+	async cancelCreate() {
+		const assignment = store.getAssignment(this.href);
+		return assignment && assignment.cancelCreate();
+	}
+
+	hasPendingChanges() {
+		const assignment = store.getAssignment(this.href);
+		if (!assignment) {
+			return false;
+		}
+
+		return assignment.dirty;
+	}
+
+	async save() {
+		const assignment = store.getAssignment(this.href);
+		if (!assignment) {
+			return;
+		}
+
+		await assignment.save();
+	}
+
 	_saveInstructions(value) {
 		store.getAssignment(this.href).setInstructions(value);
 		this._debounceJobs.value = Debouncer.debounce(

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ar.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ar.js
@@ -38,10 +38,6 @@ export default {
 	"assignmentSaveError": "لم يتم حفظ الفرض. يُرجى تصحيح الحقول الموضّحة باللون الأحمر.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
 	"folderTypeNoGroups": "لا تتوفر أي مجموعة. أنشئ مجموعات جديدة باستخدام أداة المجموعات.", // Folder type no groups
 	"folderTypeCreateGroups": "أنشئ مجموعات جديدة باستخدام أداة المجموعات.", // Folder type create groups
-	"discardChangesTitle": "هل تريد تجاهل التغييرات؟", // Discard Changes User Prompt
-	"discardChangesQuestion": "هل تريد بالتأكيد تجاهل التغييرات التي أجريتها؟", // Discard Changes User Prompt
-	"yesLabel": "نعم",
-	"noLabel": "لا",
 	"filesSubmissionLimit": "الملفات المسموح بها لكل إرسال",
 	"UnlimitedFilesPerSubmission": "غير محدودة",
 	"OneFilePerSubmission": "ملف واحد",

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/cy-gb.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/cy-gb.js
@@ -38,10 +38,6 @@ export default {
 	"assignmentSaveError": "Ni chadwyd eich aseiniad. Cywirwch y meysydd a amlinellir mewn coch.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
 	"folderTypeNoGroups": "Nid oes unrhyw grwpiau’n bodoli. Creu grwpiau newydd yn yr offeryn Grwpiau.", // Folder type no groups
 	"folderTypeCreateGroups": "Creu grwpiau newydd yn yr offeryn Grwpiau.", // Folder type create groups
-	"discardChangesTitle": "Dileu newidiadau?", // Discard Changes User Prompt
-	"discardChangesQuestion": "Ydych chi\'n siŵr eich bod chi eisiau dileu\'ch newidiadau?", // Discard Changes User Prompt
-	"yesLabel": "Ie",
-	"noLabel": "Na",
 	"filesSubmissionLimit": "Ffeiliau a Ganiateir Fesul Cyflwyniad",
 	"UnlimitedFilesPerSubmission": "Anghyfyngedig",
 	"OneFilePerSubmission": "Un Ffeil",

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/da-dk.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/da-dk.js
@@ -38,10 +38,6 @@ export default {
 	"assignmentSaveError": "Din opgave blev ikke gemt. Ret de felter, der er markeret med rødt.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
 	"folderTypeNoGroups": "Der eksisterer ingen grupper. Opret nye grupper i værktøjet Grupper.", // Folder type no groups
 	"folderTypeCreateGroups": "Opret nye grupper i værktøjet Grupper.", // Folder type create groups
-	"discardChangesTitle": "Slet ændringer?", // Discard Changes User Prompt
-	"discardChangesQuestion": "Er du sikker på, at du vil slette dine ændringer?", // Discard Changes User Prompt
-	"yesLabel": "Ja",
-	"noLabel": "Nej",
 	"filesSubmissionLimit": "Filer tilladt pr. aflevering",
 	"UnlimitedFilesPerSubmission": "Ubegrænset",
 	"OneFilePerSubmission": "En fil",

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/de.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/de.js
@@ -38,10 +38,6 @@ export default {
 	"assignmentSaveError": "Ihre Übung wurde nicht gespeichert. Korrigieren Sie die rot umrandeten Felder.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
 	"folderTypeNoGroups": "Es sind keine Gruppen vorhanden. Erstellen Sie neue Gruppen im Gruppen-Tool.", // Folder type no groups
 	"folderTypeCreateGroups": "Erstellen Sie neue Gruppen im Gruppen-Tool.", // Folder type create groups
-	"discardChangesTitle": "Änderungen verwerfen?", // Discard Changes User Prompt
-	"discardChangesQuestion": "Möchten Sie Ihre Änderungen wirklich verwerfen?", // Discard Changes User Prompt
-	"yesLabel": "Ja",
-	"noLabel": "Nein",
 	"filesSubmissionLimit": "Zulässige Dateien pro Abgabe",
 	"UnlimitedFilesPerSubmission": "Unbegrenzt",
 	"OneFilePerSubmission": "Eine Datei",

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
@@ -38,10 +38,6 @@ export default {
 	"assignmentSaveError": "Your assignment wasn't saved. Please correct the fields outlined in red.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
 	"folderTypeNoGroups": "No groups exist. Create new groups in the Groups tool.", // Folder type no groups
 	"folderTypeCreateGroups": "Create new groups in the Groups tool.", // Folder type create groups
-	"discardChangesTitle": "Discard changes?", // Discard Changes User Prompt
-	"discardChangesQuestion": "Are you sure you want to discard your changes?", // Discard Changes User Prompt
-	"yesLabel": "Yes",
-	"noLabel": "No",
 	"filesSubmissionLimit": "Files Allowed Per Submission",
 	"UnlimitedFilesPerSubmission": "Unlimited",
 	"OneFilePerSubmission": "One File",

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/es-es.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/es-es.js
@@ -38,10 +38,6 @@ export default {
 	"assignmentSaveError": "Su tarea no se ha guardado. Corrija los campos señalados en rojo.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
 	"folderTypeNoGroups": "No existe ningún grupo. Cree nuevos grupos en la herramienta Grupos.", // Folder type no groups
 	"folderTypeCreateGroups": "Cree nuevos grupos en la herramienta Grupos.", // Folder type create groups
-	"discardChangesTitle": "¿Descartar cambios?", // Discard Changes User Prompt
-	"discardChangesQuestion": "¿Seguro que desea descartar los cambios?", // Discard Changes User Prompt
-	"yesLabel": "Sí",
-	"noLabel": "No",
 	"filesSubmissionLimit": "Archivos permitidos por envío",
 	"UnlimitedFilesPerSubmission": "Ilimitado",
 	"OneFilePerSubmission": "Un archivo",

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/es.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/es.js
@@ -38,10 +38,6 @@ export default {
 	"assignmentSaveError": "No se guardó la asignación. Corrija los campos marcados en color rojo.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
 	"folderTypeNoGroups": "No existen grupos. Cree nuevos grupos en la herramienta Grupos.", // Folder type no groups
 	"folderTypeCreateGroups": "Cree nuevos grupos en la herramienta Grupos.", // Folder type create groups
-	"discardChangesTitle": "¿Desea descartar los cambios?", // Discard Changes User Prompt
-	"discardChangesQuestion": "¿Está seguro de que desea descartar los cambios?", // Discard Changes User Prompt
-	"yesLabel": "Sí",
-	"noLabel": "No",
 	"filesSubmissionLimit": "Archivos permitidos por envío",
 	"UnlimitedFilesPerSubmission": "Ilimitado",
 	"OneFilePerSubmission": "Un archivo",

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/fr-fr.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/fr-fr.js
@@ -38,10 +38,6 @@ export default {
 	"assignmentSaveError": "Votre devoir n’a pas été enregistré. Corrigez les champs indiqués en rouge.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
 	"folderTypeNoGroups": "Aucun groupe n’existe. Créer des groupes dans l’outil Groupes.", // Folder type no groups
 	"folderTypeCreateGroups": "Créer des groupes dans l’outil Groupes.", // Folder type create groups
-	"discardChangesTitle": "Annuler les modifications ?", // Discard Changes User Prompt
-	"discardChangesQuestion": "Voulez-vous vraiment annuler vos modifications ?", // Discard Changes User Prompt
-	"yesLabel": "Oui",
-	"noLabel": "Non",
 	"filesSubmissionLimit": "Nombre de fichiers autorisé par soumission",
 	"UnlimitedFilesPerSubmission": "Illimité",
 	"OneFilePerSubmission": "Un fichier",

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/fr.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/fr.js
@@ -38,10 +38,6 @@ export default {
 	"assignmentSaveError": "Votre travail n\'était pas enregistré. Veuillez corriger les champs indiqués en rouge.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
 	"folderTypeNoGroups": "Aucun groupe n\'existe. Créez des groupes dans l\'outil Groupes.", // Folder type no groups
 	"folderTypeCreateGroups": "Créez des groupes dans l\'outil Groupes.", // Folder type create groups
-	"discardChangesTitle": "Abandonner les modifications?", // Discard Changes User Prompt
-	"discardChangesQuestion": "Êtes-vous certain de vouloir abandonner vos modifications?", // Discard Changes User Prompt
-	"yesLabel": "Oui",
-	"noLabel": "Non",
 	"filesSubmissionLimit": "Fichiers autorisés par soumission",
 	"UnlimitedFilesPerSubmission": "Illimité",
 	"OneFilePerSubmission": "Un seul fichier",

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ko.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/ko.js
@@ -38,10 +38,6 @@ export default {
 	"assignmentSaveError": "과제가 저장되지 않았습니다. 빨간색으로 표시된 필드를 수정하십시오.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
 	"folderTypeNoGroups": "그룹이 없습니다. 그룹 도구에서 새 그룹을 만듭니다.", // Folder type no groups
 	"folderTypeCreateGroups": "그룹 도구에서 새 그룹을 만듭니다.", // Folder type create groups
-	"discardChangesTitle": "변경 사항을 제거하시겠습니까?", // Discard Changes User Prompt
-	"discardChangesQuestion": "이 변경 사항을 제거하시겠습니까?", // Discard Changes User Prompt
-	"yesLabel": "예",
-	"noLabel": "아니요",
 	"filesSubmissionLimit": "제출당 허용되는 파일 수",
 	"UnlimitedFilesPerSubmission": "제한 없음",
 	"OneFilePerSubmission": "파일 1개",

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/nl.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/nl.js
@@ -38,10 +38,6 @@ export default {
 	"assignmentSaveError": "Uw opdracht is niet opgeslagen. Corrigeer de rood omlijnde velden.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
 	"folderTypeNoGroups": "Er bestaan geen groepen. Maak nieuwe groepen aan in de Groepen-tool.", // Folder type no groups
 	"folderTypeCreateGroups": "Maak nieuwe groepen aan in de Groepen-tool.", // Folder type create groups
-	"discardChangesTitle": "Wijzigingen verwijderen?", // Discard Changes User Prompt
-	"discardChangesQuestion": "Weet u zeker dat u uw wijzigingen wilt verwijderen?", // Discard Changes User Prompt
-	"yesLabel": "Ja",
-	"noLabel": "Nee",
 	"filesSubmissionLimit": "Bestanden toegestaan per indiening",
 	"UnlimitedFilesPerSubmission": "Onbeperkt",
 	"OneFilePerSubmission": "Eén bestand",

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/pt.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/pt.js
@@ -38,10 +38,6 @@ export default {
 	"assignmentSaveError": "Sua atividade não foi salva. Corrija os campos destacados em vermelho.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
 	"folderTypeNoGroups": "Nenhum grupo. Crie grupos na ferramenta Grupos.", // Folder type no groups
 	"folderTypeCreateGroups": "Crie grupos na ferramenta Grupos.", // Folder type create groups
-	"discardChangesTitle": "Descartar alterações?", // Discard Changes User Prompt
-	"discardChangesQuestion": "Tem certeza de que deseja descartar suas alterações?", // Discard Changes User Prompt
-	"yesLabel": "Sim",
-	"noLabel": "Não",
 	"filesSubmissionLimit": "Arquivos permitidos por envio",
 	"UnlimitedFilesPerSubmission": "Ilimitado",
 	"OneFilePerSubmission": "Um arquivo",

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/sv.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/sv.js
@@ -38,10 +38,6 @@ export default {
 	"assignmentSaveError": "Ditt uppdrag sparades inte. Korrigera de fält som är markerade med rött.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
 	"folderTypeNoGroups": "Det finns inga grupper. Skapa nya grupper i gruppverktyget.", // Folder type no groups
 	"folderTypeCreateGroups": "Skapa nya grupper i gruppverktyget.", // Folder type create groups
-	"discardChangesTitle": "Vill du ignorera ändringarna?", // Discard Changes User Prompt
-	"discardChangesQuestion": "Är du säker på att du vill ignorera dina ändringar?", // Discard Changes User Prompt
-	"yesLabel": "Ja",
-	"noLabel": "Nej",
 	"filesSubmissionLimit": "Tillåtna filer per inlämning",
 	"UnlimitedFilesPerSubmission": "Obegränsad",
 	"OneFilePerSubmission": "En fil",

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/tr.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/tr.js
@@ -38,10 +38,6 @@ export default {
 	"assignmentSaveError": "Ödeviniz kaydedilmedi. Lütfen kırmızı ile gösterilen alanları düzeltin.", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
 	"folderTypeNoGroups": "Hiç grup yok. Gruplar aracında yeni gruplar oluşturun.", // Folder type no groups
 	"folderTypeCreateGroups": "Gruplar aracında yeni gruplar oluşturun.", // Folder type create groups
-	"discardChangesTitle": "Değişiklikler atılsın mı?", // Discard Changes User Prompt
-	"discardChangesQuestion": "Değişiklerinizi atmak istediğinizden emin misiniz?", // Discard Changes User Prompt
-	"yesLabel": "Evet",
-	"noLabel": "Hayır",
 	"filesSubmissionLimit": "Gönderim Başına İzin Verilen Dosya Sayısı",
 	"UnlimitedFilesPerSubmission": "Sınırsız",
 	"OneFilePerSubmission": "Tek Dosya",

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/zh-tw.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/zh-tw.js
@@ -38,10 +38,6 @@ export default {
 	"assignmentSaveError": "您的作業未儲存。請修正以紅色顯示的欄位。", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
 	"folderTypeNoGroups": "尚無群組。在「群組」工具中建立新群組。", // Folder type no groups
 	"folderTypeCreateGroups": "在「群組」工具中建立新群組。", // Folder type create groups
-	"discardChangesTitle": "捨棄變更？", // Discard Changes User Prompt
-	"discardChangesQuestion": "確定要捨棄您的變更？", // Discard Changes User Prompt
-	"yesLabel": "是",
-	"noLabel": "否",
 	"filesSubmissionLimit": "每個交件匣提交允許的檔案數",
 	"UnlimitedFilesPerSubmission": "無限制",
 	"OneFilePerSubmission": "一個檔案",

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/zh.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/zh.js
@@ -38,10 +38,6 @@ export default {
 	"assignmentSaveError": "您的作业未保存。请更正以红色标出的字段。", // Error message to inform the user that there was a problem saving the assignment, instructing them to correct invalid fields
 	"folderTypeNoGroups": "没有任何组。在组工具中创建新组。", // Folder type no groups
 	"folderTypeCreateGroups": "在组工具中创建新组。", // Folder type create groups
-	"discardChangesTitle": "放弃更改？", // Discard Changes User Prompt
-	"discardChangesQuestion": "是否确定要放弃您所做的更改？", // Discard Changes User Prompt
-	"yesLabel": "是",
-	"noLabel": "否",
 	"filesSubmissionLimit": "每次提交允许的文件",
 	"UnlimitedFilesPerSubmission": "无限制",
 	"OneFilePerSubmission": "一个文件",

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
@@ -5,35 +5,28 @@ import './d2l-activity-content-editor-secondary.js';
 import '@brightspace-ui/core/templates/primary-secondary/primary-secondary.js';
 import '@brightspace-ui/core/components/colors/colors.js';
 import { css, html } from 'lit-element/lit-element.js';
-import { ActivityEditorContainerMixin } from '../mixins/d2l-activity-editor-container-mixin.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { shared as activityStore } from '../state/activity-store.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { shared as store } from './state/content-store.js';
 
-class ContentEditor extends ActivityEditorContainerMixin(RtlMixin(ActivityEditorMixin(MobxLitElement))) {
+class ContentEditor extends RtlMixin(ActivityEditorMixin(MobxLitElement)) {
 
 	static get properties() {
 		return {
-			widthType: { type: String, attribute: 'width-type' }
+			widthType: { type: String, attribute: 'width-type' },
+			/**
+			 * Is Creating New
+			 */
+			isNew: { type: Boolean }
 		};
 	}
 
 	static get styles() {
 		return css`
 			:host {
-				--d2l-primary-padding: 20px;
-				--d2l-secondary-padding: 10px;
 				display: block;
-			}
-			div[slot="primary"] {
-				padding: var(--d2l-primary-padding);
-			}
-			div[slot="secondary"] {
-				background: var(--d2l-color-gypsum);
-				height: calc(100% - 2 * var(--d2l-secondary-padding));
-				padding: var(--d2l-secondary-padding);
 			}
 			d2l-icon {
 				padding-right: 1rem;
@@ -58,6 +51,9 @@ class ContentEditor extends ActivityEditorContainerMixin(RtlMixin(ActivityEditor
 				telemetryId="content"
 				.href=${this.href}
 				.token=${this.token}
+				width-type="${this.widthType}"
+				error-term=""
+				?isnew="${this.isNew}"
 			>
 				${this._editorTemplate}
 			</d2l-activity-editor>
@@ -84,29 +80,21 @@ class ContentEditor extends ActivityEditorContainerMixin(RtlMixin(ActivityEditor
 
 	get _editorTemplate() {
 		return html`
-			<d2l-template-primary-secondary slot="editor" width-type="${this.widthType}">
-				<slot name="editor-nav" slot="header"></slot>
-				<div slot="primary">
-					<d2l-activity-content-editor-detail
-						.href="${this.href}"
-						.token="${this.token}"
-					>
-					</d2l-activity-content-editor-detail>
-				</div>
-				<div slot="secondary">
-					<d2l-activity-content-editor-secondary
-						.href="${this.href}"
-						.token="${this.token}"
-					>
-					</d2l-activity-content-editor-secondary>
-				</div>
-				<d2l-activity-editor-footer
+			<slot name="editor-nav" slot="header"></slot>
+			<div slot="primary">
+				<d2l-activity-content-editor-detail
 					.href="${this.href}"
 					.token="${this.token}"
-					slot="footer"
 				>
-				</d2l-activity-editor-footer>
-			</d2l-template-primary-secondary>
+				</d2l-activity-content-editor-detail>
+			</div>
+			<div slot="secondary">
+				<d2l-activity-content-editor-secondary
+					.href="${this.href}"
+					.token="${this.token}"
+				>
+				</d2l-activity-content-editor-secondary>
+			</div>
 		`;
 	}
 }

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -1,16 +1,22 @@
 import '@brightspace-ui/core/components/backdrop/backdrop.js';
+import '@brightspace-ui/core/templates/primary-secondary/primary-secondary.js';
+import '@brightspace-ui/core/components/dialog/dialog-confirm.js';
+
 import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { ActivityEditorContainerMixin } from './mixins/d2l-activity-editor-container-mixin.js';
 import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
 import { ActivityEditorTelemetryMixin } from './mixins/d2l-activity-editor-telemetry-mixin';
 import { LocalizeActivityEditorMixin } from './mixins/d2l-activity-editor-lang-mixin.js';
 import { shared as store } from './state/activity-store.js';
 
-class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(ActivityEditorMixin(LocalizeActivityEditorMixin(LitElement)))) {
+class ActivityEditor extends ActivityEditorContainerMixin(ActivityEditorTelemetryMixin(AsyncContainerMixin(ActivityEditorMixin(LocalizeActivityEditorMixin(LitElement))))) {
 
 	static get properties() {
 		return {
 			isSaving: { type: Boolean, attribute: 'is-saving' },
+			widthType: { type: String, attribute: 'width-type' },
+			errorTerm: { type: String, attribute: 'error-term' },
 			_backdropShown: { type: Boolean }
 		};
 	}
@@ -26,6 +32,16 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 			.d2l-activity-editor-loading {
 				padding: 20px;
 			}
+			.d2l-primary-panel {
+				padding: 20px;
+			}
+			.d2l-secondary-panel {
+				padding: 10px;
+			}
+			d2l-alert {
+				margin-bottom: 10px;
+				max-width: 100%;
+			}
 		`;
 	}
 
@@ -39,7 +55,22 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 	render() {
 		return html`
 			<div id="editor-container">
-				<slot name="editor"></slot>
+				<d2l-template-primary-secondary background-shading="secondary" width-type="${this.widthType}">
+					<slot name="header" slot="header"></slot>
+					<div slot="primary" class="d2l-primary-panel">
+						<d2l-alert type="error" ?hidden=${!this.isError}>${this.errorTerm}</d2l-alert>
+						<slot name="primary"></slot>
+					</div>
+					<div slot="secondary" class="d2l-secondary-panel">
+						<slot name="secondary"></slot>
+					</div>
+					<d2l-activity-editor-footer
+						.href="${this.href}"
+						.token="${this.token}"
+						slot="footer"
+						class="d2l-activity-editor-footer">
+					</d2l-activity-editor-footer>
+				</d2l-template-primary-secondary>
 			</div>
 			<d2l-backdrop
 				for-target="editor-container"
@@ -48,6 +79,10 @@ class ActivityEditor extends ActivityEditorTelemetryMixin(AsyncContainerMixin(Ac
 				delay-transition
 				slow-transition>
 			</d2l-backdrop>
+			<d2l-dialog-confirm title-text="${this.localize('editor.discardChangesTitle')}" text=${this.localize('editor.discardChangesQuestion')}>
+				<d2l-button slot="footer" primary dialog-action="confirm">${this.localize('editor.yesLabel')}</d2l-button>
+				<d2l-button slot="footer" dialog-action="cancel">${this.localize('editor.noLabel')}</d2l-button>
+			</d2l-dialog-confirm>
 		`;
 	}
 	update(changedProperties) {

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -1,15 +1,18 @@
 import { html, LitElement } from 'lit-element/lit-element.js';
-import { ActivityEditorContainerMixin } from '../mixins/d2l-activity-editor-container-mixin';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 
-class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LitElement)) {
+class QuizEditor extends EntityMixinLit(LitElement) {
 
 	static get properties() {
 		return {
 			/**
 			* Set the WidthType on the template to constrain page width if necessary
 			*/
-			widthType: { type: String, attribute: 'width-type' }
+			widthType: { type: String, attribute: 'width-type' },
+			/**
+			 * Is Creating New
+			 */
+			isNew: { type: Boolean },
 		};
 	}
 
@@ -26,7 +29,9 @@ class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LitElement)
 				telemetryId="${this.telemetryId}"
 				.href=${this.href}
 				.token=${this.token}
-				?is-saving=${this.isSaving}>
+				width-type="${this.widthType}"
+				error-term=""
+				?isnew="${this.isNew}">
 
 				${this._editorTemplate}
 
@@ -36,16 +41,9 @@ class QuizEditor extends ActivityEditorContainerMixin(EntityMixinLit(LitElement)
 
 	get _editorTemplate() {
 		return html`
-			<d2l-template-primary-secondary background-shading="secondary" slot="editor" width-type="${this.widthType}">
-				<slot name="editor-nav" slot="header"></slot>
-				<div slot="secondary"></div>
-				<d2l-activity-editor-footer
-					.href="${this.href}"
-					.token="${this.token}"
-					slot="footer"
-					class="d2l-activity-editor-footer">
-				</d2l-activity-editor-footer>
-			</d2l-template-primary-secondary>
+			<slot name="editor-nav" slot="header"></slot>
+			<div slot="primary"></div>
+			<div slot="secondary"></div>
 		`;
 	}
 }

--- a/components/d2l-activity-editor/lang/ar.js
+++ b/components/d2l-activity-editor/lang/ar.js
@@ -70,6 +70,10 @@ export default {
 	"editor.noUsersWithSpecialAccess": "ما من مستخدمين", // text label when there are no users with special access
 	"editor.specialAccessDialogTitle": "إدارة الوصول الخاص", // Dialog title
 	"editor.specialAccessHidden": "تم الإخفاء بواسطة الوصول الخاص", // Warning label that the activity is restricted but is being hidden from all users by special access rules
+	"editor.discardChangesTitle": "هل تريد تجاهل التغييرات؟", // Discard Changes User Prompt
+	"editor.discardChangesQuestion": "هل تريد بالتأكيد تجاهل التغييرات التي أجريتها؟", // Discard Changes User Prompt
+	"editor.yesLabel": "نعم",
+	"editor.noLabel": "لا",
 
 	"rubrics.btnAddRubric": "إضافة آلية تقييم", //text for add rubric button
 	"rubrics.btnCreateNew": "إنشاء جديد", //Text for create new dropdown

--- a/components/d2l-activity-editor/lang/cy-gb.js
+++ b/components/d2l-activity-editor/lang/cy-gb.js
@@ -70,6 +70,10 @@ export default {
 	"editor.noUsersWithSpecialAccess": "Dim Defnyddwyr", // text label when there are no users with special access
 	"editor.specialAccessDialogTitle": "Rheoli Mynediad Arbennig", // Dialog title
 	"editor.specialAccessHidden": "Cudd gan fynediad arbennig", // Warning label that the activity is restricted but is being hidden from all users by special access rules
+	"editor.discardChangesTitle": "Dileu newidiadau?", // Discard Changes User Prompt
+	"editor.discardChangesQuestion": "Ydych chi\'n siŵr eich bod chi eisiau dileu\'ch newidiadau?", // Discard Changes User Prompt
+	"editor.yesLabel": "Ie",
+	"editor.noLabel": "Na",
 
 	"rubrics.btnAddRubric": "Ychwanegu cyfeireb", //text for add rubric button
 	"rubrics.btnCreateNew": "Creu Un Newydd", //Text for create new dropdown

--- a/components/d2l-activity-editor/lang/da-dk.js
+++ b/components/d2l-activity-editor/lang/da-dk.js
@@ -70,6 +70,10 @@ export default {
 	"editor.noUsersWithSpecialAccess": "Ingen brugere", // text label when there are no users with special access
 	"editor.specialAccessDialogTitle": "Administrer særlig adgang", // Dialog title
 	"editor.specialAccessHidden": "Skjult af særlig adgang", // Warning label that the activity is restricted but is being hidden from all users by special access rules
+	"editor.discardChangesTitle": "Slet ændringer?", // Discard Changes User Prompt
+	"editor.discardChangesQuestion": "Er du sikker på, at du vil slette dine ændringer?", // Discard Changes User Prompt
+	"editor.yesLabel": "Ja",
+	"editor.noLabel": "Nej",
 
 	"rubrics.btnAddRubric": "Tilføj rubrik", //text for add rubric button
 	"rubrics.btnCreateNew": "Opret ny", //Text for create new dropdown

--- a/components/d2l-activity-editor/lang/de.js
+++ b/components/d2l-activity-editor/lang/de.js
@@ -70,6 +70,10 @@ export default {
 	"editor.noUsersWithSpecialAccess": "Keine Benutzer", // text label when there are no users with special access
 	"editor.specialAccessDialogTitle": "Beschränkten Zugriff verwalten", // Dialog title
 	"editor.specialAccessHidden": "Durch beschränkten Zugriff ausgeblendet", // Warning label that the activity is restricted but is being hidden from all users by special access rules
+	"editor.discardChangesTitle": "Änderungen verwerfen?", // Discard Changes User Prompt
+	"editor.discardChangesQuestion": "Möchten Sie Ihre Änderungen wirklich verwerfen?", // Discard Changes User Prompt
+	"editor.yesLabel": "Ja",
+	"editor.noLabel": "Nein",
 
 	"rubrics.btnAddRubric": "Bewertungsschema hinzufügen", //text for add rubric button
 	"rubrics.btnCreateNew": "Neu erstellen", //Text for create new dropdown

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -70,6 +70,10 @@ export default {
 	"editor.noUsersWithSpecialAccess": "No users", // text label when there are no users with special access
 	"editor.specialAccessDialogTitle": "Manage Special Access", // Dialog title
 	"editor.specialAccessHidden": "Hidden by special access", // Warning label that the activity is restricted but is being hidden from all users by special access rules
+	"editor.discardChangesTitle": "Discard changes?", // Discard Changes User Prompt
+	"editor.discardChangesQuestion": "Are you sure you want to discard your changes?", // Discard Changes User Prompt
+	"editor.yesLabel": "Yes",
+	"editor.noLabel": "No",
 
 	"rubrics.btnAddRubric": "Add rubric", //text for add rubric button
 	"rubrics.btnCreateNew": "Create New", //Text for create new dropdown

--- a/components/d2l-activity-editor/lang/es-es.js
+++ b/components/d2l-activity-editor/lang/es-es.js
@@ -70,6 +70,10 @@ export default {
 	"editor.noUsersWithSpecialAccess": "No hay usuarios", // text label when there are no users with special access
 	"editor.specialAccessDialogTitle": "Administrar acceso especial", // Dialog title
 	"editor.specialAccessHidden": "Oculto por acceso especial", // Warning label that the activity is restricted but is being hidden from all users by special access rules
+	"editor.discardChangesTitle": "¿Descartar cambios?", // Discard Changes User Prompt
+	"editor.discardChangesQuestion": "¿Seguro que desea descartar los cambios?", // Discard Changes User Prompt
+	"editor.yesLabel": "Sí",
+	"editor.noLabel": "No",
 
 	"rubrics.btnAddRubric": "Agregar rúbrica", //text for add rubric button
 	"rubrics.btnCreateNew": "Crear nuevo", //Text for create new dropdown

--- a/components/d2l-activity-editor/lang/es.js
+++ b/components/d2l-activity-editor/lang/es.js
@@ -70,6 +70,10 @@ export default {
 	"editor.noUsersWithSpecialAccess": "No hay usuarios", // text label when there are no users with special access
 	"editor.specialAccessDialogTitle": "Administrar acceso especial", // Dialog title
 	"editor.specialAccessHidden": "Oculto por acceso especial", // Warning label that the activity is restricted but is being hidden from all users by special access rules
+	"editor.discardChangesTitle": "¿Desea descartar los cambios?", // Discard Changes User Prompt
+	"editor.discardChangesQuestion": "¿Está seguro de que desea descartar los cambios?", // Discard Changes User Prompt
+	"editor.yesLabel": "Sí",
+	"editor.noLabel": "No",
 
 	"rubrics.btnAddRubric": "Agregar rúbrica", //text for add rubric button
 	"rubrics.btnCreateNew": "Crear nuevo", //Text for create new dropdown

--- a/components/d2l-activity-editor/lang/fr-fr.js
+++ b/components/d2l-activity-editor/lang/fr-fr.js
@@ -70,6 +70,10 @@ export default {
 	"editor.noUsersWithSpecialAccess": "Aucun utilisateur", // text label when there are no users with special access
 	"editor.specialAccessDialogTitle": "Gérer l’accès spécial", // Dialog title
 	"editor.specialAccessHidden": "Masqué par un accès spécial", // Warning label that the activity is restricted but is being hidden from all users by special access rules
+	"editor.discardChangesTitle": "Annuler les modifications ?", // Discard Changes User Prompt
+	"editor.discardChangesQuestion": "Voulez-vous vraiment annuler vos modifications ?", // Discard Changes User Prompt
+	"editor.yesLabel": "Oui",
+	"editor.noLabel": "Non",
 
 	"rubrics.btnAddRubric": "Ajouter une grille d’évaluation", //text for add rubric button
 	"rubrics.btnCreateNew": "Créer", //Text for create new dropdown

--- a/components/d2l-activity-editor/lang/fr.js
+++ b/components/d2l-activity-editor/lang/fr.js
@@ -70,6 +70,10 @@ export default {
 	"editor.noUsersWithSpecialAccess": "Aucun utilisateur", // text label when there are no users with special access
 	"editor.specialAccessDialogTitle": "Gérer l’accès spécial", // Dialog title
 	"editor.specialAccessHidden": "Masqué par accès spécial", // Warning label that the activity is restricted but is being hidden from all users by special access rules
+	"editor.discardChangesTitle": "Abandonner les modifications?", // Discard Changes User Prompt
+	"editor.discardChangesQuestion": "Êtes-vous certain de vouloir abandonner vos modifications?", // Discard Changes User Prompt
+	"editor.yesLabel": "Oui",
+	"editor.noLabel": "Non",
 
 	"rubrics.btnAddRubric": "Ajouter une rubrique", //text for add rubric button
 	"rubrics.btnCreateNew": "Créer", //Text for create new dropdown

--- a/components/d2l-activity-editor/lang/ja.js
+++ b/components/d2l-activity-editor/lang/ja.js
@@ -70,6 +70,10 @@ export default {
 	"editor.noUsersWithSpecialAccess": "ユーザーはいません", // text label when there are no users with special access
 	"editor.specialAccessDialogTitle": "特殊なアクセスの管理", // Dialog title
 	"editor.specialAccessHidden": "特殊なアクセスで非表示", // Warning label that the activity is restricted but is being hidden from all users by special access rules
+	"editor.discardChangesTitle": "変更を破棄しますか？", // Discard Changes User Prompt
+	"editor.discardChangesQuestion": "この変更を破棄してもよろしいですか？", // Discard Changes User Prompt
+	"editor.yesLabel": "はい",
+	"editor.noLabel": "いいえ",
 
 	"rubrics.btnAddRubric": "注釈の追加", //text for add rubric button
 	"rubrics.btnCreateNew": "新規作成", //Text for create new dropdown

--- a/components/d2l-activity-editor/lang/ko.js
+++ b/components/d2l-activity-editor/lang/ko.js
@@ -70,6 +70,10 @@ export default {
 	"editor.noUsersWithSpecialAccess": "No users", // text label when there are no users with special access
 	"editor.specialAccessDialogTitle": "특별 접근 관리", // Dialog title
 	"editor.specialAccessHidden": "Hidden by special access", // Warning label that the activity is restricted but is being hidden from all users by special access rules
+	"editor.discardChangesTitle": "변경 사항을 제거하시겠습니까?", // Discard Changes User Prompt
+	"editor.discardChangesQuestion": "이 변경 사항을 제거하시겠습니까?", // Discard Changes User Prompt
+	"editor.yesLabel": "예",
+	"editor.noLabel": "아니요",
 
 	"rubrics.btnAddRubric": "루브릭 추가", //text for add rubric button
 	"rubrics.btnCreateNew": "새로 만들기", //Text for create new dropdown

--- a/components/d2l-activity-editor/lang/nl.js
+++ b/components/d2l-activity-editor/lang/nl.js
@@ -70,6 +70,10 @@ export default {
 	"editor.noUsersWithSpecialAccess": "No users", // text label when there are no users with special access
 	"editor.specialAccessDialogTitle": "Speciale toegang beheren", // Dialog title
 	"editor.specialAccessHidden": "Hidden by special access", // Warning label that the activity is restricted but is being hidden from all users by special access rules
+	"editor.discardChangesTitle": "Wijzigingen verwijderen?", // Discard Changes User Prompt
+	"editor.discardChangesQuestion": "Weet u zeker dat u uw wijzigingen wilt verwijderen?", // Discard Changes User Prompt
+	"editor.yesLabel": "Ja",
+	"editor.noLabel": "Nee",
 
 	"rubrics.btnAddRubric": "Rubric toevoegen", //text for add rubric button
 	"rubrics.btnCreateNew": "Nieuwe maken", //Text for create new dropdown

--- a/components/d2l-activity-editor/lang/pt.js
+++ b/components/d2l-activity-editor/lang/pt.js
@@ -70,6 +70,10 @@ export default {
 	"editor.noUsersWithSpecialAccess": "Nenhum usuário", // text label when there are no users with special access
 	"editor.specialAccessDialogTitle": "Gerenciar acesso especial", // Dialog title
 	"editor.specialAccessHidden": "Oculta por acesso especial", // Warning label that the activity is restricted but is being hidden from all users by special access rules
+	"editor.discardChangesTitle": "Descartar alterações?", // Discard Changes User Prompt
+	"editor.discardChangesQuestion": "Tem certeza de que deseja descartar suas alterações?", // Discard Changes User Prompt
+	"editor.yesLabel": "Sim",
+	"editor.noLabel": "Não",
 
 	"rubrics.btnAddRubric": "Adicionar rubrica", //text for add rubric button
 	"rubrics.btnCreateNew": "Criar novo", //Text for create new dropdown

--- a/components/d2l-activity-editor/lang/sv.js
+++ b/components/d2l-activity-editor/lang/sv.js
@@ -70,6 +70,10 @@ export default {
 	"editor.noUsersWithSpecialAccess": "Inga användare", // text label when there are no users with special access
 	"editor.specialAccessDialogTitle": "Hantera särskild behörighet", // Dialog title
 	"editor.specialAccessHidden": "Dold av särskild behörighet", // Warning label that the activity is restricted but is being hidden from all users by special access rules
+	"editor.discardChangesTitle": "Vill du ignorera ändringarna?", // Discard Changes User Prompt
+	"editor.discardChangesQuestion": "Är du säker på att du vill ignorera dina ändringar?", // Discard Changes User Prompt
+	"editor.yesLabel": "Ja",
+	"editor.noLabel": "Nej",
 
 	"rubrics.btnAddRubric": "Lägg till rubricering", //text for add rubric button
 	"rubrics.btnCreateNew": "Skapa ny", //Text for create new dropdown

--- a/components/d2l-activity-editor/lang/tr.js
+++ b/components/d2l-activity-editor/lang/tr.js
@@ -70,6 +70,10 @@ export default {
 	"editor.noUsersWithSpecialAccess": "Kullanıcı yok", // text label when there are no users with special access
 	"editor.specialAccessDialogTitle": "Özel Erişimi Yönet", // Dialog title
 	"editor.specialAccessHidden": "Özel erişim ile gizlendi", // Warning label that the activity is restricted but is being hidden from all users by special access rules
+	"editor.discardChangesTitle": "Değişiklikler atılsın mı?", // Discard Changes User Prompt
+	"editor.discardChangesQuestion": "Değişiklerinizi atmak istediğinizden emin misiniz?", // Discard Changes User Prompt
+	"editor.yesLabel": "Evet",
+	"editor.noLabel": "Hayır",
 
 	"rubrics.btnAddRubric": "Rubrik ekle", //text for add rubric button
 	"rubrics.btnCreateNew": "Yeni Oluştur", //Text for create new dropdown

--- a/components/d2l-activity-editor/lang/zh-tw.js
+++ b/components/d2l-activity-editor/lang/zh-tw.js
@@ -70,6 +70,10 @@ export default {
 	"editor.noUsersWithSpecialAccess": "沒有使用者", // text label when there are no users with special access
 	"editor.specialAccessDialogTitle": "管理特殊存取權限", // Dialog title
 	"editor.specialAccessHidden": "由特殊存取權限隱藏", // Warning label that the activity is restricted but is being hidden from all users by special access rules
+	"editor.discardChangesTitle": "捨棄變更？", // Discard Changes User Prompt
+	"editor.discardChangesQuestion": "確定要捨棄您的變更？", // Discard Changes User Prompt
+	"editor.yesLabel": "是",
+	"editor.noLabel": "否",
 
 	"rubrics.btnAddRubric": "新增量規", //text for add rubric button
 	"rubrics.btnCreateNew": "建立新的", //Text for create new dropdown

--- a/components/d2l-activity-editor/lang/zh.js
+++ b/components/d2l-activity-editor/lang/zh.js
@@ -70,6 +70,10 @@ export default {
 	"editor.noUsersWithSpecialAccess": "没有用户", // text label when there are no users with special access
 	"editor.specialAccessDialogTitle": "管理特殊访问权限", // Dialog title
 	"editor.specialAccessHidden": "按特殊访问权限隐藏", // Warning label that the activity is restricted but is being hidden from all users by special access rules
+	"editor.discardChangesTitle": "放弃更改？", // Discard Changes User Prompt
+	"editor.discardChangesQuestion": "是否确定要放弃您所做的更改？", // Discard Changes User Prompt
+	"editor.yesLabel": "是",
+	"editor.noLabel": "否",
 
 	"rubrics.btnAddRubric": "添加量规", //text for add rubric button
 	"rubrics.btnCreateNew": "新建", //Text for create new dropdown

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
@@ -40,8 +40,6 @@ export const ActivityEditorContainerMixin = superclass => class extends Activity
 		});
 	}
 
-	async cancelCreate() {}
-
 	get saveCompleteEvent() {
 		return new CustomEvent('d2l-activity-editor-save-complete', {
 			bubbles: true,
@@ -72,11 +70,18 @@ export const ActivityEditorContainerMixin = superclass => class extends Activity
 		}
 
 		if (this.isNew) {
-			await this.cancelCreate();
+			await this._cancelCreate();
 		}
 
 		this.dispatchEvent(this.cancelCompleteEvent);
 	}
+
+	async _cancelCreate() {
+		return Promise.all(
+			Array.from(this._editors).map(editor => editor.cancelCreate())
+		);
+	}
+
 	async _focusOnInvalid() {
 		const isAriaInvalid = node => node.getAttribute('aria-invalid') === 'true' && node.getClientRects().length > 0 && !this._hasSkipAlertAncestor(node);
 		for (const editor of this._editors) {

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
@@ -68,6 +68,9 @@ export const ActivityEditorMixin = superclass => class extends superclass {
 			this.store && this._fetch(() => this.store.fetch(this.href, this.token));
 		}
 	}
+
+	async cancelCreate() { }
+
 	hasPendingChanges() {
 		return false;
 	}


### PR DESCRIPTION
…or and the ActivityEditorContainerMixin to enable more shared functionality.

https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Ftask%2F440737131360

This PR is to work around some duplication that was occurring in how activity editors were being setup, particularly for things like using the page template, and having access to the confirmation dialog for handling save/cancel.

This does require a change in which component is now in control of all the editors (implements the `ActivityEditorContainerMixin`). It used to be the top level domain editor, e.g. `d2l-activity-assigment-editor`, but that made it difficult to share functionality like the cancel confirmation dialog, because the dialog was being duplicated in the local dom of each of those editors. To move it into the render of the `d2l-activity-editor` requires shifting the `ActivityEditorContainerMixin` implementation to the `d2l-activity-editor` instead. 

By moving the mixin to `d2l-activity-editor` component, it means that technically the root component e.g. `d2l-activity-assignment-editor` is no longer tracked as an editor (because it is a parent of the `d2l-activity-editor` which is now the `ActivityEditorContainerMixin`, and so it doesn't get registered using the `d2l-activity-editor-connected` event. 

So this does subtly change the role of the top level editor like `d2l-activity-assignment-editor`, `d2l-activity-quiz-editor` and `d2l-activity-content-editor` as previously they were implementing features like `save` and `hasPendingChanges` which was convenient, but also kind of meant that some of the lower level components are not really reusable in their own right. Going forward we should just consider that root component as the thing that knits together all the domain components. 

@imcdonald-d2l This shouldn't affect the content component too much yet as you don't have any save implementation (at least not committed) etc, but I did update it to remove the duplication of the template and some styling stuff. Tested it locally and looked OK to me but let me know if you see any issues.

The impact of changing which component implements the `ActivityEditorContainerMixin` on assignments is that for now I've just moved the save/cancel related implementations to the `d2l-activity-editor-assignment-detail` but I plan on putting up some follow on PRs that allow us to support these callbacks on multiple nested components. eg. we should be able to implement the `save` callback on both the `d2l-activity-assignment-editor-detail` and the `d2l-activity-assignment-editor-secondary` (or lower level components). The problem with that at the moment is that it would lead to multiple save calls. So I plan to enhance the save implementation to support that using promises to enable multiple save calls to be made against a single store, but where only one call will end up calling the API. We also needed to add some ordering support for assignments, that makes this more tricky too, but I have a PR in the works that will support the ordering for the multiple save calls too.

There are some other things I'd like to fix up with the way the base editor is implemented. e.g. currently we instantiate an ActivityUsage and an AssignmentActivityUsage (in order to get at the assignment href), but this is kind of pointless now because we can get the assignment href from the activity usage itself using the specialization rel href. So I plan to include that in a follow up PR too. That will simplify the assignment store.


