### PR TITLE
Us121271 add availability accordion for quiz

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-secondary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-secondary.js
@@ -43,7 +43,6 @@ class AssignmentEditorSecondary extends ActivityEditorFeaturesMixin(AsyncContain
 
 	constructor() {
 		super();
-		this._debounceJobs = {};
 		this.skeleton = true;
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-availability-editor.js
@@ -39,8 +39,7 @@ class ActivityQuizAvailabilityEditor extends SkeletonMixin(ActivityEditorFeature
 	render() {
 		return html`
 			<d2l-activity-accordion-collapse
-				?has-errors=${this._errorInAccordion()}
-				?skeleton="${this.skeleton}">
+				?has-errors=${this._errorInAccordion()}>
 
 				<span slot="header">
 					TODO: add localized hdrAvailability

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-availability-editor.js
@@ -2,11 +2,13 @@ import '../d2l-activity-accordion-collapse.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorFeaturesMixin } from '../mixins/d2l-activity-editor-features-mixin.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
+import { AsyncContainerMixin } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
+import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang-mixin';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import { shared as store } from '../state/activity-store.js';
 
-class ActivityQuizAvailabilityEditor extends SkeletonMixin(ActivityEditorFeaturesMixin(ActivityEditorMixin(MobxLitElement))) {
+class ActivityQuizAvailabilityEditor extends AsyncContainerMixin(LocalizeActivityQuizEditorMixin(SkeletonMixin(ActivityEditorFeaturesMixin(ActivityEditorMixin(MobxLitElement))))) {
 
 	static get properties() {
 
@@ -42,7 +44,7 @@ class ActivityQuizAvailabilityEditor extends SkeletonMixin(ActivityEditorFeature
 				?has-errors=${this._errorInAccordion()}>
 
 				<span slot="header">
-					TODO: add localized hdrAvailability
+					${this.localize('hdrAvailability')}
 				</span>
 			</d2l-activity-accordion-collapse>
 		`;

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-availability-editor.js
@@ -1,0 +1,65 @@
+import '../d2l-activity-accordion-collapse.js';
+import { css, html } from 'lit-element/lit-element.js';
+import { ActivityEditorFeaturesMixin } from '../mixins/d2l-activity-editor-features-mixin.js';
+import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
+import { MobxLitElement } from '@adobe/lit-mobx';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
+import { shared as store } from '../state/activity-store.js';
+
+class ActivityQuizAvailabilityEditor extends SkeletonMixin(ActivityEditorFeaturesMixin(ActivityEditorMixin(MobxLitElement))) {
+
+	static get properties() {
+
+		return {
+			href: { type: String },
+			token: { type: Object }
+		};
+	}
+
+	static get styles() {
+
+		return [
+			super.styles,
+			css`
+				:host {
+					display: block;
+				}
+
+				:host([hidden]) {
+					display: none;
+				}
+			`
+		];
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+	}
+
+	render() {
+		return html`
+			<d2l-activity-accordion-collapse
+				?has-errors=${this._errorInAccordion()}
+				?skeleton="${this.skeleton}">
+
+				<span slot="header">
+					TODO: add localized hdrAvailability
+				</span>
+			</d2l-activity-accordion-collapse>
+		`;
+	}
+	// Returns true if any error states relevant to this accordion are set
+	_errorInAccordion() {
+		const activity = store.get(this.href);
+		if (!activity || !activity.dates) {
+			return false;
+		}
+
+		return !!(activity.dates.endDateErrorTerm || activity.dates.startDateErrorTerm);
+	}
+}
+
+customElements.define(
+	'd2l-activity-quiz-availability-editor',
+	ActivityQuizAvailabilityEditor
+);

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-secondary.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-secondary.js
@@ -1,0 +1,71 @@
+import './d2l-activity-quiz-availability-editor.js';
+import '@brightspace-ui/core/components/colors/colors.js';
+import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { ActivityEditorFeaturesMixin } from '../mixins/d2l-activity-editor-features-mixin.js';
+import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
+
+class QuizEditorSecondary extends ActivityEditorFeaturesMixin(AsyncContainerMixin(SkeletonMixin(RtlMixin(LitElement)))) {
+
+	static get properties() {
+		return {
+			activityUsageHref: { type: String, attribute: 'activity-usage-href' },
+		};
+	}
+
+	static get styles() {
+		return [
+			super.styles,
+			labelStyles,
+			css`
+				:host {
+					background: var(--d2l-color-gypsum);
+					display: block;
+				}
+				:host([hidden]) {
+					display: none;
+				}
+				:host > * {
+					background: var(--d2l-color-white);
+					border-radius: 8px;
+					margin-bottom: 10px;
+					padding: 20px;
+					padding-top: 0;
+				}
+			`
+		];
+	}
+
+	constructor() {
+		super();
+		this._debounceJobs = {};
+		this.skeleton = true;
+	}
+
+	render() {
+		const availabilityAccordian = html`
+			<d2l-activity-quiz-availability-editor
+				.href="${this.activityUsageHref}"
+				.token="${this.token}"
+				?skeleton="${this.skeleton}">
+			</d2l-activity-quiz-availability-editor>
+		`;
+
+		return html`
+			${availabilityAccordian}
+		`;
+
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
+
+		if (changedProperties.has('asyncState')) {
+			this.skeleton = this.asyncState !== asyncStates.complete;
+		}
+	}
+
+}
+customElements.define('d2l-activity-quiz-editor-secondary', QuizEditorSecondary);

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -1,4 +1,5 @@
 import './d2l-activity-quiz-editor-detail.js';
+import './d2l-activity-quiz-editor-secondary.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { AsyncContainerMixin } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
 import { html } from 'lit-element/lit-element.js';
@@ -52,7 +53,13 @@ class QuizEditor extends AsyncContainerMixin(RtlMixin(ActivityEditorMixin(MobxLi
 					.token="${this.token}">
 				</d2l-activity-quiz-editor-detail>
 			</div>
-			<div slot="secondary"></div>
+			<div slot="secondary">
+				<d2l-activity-quiz-editor-secondary
+					.href="${this.href}"
+					.token="${this.token}"
+					activity-usage-href="${this.href}">
+				</d2l-activity-quiz-editor-secondary>
+			</div>
 		`;
 	}
 }

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
@@ -3,4 +3,5 @@
 export default {
 	"name": "Name", // Label for the name field when creating/editing an activity
 	"quizSaveError": "Your quiz wasn't saved. Please correct the fields outlined in red.", // Error message to inform the user that there was a problem saving the quiz, instructing them to correct invalid fields
+	"hdrAvailability": "Availability Dates & Conditions", // availability header
 };


### PR DESCRIPTION
This adds the accordion for availability dates & conditions according to [US121271](https://rally1.rallydev.com/#/29180338367ud/iterationstatus?detail=%2Fuserstory%2F440730104040). 
Note it does not skeletize yet, as it needs to be able to load something for the skeleton to disappear, so that will be added with the story that actually loads/saves the dates info.