### PR TITLE
US121272 TA147992 Part1: Move assigment functionality from root compo…

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -85,21 +85,6 @@ class AssignmentEditor extends AsyncContainerMixin(RtlMixin(LocalizeActivityAssi
 			:host([hidden]) {
 				display: none;
 			}
-			d2l-alert {
-				margin-bottom: 10px;
-				max-width: 100%;
-			}
-			.d2l-locked-alert {
-				align-items: baseline;
-				display: flex;
-			}
-			d2l-icon {
-				padding-right: 1rem;
-			}
-			:host([dir="rtl"]) d2l-icon {
-				padding-left: 1rem;
-				padding-right: 0;
-			}
 		`;
 	}
 
@@ -148,18 +133,9 @@ class AssignmentEditor extends AsyncContainerMixin(RtlMixin(LocalizeActivityAssi
 			assignmentHref
 		} = activity || {};
 
-		const assignment = store.getAssignment(assignmentHref);
-		const hasSubmissions = assignment && assignment.submissionAndCompletionProps.assignmentHasSubmissions;
-
 		return html`
 			<slot name="editor-nav" slot="header"></slot>
 			<div slot="primary" class="d2l-activity-assignment-editor-primary-panel">
-				<d2l-alert ?hidden=${!hasSubmissions}>
-					<div class="d2l-locked-alert">
-						<d2l-icon icon="tier1:lock-locked"></d2l-icon>
-						<div>${this.localize('assignmentLocked')}</div>
-					</div>
-				</d2l-alert>
 				<d2l-activity-assignment-editor-detail
 					activity-usage-href=${this.href}
 					.href="${assignmentHref}"
@@ -241,17 +217,6 @@ class AssignmentEditor extends AsyncContainerMixin(RtlMixin(LocalizeActivityAssi
 
 		if (e.detail.key === 'd2l-provider-browse-outcomes-text') {
 			e.detail.provider = this.browseOutcomesText;
-			e.stopPropagation();
-			return;
-		}
-
-		// Provides orgUnitId for d2l-labs-attachment
-		// https://github.com/Brightspace/attachment/blob/74a66e85f03790aa9f4e6ec5025cd3c62cfb5264/mixins/attachment-mixin.js#L19
-		if (e.detail.key === 'd2l-provider-org-unit-id') {
-			const activity = store.getActivity(this.href);
-			const assignment = activity && store.getAssignment(activity.assignmentHref);
-			const richTextEditorConfig = assignment && assignment.instructionsRichTextEditorConfig;
-			e.detail.provider = richTextEditorConfig && richTextEditorConfig.properties && richTextEditorConfig.properties.orgUnit && richTextEditorConfig.properties.orgUnit.OrgUnitId;
 			e.stopPropagation();
 			return;
 		}


### PR DESCRIPTION
…nent to detail component so that root component can just deal with activity usage and allow for simpler assignment store implementation. Store refactoring coming in Part2.

https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Ftask%2F440737138828

@imcdonald-d2l You don't really need to pay attention to this PR but including you as an FYI as part 2 of this PR may be more interesting to you.

The mechanism by which we get the assignment href from the activity usage is more complicated than it needs to be. We created an additional `AssignmentActivityUsage` siren-sdk component so that we could get at the assignment href link more explicitly and to avoid having to add assignment methods to the siren-sdk `ActivityUsage` class. But someone had the great idea of using a `specialization` rel for the domain link which means that can be used to get the assignment href, which negates the need to use the `AssignmentActivityUsage` class. Without that class we can simplify the store implementation for assignments as it will only deal with assignments.

So that is coming in Part 2 of this change, but in Part 1 I am just removing any references to the assignment from `d2l-activity-assignment-editor`, so that it can just deal with activity usages. In this case that included handling the alert when there are already submissions and setting up one of the request providers.