### PR TITLE
fix summarizer converting dates to browser settings instead of bright…

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-availability-dates-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-summary.js
@@ -1,5 +1,6 @@
 import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
 import { formatDate } from '@brightspace-ui/intl/lib/dateTime.js';
+import { getDateFromISODateTime } from '@brightspace-ui/core/helpers/dateTime.js';
 import { html } from 'lit-element/lit-element';
 import { LocalizeActivityEditorMixin } from './mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
@@ -57,7 +58,7 @@ class ActivityAvailabilityDatesSummary
 			return null;
 		}
 
-		const date = new Date(suspiciousString);
+		const date = getDateFromISODateTime(suspiciousString);
 
 		if (isNaN(date.getTime())) {
 			return null;


### PR DESCRIPTION
…space locale settings

Using javascript's `Date` constructor causes the date to be converted to the browser timezone instead of the user's locale setting in brightspace. The `BrightspaceUI/core/helper/dateTime` functions use the correct locale settings.