### PR TITLE
Updated default quiz date/ times to 12am

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
@@ -10,6 +10,9 @@ import { shared as store } from './state/activity-store.js';
 class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeActivityEditorMixin(MobxLitElement))) {
 
 	static get properties() {
+		/*
+			Used to set the start time if something other than endOfDay is required. This is likely a temporary solution as eventually assignments will also adopt this default start time and it will no longer need to be dynamic.
+		 */
 		return {
 			'startDateDefaultTime': {
 				type: String

--- a/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
@@ -9,6 +9,14 @@ import { shared as store } from './state/activity-store.js';
 
 class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeActivityEditorMixin(MobxLitElement))) {
 
+	static get properties() {
+		return {
+			'startDateDefaultTime': {
+				type: String
+			}
+		};
+	}
+
 	static get styles() {
 		return [labelStyles, css`
 			:host([hidden]) {
@@ -41,7 +49,7 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeActiv
 			<d2l-input-date-time
 				id="start-date-input"
 				label="${this.localize('editor.startDate')}"
-				time-default-value="00:00:00"
+				time-default-value=${this.startDateDefaultTime || 'endOfDay'}
 				value="${startDate}"
 				@change="${this._onStartDatetimeChanged}">
 			</d2l-input-date-time>
@@ -53,7 +61,7 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeActiv
 			<d2l-input-date-time
 				id="end-date-input"
 				label="${this.localize('editor.endDate')}"
-				time-default-value="00:00:00"
+				time-default-value="endOfDay"
 				value="${endDate}"
 				@change="${this._onEndDatetimeChanged}">
 			</d2l-input-date-time>

--- a/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
@@ -11,7 +11,7 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeActiv
 
 	static get properties() {
 		/*
-			Used to set the start time if something other than endOfDay is required. This is likely a temporary solution as eventually assignments will also adopt this default start time and it will no longer need to be dynamic.
+			Used to set the start time if something other than endOfDay is required. This is likely a temporary solution as eventually assignments will also adopt 12am as it's default start time and it will no longer need to be dynamic.
 		 */
 		return {
 			'startDateDefaultTime': {

--- a/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
@@ -41,7 +41,7 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeActiv
 			<d2l-input-date-time
 				id="start-date-input"
 				label="${this.localize('editor.startDate')}"
-				time-default-value="endOfDay"
+				time-default-value="00:00:00"
 				value="${startDate}"
 				@change="${this._onStartDatetimeChanged}">
 			</d2l-input-date-time>
@@ -53,7 +53,7 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeActiv
 			<d2l-input-date-time
 				id="end-date-input"
 				label="${this.localize('editor.endDate')}"
-				time-default-value="endOfDay"
+				time-default-value="00:00:00"
 				value="${endDate}"
 				@change="${this._onEndDatetimeChanged}">
 			</d2l-input-date-time>

--- a/components/d2l-activity-editor/d2l-activity-due-date-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-due-date-editor.js
@@ -42,7 +42,7 @@ class ActivityDueDateEditor extends SkeletonMixin(ActivityEditorMixin(LocalizeAc
 				?skeleton="${this.skeleton}"
 				id="due-date-input"
 				label="${this.localize('editor.dueDate')}"
-				time-default-value="endOfDay"
+				time-default-value="00:00:00"
 				value="${dueDate}"
 				@change="${this._onDatetimeChanged}">
 			</d2l-input-date-time>

--- a/components/d2l-activity-editor/d2l-activity-due-date-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-due-date-editor.js
@@ -42,7 +42,7 @@ class ActivityDueDateEditor extends SkeletonMixin(ActivityEditorMixin(LocalizeAc
 				?skeleton="${this.skeleton}"
 				id="due-date-input"
 				label="${this.localize('editor.dueDate')}"
-				time-default-value="00:00:00"
+				time-default-value="endOfDay"
 				value="${dueDate}"
 				@change="${this._onDatetimeChanged}">
 			</d2l-input-date-time>

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-availability-editor.js
@@ -72,7 +72,8 @@ class ActivityQuizAvailabilityEditor extends AsyncContainerMixin(LocalizeActivit
 			<div class="d2l-editor">
 				<d2l-activity-availability-dates-editor
 					href="${this.href}"
-					.token="${this.token}">
+					.token="${this.token}"
+					startDateDefaultTime="00:00:00">
 				</d2l-activity-availability-dates-editor>
 			</div>
 		`;


### PR DESCRIPTION
As per Joseph, for quizzing (and eventually for assignments) the default start time should be 12AM.

I'm not a big fan of this approach as it's quite specific to just start date. What happens if we want to make the end date dynamic for example? Do we keep adding new properties? 

I believe this is just a temporary solution as eventually assignments will also adopt this default start time and it will no longer need to be dynamic.

Also wondering if it's better to have a fallback time e.g. `${this.startDateDefaultTime || 'endOfDay'}` or if it would be preferred to avoid the fallback and explicitly set the start time for each component?