### PR TITLE
Part 2: Use activity usage specialization rel to get assignment href from activity and simplify mobx assignment store

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-editor.js
@@ -4,7 +4,7 @@ import { labelStyles } from '@brightspace-ui/core/components/typography/styles.j
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
-import { assignments as store } from './state/assignment-store.js';
+import { shared as store } from './state/assignment-store.js';
 
 class ActivityAssignmentAnnotationsEditor
 	extends ActivityEditorMixin(RtlMixin(LocalizeActivityAssignmentEditorMixin(MobxLitElement))) {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-summary.js
@@ -2,7 +2,7 @@ import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { html } from 'lit-element/lit-element.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
-import { assignments as store } from './state/assignment-store.js';
+import { shared as store } from './state/assignment-store.js';
 
 class ActivityAssignmentAnnotationsSummary
 	extends ActivityEditorMixin(LocalizeActivityAssignmentEditorMixin(MobxLitElement)) {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-editor.js
@@ -6,7 +6,7 @@ import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
-import { assignments as store } from './state/assignment-store.js';
+import { shared as store } from './state/assignment-store.js';
 
 class ActivityAssignmentAnonymousMarkingEditor
 	extends ActivityEditorMixin(RtlMixin(LocalizeActivityAssignmentEditorMixin(MobxLitElement))) {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-summary.js
@@ -2,7 +2,7 @@ import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
-import { assignments as store } from './state/assignment-store.js';
+import { shared as store } from './state/assignment-store.js';
 
 class ActivityAssignmentAnonymousMarkingSummary
 	extends ActivityEditorMixin(LocalizeActivityAssignmentEditorMixin(MobxLitElement)) {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -84,7 +84,7 @@ class AssignmentEditorDetail extends AsyncContainerMixin(SkeletonMixin(SaveStatu
 	}
 
 	constructor() {
-		super();
+		super(store);
 		this._debounceJobs = {};
 		this._linksProcessor = new LinksInMessageProcessor();
 		this.skeleton = true;
@@ -92,7 +92,7 @@ class AssignmentEditorDetail extends AsyncContainerMixin(SkeletonMixin(SaveStatu
 	}
 
 	render() {
-		const assignment = store.getAssignment(this.href);
+		const assignment = store.get(this.href);
 
 		const {
 			name,
@@ -188,16 +188,12 @@ class AssignmentEditorDetail extends AsyncContainerMixin(SkeletonMixin(SaveStatu
 	updated(changedProperties) {
 		super.updated(changedProperties);
 
-		if ((changedProperties.has('href') || changedProperties.has('token')) &&
-			this.href && this.token) {
-			super._fetch(() => store.fetchAssignment(this.href, this.token));
-		}
 		if (changedProperties.has('asyncState')) {
 			this.skeleton = this.asyncState !== asyncStates.complete;
 		}
 	}
 	addLinks(links) {
-		const attachmentsHref = store.getAssignment(this.href).attachmentsHref;
+		const attachmentsHref = store.get(this.href).attachmentsHref;
 		const collection = attachmentCollectionStore.get(attachmentsHref);
 		links = links || [];
 		links.forEach(element => {
@@ -206,12 +202,12 @@ class AssignmentEditorDetail extends AsyncContainerMixin(SkeletonMixin(SaveStatu
 	}
 
 	async cancelCreate() {
-		const assignment = store.getAssignment(this.href);
+		const assignment = store.get(this.href);
 		return assignment && assignment.cancelCreate();
 	}
 
 	hasPendingChanges() {
-		const assignment = store.getAssignment(this.href);
+		const assignment = store.get(this.href);
 		if (!assignment) {
 			return false;
 		}
@@ -220,7 +216,7 @@ class AssignmentEditorDetail extends AsyncContainerMixin(SkeletonMixin(SaveStatu
 	}
 
 	async save() {
-		const assignment = store.getAssignment(this.href);
+		const assignment = store.get(this.href);
 		if (!assignment) {
 			return;
 		}
@@ -232,7 +228,7 @@ class AssignmentEditorDetail extends AsyncContainerMixin(SkeletonMixin(SaveStatu
 		// Provides orgUnitId for d2l-labs-attachment
 		// https://github.com/Brightspace/attachment/blob/74a66e85f03790aa9f4e6ec5025cd3c62cfb5264/mixins/attachment-mixin.js#L19
 		if (e.detail.key === 'd2l-provider-org-unit-id') {
-			const assignment = store.getAssignment(this.href);
+			const assignment = store.get(this.href);
 			const richTextEditorConfig = assignment && assignment.instructionsRichTextEditorConfig;
 			e.detail.provider = richTextEditorConfig && richTextEditorConfig.properties && richTextEditorConfig.properties.orgUnit && richTextEditorConfig.properties.orgUnit.OrgUnitId;
 			e.stopPropagation();
@@ -241,7 +237,7 @@ class AssignmentEditorDetail extends AsyncContainerMixin(SkeletonMixin(SaveStatu
 	}
 
 	_saveInstructions(value) {
-		store.getAssignment(this.href).setInstructions(value);
+		store.get(this.href).setInstructions(value);
 		this._debounceJobs.value = Debouncer.debounce(
 			this._debounceJobs.value,
 			timeOut.after(2000),
@@ -259,7 +255,7 @@ class AssignmentEditorDetail extends AsyncContainerMixin(SkeletonMixin(SaveStatu
 		);
 	}
 	_saveName(value) {
-		store.getAssignment(this.href).setName(value);
+		store.get(this.href).setName(value);
 	}
 	_saveNameOnInput(e) {
 		const name = e.target.value;

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -83,7 +83,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 	}
 
 	render() {
-		const assignment = store.getAssignment(this.href);
+		const assignment = store.get(this.href);
 		return html`
 			<d2l-labs-accordion-collapse
 				class="accordion"
@@ -171,7 +171,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 	}
 
 	_onNotificationEmailChanged(e) {
-		const assignment = store.getAssignment(this.href);
+		const assignment = store.get(this.href);
 		const data = e.target.value;
 		assignment && assignment.setNotificationEmail(data);
 	}
@@ -413,21 +413,21 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 		`;
 	}
 	_saveCompletionTypeOnChange(event) {
-		store.getAssignment(this.href).setCompletionType(event.target.value);
+		store.get(this.href).setCompletionType(event.target.value);
 	}
 
 	_saveSubmissionTypeOnChange(event) {
-		store.getAssignment(this.href).setSubmissionType(event.target.value);
+		store.get(this.href).setSubmissionType(event.target.value);
 	}
 
 	_setfilesSubmisisonLimit(e) {
-		const assignment = store.getAssignment(this.href);
+		const assignment = store.get(this.href);
 		const data = e.target.value;
 		assignment && assignment.setFilesSubmissionLimit(data);
 	}
 
 	_setSubmisisonsRule(e) {
-		const assignment = store.getAssignment(this.href);
+		const assignment = store.get(this.href);
 		const data = e.target.value;
 		assignment &&
 		assignment.submissionAndCompletionProps &&

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -85,21 +85,6 @@ class AssignmentEditor extends AsyncContainerMixin(RtlMixin(LocalizeActivityAssi
 			:host([hidden]) {
 				display: none;
 			}
-			d2l-alert {
-				margin-bottom: 10px;
-				max-width: 100%;
-			}
-			.d2l-locked-alert {
-				align-items: baseline;
-				display: flex;
-			}
-			d2l-icon {
-				padding-right: 1rem;
-			}
-			:host([dir="rtl"]) d2l-icon {
-				padding-left: 1rem;
-				padding-right: 0;
-			}
 		`;
 	}
 
@@ -148,18 +133,9 @@ class AssignmentEditor extends AsyncContainerMixin(RtlMixin(LocalizeActivityAssi
 			assignmentHref
 		} = activity || {};
 
-		const assignment = store.getAssignment(assignmentHref);
-		const hasSubmissions = assignment && assignment.submissionAndCompletionProps.assignmentHasSubmissions;
-
 		return html`
 			<slot name="editor-nav" slot="header"></slot>
 			<div slot="primary" class="d2l-activity-assignment-editor-primary-panel">
-				<d2l-alert ?hidden=${!hasSubmissions}>
-					<div class="d2l-locked-alert">
-						<d2l-icon icon="tier1:lock-locked"></d2l-icon>
-						<div>${this.localize('assignmentLocked')}</div>
-					</div>
-				</d2l-alert>
 				<d2l-activity-assignment-editor-detail
 					activity-usage-href=${this.href}
 					.href="${assignmentHref}"
@@ -241,17 +217,6 @@ class AssignmentEditor extends AsyncContainerMixin(RtlMixin(LocalizeActivityAssi
 
 		if (e.detail.key === 'd2l-provider-browse-outcomes-text') {
 			e.detail.provider = this.browseOutcomesText;
-			e.stopPropagation();
-			return;
-		}
-
-		// Provides orgUnitId for d2l-labs-attachment
-		// https://github.com/Brightspace/attachment/blob/74a66e85f03790aa9f4e6ec5025cd3c62cfb5264/mixins/attachment-mixin.js#L19
-		if (e.detail.key === 'd2l-provider-org-unit-id') {
-			const activity = store.getActivity(this.href);
-			const assignment = activity && store.getAssignment(activity.assignmentHref);
-			const richTextEditorConfig = assignment && assignment.instructionsRichTextEditorConfig;
-			e.detail.provider = richTextEditorConfig && richTextEditorConfig.properties && richTextEditorConfig.properties.orgUnit && richTextEditorConfig.properties.orgUnit.OrgUnitId;
 			e.stopPropagation();
 			return;
 		}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -12,7 +12,7 @@ import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
-import { shared as store } from './state/assignment-store.js';
+import { shared as store } from '../state/activity-store.js';
 
 class AssignmentEditor extends AsyncContainerMixin(RtlMixin(LocalizeActivityAssignmentEditorMixin(ActivityEditorMixin(MobxLitElement)))) {
 
@@ -118,19 +118,15 @@ class AssignmentEditor extends AsyncContainerMixin(RtlMixin(LocalizeActivityAssi
 	updated(changedProperties) {
 		super.updated(changedProperties);
 
-		if ((changedProperties.has('href') || changedProperties.has('token')) &&
-			this.href && this.token) {
-			super._fetch(() => store.fetchActivity(this.href, this.token));
-		}
 		if (changedProperties.has('asyncState')) {
 			this.skeleton = this.asyncState !== asyncStates.complete;
 		}
 	}
 
 	get _editorTemplate() {
-		const activity = store.getActivity(this.href);
+		const activity = store.get(this.href);
 		const {
-			assignmentHref
+			specializationHref
 		} = activity || {};
 
 		return html`
@@ -138,13 +134,13 @@ class AssignmentEditor extends AsyncContainerMixin(RtlMixin(LocalizeActivityAssi
 			<div slot="primary" class="d2l-activity-assignment-editor-primary-panel">
 				<d2l-activity-assignment-editor-detail
 					activity-usage-href=${this.href}
-					.href="${assignmentHref}"
+					.href="${specializationHref}"
 					.token="${this.token}">
 				</d2l-activity-assignment-editor-detail>
 			</div>
 			<div slot="secondary">
 				<d2l-activity-assignment-editor-secondary
-					.href="${assignmentHref}"
+					.href="${specializationHref}"
 					.token="${this.token}"
 					activity-usage-href="${this.href}">
 				</d2l-activity-assignment-editor-secondary>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
@@ -65,7 +65,7 @@ class ActivityAssignmentEvaluationEditor extends SkeletonMixin(ActivityEditorFea
 	}
 
 	render() {
-		const assignment = store.getAssignment(this.href) || {};
+		const assignment = store.get(this.href) || {};
 		const activity = activityStore.get(this.activityUsageHref) || {};
 
 		return html`

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
@@ -6,7 +6,7 @@ import { MobxLitElement } from '@adobe/lit-mobx';
 import { radioStyles } from '@brightspace-ui/core/components/inputs/input-radio-styles.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';
-import { assignments as store } from './state/assignment-store.js';
+import { shared as store } from './state/assignment-store.js';
 
 class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeActivityAssignmentEditorMixin(MobxLitElement))) {
 

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-summary.js
@@ -3,7 +3,7 @@ import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
-import { assignments as store } from './state/assignment-store.js';
+import { shared as store } from './state/assignment-store.js';
 
 class AssignmentTypeSummary extends ActivityEditorMixin(RtlMixin(LocalizeActivityAssignmentEditorMixin(MobxLitElement))) {
 

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-submission-email-notification-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-submission-email-notification-summary.js
@@ -3,7 +3,7 @@ import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
-import { assignments as store } from './state/assignment-store.js';
+import { shared as store } from './state/assignment-store.js';
 
 class SubmissionEmailNotificationSummary extends ActivityEditorMixin(RtlMixin(LocalizeActivityAssignmentEditorMixin(MobxLitElement))) {
 

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-assignment-turnitin-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-assignment-turnitin-editor.js
@@ -5,7 +5,7 @@ import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
-import { assignments as store } from './state/assignment-store.js';
+import { shared as store } from './state/assignment-store.js';
 
 class AssignmentTurnitinEditor
 	extends ActivityEditorMixin(LocalizeActivityAssignmentEditorMixin(MobxLitElement)) {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-assignment-turnitin-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-assignment-turnitin-summary.js
@@ -3,7 +3,7 @@ import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { html } from 'lit-element/lit-element';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
-import { assignments as store } from './state/assignment-store.js';
+import { shared as store } from './state/assignment-store.js';
 
 class AssignmentTurnitinSummary
 	extends ActivityEditorMixin(LocalizeActivityAssignmentEditorMixin(MobxLitElement)) {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-store.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-store.js
@@ -1,38 +1,10 @@
 import { Assignment } from './assignment.js';
-import { AssignmentActivityUsage } from './assignment-activity-usage.js';
 import { ObjectStore } from '../../state/object-store.js';
 
-export class AssignmentStore {
+export class AssignmentStore extends ObjectStore {
 	constructor() {
-		this._assignments = new ObjectStore(Assignment);
-		this._activities = new ObjectStore(AssignmentActivityUsage);
-	}
-
-	clear() {
-		this._assignments.clear();
-		this._activities.clear();
-	}
-
-	fetchActivity(href, token) {
-		return this._activities.fetch(href, token);
-	}
-
-	fetchAssignment(href, token) {
-		return this._assignments.fetch(href, token);
-	}
-
-	getActivity(href) {
-		return this._activities.get(href);
-	}
-
-	getAssignment(href) {
-		return this._assignments.get(href);
-	}
-
-	put(href, object) {
-		this._assignments.put(href, object);
+		super(Assignment);
 	}
 }
 
 export const shared = new AssignmentStore();
-export const { _assignments: assignments } = shared;

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -238,7 +238,7 @@ class ActivityRubricsListContainer extends ActivityEditorFeaturesMixin(ActivityE
 	}
 	_renderDefaultScoringRubric(entity) {
 
-		const assignment = assignmentStore.getAssignment(this.assignmentHref);
+		const assignment = assignmentStore.get(this.assignmentHref);
 		const shouldRender = this._isMilestoneEnabled(Milestones.M3DefaultScoringRubric);
 
 		if (!entity || !assignment || !shouldRender) {
@@ -285,7 +285,7 @@ class ActivityRubricsListContainer extends ActivityEditorFeaturesMixin(ActivityE
 	}
 
 	_saveDefaultScoringRubricOnChange(event) {
-		const assignment = assignmentStore.getAssignment(this.assignmentHref);
+		const assignment = assignmentStore.get(this.assignmentHref);
 
 		if (!assignment) {
 			return;

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
@@ -55,7 +55,7 @@ class ActivityRubricsListEditor extends ActivityEditorFeaturesMixin(ActivityEdit
 	render() {
 
 		const entity = store.get(this.href);
-		const assignment = assignmentStore.getAssignment(this.assignmentHref);
+		const assignment = assignmentStore.get(this.assignmentHref);
 
 		if (!entity || !assignment) {
 			return html``;
@@ -80,7 +80,7 @@ class ActivityRubricsListEditor extends ActivityEditorFeaturesMixin(ActivityEdit
 
 		if (m3FeatureFlagEnabled) {
 			const entity = store.get(this.href);
-			const assignment = assignmentStore.getAssignment(this.assignmentHref);
+			const assignment = assignmentStore.get(this.assignmentHref);
 
 			if (!entity || !assignment) {
 				return;

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -38,6 +38,7 @@ export class ActivityUsage {
 		this.dates = new ActivityDates(entity);
 		this.scoreAndGrade = new ActivityScoreGrade(entity, this.token);
 		this.associationsHref = entity.getDirectRubricAssociationsHref();
+		this.specializationHref = entity.specializationHref();
 
 		await Promise.all([
 			this._loadSpecialAccess(entity),
@@ -218,6 +219,7 @@ decorate(ActivityUsage, {
 	dates: observable,
 	associationsHref: observable,
 	alignmentsHref: observable,
+	specializationHref: observable,
 	canUpdateAlignments: observable,
 	competenciesHref: observable,
 	associatedCompetenciesCount: observable,

--- a/test/d2l-activity-editor/state/activity-usage.spec.js
+++ b/test/d2l-activity-editor/state/activity-usage.spec.js
@@ -51,7 +51,8 @@ describe('Activity Usage', function() {
 			associatedCompetenciesCount: () => associatedCompetenciesCount,
 			unevaluatedCompetenciesCount: () => unevaluatedCompetenciesCount,
 			competenciesDialogUrl: () => competenciesDialogUrl,
-			specialAccessHref: () => null
+			specialAccessHref: () => null,
+			specializationHref: () => null
 		};
 	}
 


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Ftask%2F440737138828

By using the specialization rel to get the assignment href from the activity usage we no longer need to use the `AssignmentActivityUsage` siren-sdk entity which means we can simplify the loading of the `d2l-activity-assignment-editor` and the `assignment-store`. 

Most of the changes are just updates to dependent classes to change calls from `store.getAssignment(href)` to just `store.get(href)` and to update imports of the store object.

**Just pay attention to the second commit on this PR - This was branched from a previous PR which has now been merged, so I'm confused why the commits from that original PR are still showing up on this one. I thought Github was smart enough to handle this. I'm sure I've seen it handle this better in the past.**