### PR TITLE
Refactor save to support grouping editors by save order including enh…

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -77,6 +77,11 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 		];
 	}
 
+	constructor() {
+		super(store);
+		this.saveOrder = 2000;
+	}
+
 	connectedCallback() {
 		super.connectedCallback();
 		this._m4EmailNotificationEnabled = this._isMilestoneEnabled(Milestones.M4EmailSubmission);
@@ -108,6 +113,15 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 				${this._renderAssignmentSubmissionNotificationEmail(assignment)}
 			</d2l-labs-accordion-collapse>
 		`;
+	}
+
+	async save() {
+		const assignment = store.get(this.href);
+		if (!assignment) {
+			return;
+		}
+
+		await assignment.save();
 	}
 
 	_checkNotificationEmail(e) {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -12,6 +12,7 @@ export class Assignment {
 	constructor(href, token) {
 		this.href = href;
 		this.token = token;
+		this._saving = null;
 	}
 
 	cancelCreate() {
@@ -104,7 +105,15 @@ export class Assignment {
 		if (!this._entity) {
 			return;
 		}
-		await this._entity.save(this._makeAssignmentData());
+
+		if (this._saving) {
+			return this._saving;
+		}
+
+		this._saving = this._entity.save(this._makeAssignmentData());
+		await this._saving;
+		this._saving = null;
+
 		await this.fetch();
 	}
 	setAnnotationToolsAvailable(value) {

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -14,7 +14,6 @@ class ActivityEditor extends ActivityEditorContainerMixin(ActivityEditorTelemetr
 
 	static get properties() {
 		return {
-			isSaving: { type: Boolean, attribute: 'is-saving' },
 			widthType: { type: String, attribute: 'width-type' },
 			errorTerm: { type: String, attribute: 'error-term' },
 			_backdropShown: { type: Boolean }
@@ -48,7 +47,6 @@ class ActivityEditor extends ActivityEditorContainerMixin(ActivityEditorTelemetr
 	constructor() {
 		super();
 
-		this.isSaving = false;
 		this._backdropShown = false;
 	}
 


### PR DESCRIPTION
…anced promise handling to allow multiple editors to call save on the same store.

https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Ftask%2F440737132964

This refactoring is not essential but it makes components more reusable by allowing any component to call `save` on it's associated store. Previously we were hard wiring things such that a single 'dominant' component was responsible for calling save. To support multiple editor components being able to call `save`, the store's `save` implementation needs to be written in such a way that it generates a promise when save is called and subsequent calls to save before the initial save has completed just return that promise. This prevents the same save API being called multiple times for a single save interaction.

To support this approach, the `ActivityEditorAsyncContainerMixin` `save` implementation had to be refactored to execute multiple `save` calls for the same `saveOrder` grouping concurrently otherwise, it still led to the same `save` API being called multiple times. So now before calling `validate/save`, the mixin groups editors by their `saveOrder` attribute and then iteratively calls `validate/save` on each group in turn, but calls within the same group are processed as part of the same `Promise.all` batch.