### PR TITLE
Rfegan/us119416 add quiz name input

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
@@ -10,12 +10,11 @@ import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { AsyncContainerMixin } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
-import { LocalizeActivityAssignmentEditorMixin } from '../d2l-activity-assignment-editor/mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
-class QuizEditorDetail extends AsyncContainerMixin(SkeletonMixin(LocalizeActivityAssignmentEditorMixin(RtlMixin(ActivityEditorMixin(MobxLitElement))))) {
+class QuizEditorDetail extends AsyncContainerMixin(SkeletonMixin((RtlMixin(ActivityEditorMixin(MobxLitElement))))) {
 
 	static get properties() {
 		return {
@@ -70,7 +69,6 @@ class QuizEditorDetail extends AsyncContainerMixin(SkeletonMixin(LocalizeActivit
 				maxlength="128"
 				value="${name}"
 				@input="${this._saveNameOnInput}"
-				label="${this.localize('name')}"
 				required
 				?disabled="${!canEditName}"
 				prevent-submit>

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
@@ -1,0 +1,106 @@
+import '@brightspace-ui/core/components/inputs/input-text.js';
+import 'd2l-tooltip/d2l-tooltip';
+import '../d2l-activity-due-date-editor.js';
+import '../d2l-activity-outcomes.js';
+import '../d2l-activity-score-editor.js';
+import '../d2l-activity-text-editor.js';
+import '../d2l-activity-attachments/d2l-activity-attachments-editor.js';
+
+import { css, html } from 'lit-element/lit-element.js';
+import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
+import { AsyncContainerMixin } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
+import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
+import { LocalizeActivityAssignmentEditorMixin } from '../d2l-activity-assignment-editor/mixins/d2l-activity-assignment-lang-mixin.js';
+import { MobxLitElement } from '@adobe/lit-mobx';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
+import { shared as store } from '../d2l-activity-assignment-editor/state/assignment-store.js';
+
+class QuizEditorDetail extends AsyncContainerMixin(SkeletonMixin(LocalizeActivityAssignmentEditorMixin(RtlMixin(ActivityEditorMixin(MobxLitElement))))) {
+
+	static get properties() {
+		return {
+			activityUsageHref: { type: String, attribute: 'activity-usage-href' },
+		};
+	}
+
+	static get styles() {
+		return [
+			super.styles,
+			labelStyles,
+			css`
+				:host {
+					display: block;
+				}
+				:host([hidden]) {
+					display: none;
+				}
+				:host > div,
+				.d2l-activity-label-container {
+					margin-bottom: 8px;
+				}
+				:host([dir="rtl"]) #score-container {
+					margin-left: 40px;
+					margin-right: 0;
+				}
+				d2l-alert {
+					margin-bottom: 10px;
+					max-width: 100%;
+				}
+				.d2l-locked-alert {
+					align-items: baseline;
+					display: flex;
+				}
+				d2l-icon {
+					padding-right: 1rem;
+				}
+				:host([dir="rtl"]) d2l-icon {
+					padding-left: 1rem;
+					padding-right: 0;
+				}
+			`
+		];
+	}
+
+	constructor() {
+		super();
+		this._debounceJobs = {};
+		this.skeleton = false;
+	}
+
+	render() {
+		const quiz = store.getAssignment(this.href);
+
+		const {
+			name,
+			canEditName,
+		} = quiz || {};
+
+		const hasSubmissions = false;
+
+		return html`
+			<d2l-alert ?hidden=${!hasSubmissions}>
+				<div class="d2l-locked-alert">
+					<d2l-icon icon="tier1:lock-locked"></d2l-icon>
+					<div>${this.localize('assignmentLocked')}</div>
+				</div>
+			</d2l-alert>
+			<div id="assignment-name-container">
+				<d2l-input-text
+					?skeleton="${this.skeleton}"
+					id="assignment-name"
+					maxlength="128"
+					value="${name}"
+					@input="${this._saveNameOnInput}"
+					label="${this.localize('name')}"
+					required
+					?disabled="${!canEditName}"
+					prevent-submit>
+				</d2l-input-text>
+			</div>
+
+		`;
+	}
+
+}
+customElements.define('d2l-activity-quiz-editor-detail', QuizEditorDetail);

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
@@ -14,7 +14,6 @@ import { LocalizeActivityAssignmentEditorMixin } from '../d2l-activity-assignmen
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
-import { shared as store } from '../d2l-activity-assignment-editor/state/assignment-store.js';
 
 class QuizEditorDetail extends AsyncContainerMixin(SkeletonMixin(LocalizeActivityAssignmentEditorMixin(RtlMixin(ActivityEditorMixin(MobxLitElement))))) {
 
@@ -56,7 +55,7 @@ class QuizEditorDetail extends AsyncContainerMixin(SkeletonMixin(LocalizeActivit
 	}
 
 	render() {
-		const quiz = store.getAssignment(this.href);
+		const quiz = {}; // TODO: implement new store function
 
 		const {
 			name,

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
@@ -39,14 +39,6 @@ class QuizEditorDetail extends AsyncContainerMixin(SkeletonMixin(LocalizeActivit
 				.d2l-activity-label-container {
 					margin-bottom: 8px;
 				}
-				d2l-alert {
-					margin-bottom: 10px;
-					max-width: 100%;
-				}
-				.d2l-locked-alert {
-					align-items: baseline;
-					display: flex;
-				}
 				d2l-icon {
 					padding-right: 1rem;
 				}
@@ -60,7 +52,6 @@ class QuizEditorDetail extends AsyncContainerMixin(SkeletonMixin(LocalizeActivit
 
 	constructor() {
 		super();
-		this._debounceJobs = {};
 		this.skeleton = false;
 	}
 
@@ -72,29 +63,19 @@ class QuizEditorDetail extends AsyncContainerMixin(SkeletonMixin(LocalizeActivit
 			canEditName,
 		} = quiz || {};
 
-		const hasSubmissions = false;
-
 		return html`
-			<d2l-alert ?hidden=${!hasSubmissions}>
-				<div class="d2l-locked-alert">
-					<d2l-icon icon="tier1:lock-locked"></d2l-icon>
-					<div>${this.localize('assignmentLocked')}</div>
-				</div>
-			</d2l-alert>
 			<div id="assignment-name-container">
-				<d2l-input-text
-					?skeleton="${this.skeleton}"
-					id="assignment-name"
-					maxlength="128"
-					value="${name}"
-					@input="${this._saveNameOnInput}"
-					label="${this.localize('name')}"
-					required
-					?disabled="${!canEditName}"
-					prevent-submit>
-				</d2l-input-text>
-			</div>
-
+			<d2l-input-text
+				?skeleton="${this.skeleton}"
+				id="assignment-name"
+				maxlength="128"
+				value="${name}"
+				@input="${this._saveNameOnInput}"
+				label="${this.localize('name')}"
+				required
+				?disabled="${!canEditName}"
+				prevent-submit>
+			</d2l-input-text>
 		`;
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
@@ -39,10 +39,6 @@ class QuizEditorDetail extends AsyncContainerMixin(SkeletonMixin(LocalizeActivit
 				.d2l-activity-label-container {
 					margin-bottom: 8px;
 				}
-				:host([dir="rtl"]) #score-container {
-					margin-left: 40px;
-					margin-right: 0;
-				}
 				d2l-alert {
 					margin-bottom: 10px;
 					max-width: 100%;

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -1,3 +1,4 @@
+import './d2l-activity-quiz-editor-detail.js';
 import { html, LitElement } from 'lit-element/lit-element.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 
@@ -42,7 +43,13 @@ class QuizEditor extends EntityMixinLit(LitElement) {
 	get _editorTemplate() {
 		return html`
 			<slot name="editor-nav" slot="header"></slot>
-			<div slot="primary"></div>
+			<div slot="primary">
+				<d2l-activity-quiz-editor-detail
+					activity-usage-href=${this.href}
+					.href="${this.href}"
+					.token="${this.token}">
+				</d2l-activity-quiz-editor-detail>
+			</div>
 			<div slot="secondary"></div>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -1,8 +1,10 @@
 import './d2l-activity-quiz-editor-detail.js';
-import { html, LitElement } from 'lit-element/lit-element.js';
-import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
-
-class QuizEditor extends EntityMixinLit(LitElement) {
+import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
+import { AsyncContainerMixin } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
+import { html } from 'lit-element/lit-element.js';
+import { MobxLitElement } from '@adobe/lit-mobx';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
+class QuizEditor extends AsyncContainerMixin(RtlMixin(ActivityEditorMixin(MobxLitElement))) {
 
 	static get properties() {
 		return {


### PR DESCRIPTION
Created a new branch for this as github didn't seem to pickup on the changes merged by Martin in my original branch.

In the interest of keeping PRs small this is the initial structure for adding in d2l-activity-quiz-editor-detail. Part of US119416.

For now it just renders the correct input element for naming a quiz with no functionality hooked up. This is all still behind an LD flag only affecting the faceqa environment.