### PR TITLE
Us121749/add timing display accordion

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
@@ -7,6 +7,7 @@ import '../d2l-activity-special-access-summary.js';
 import '../d2l-activity-accordion-collapse.js';
 import { ActivityEditorFeaturesMixin, Milestones } from '../mixins/d2l-activity-editor-features-mixin.js';
 import { css, html } from 'lit-element/lit-element.js';
+import { accordionStyles } from '../styles/accordion-styles';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { heading4Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
@@ -31,15 +32,8 @@ class ActivityAssignmentAvailabilityEditor extends SkeletonMixin(ActivityEditorF
 		return [
 			super.styles,
 			heading4Styles,
+			accordionStyles,
 			css`
-				:host {
-					display: block;
-				}
-
-				:host([hidden]) {
-					display: none;
-				}
-
 				.d2l-editor {
 					margin: 1rem 0;
 				}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -7,6 +7,7 @@ import './d2l-activity-submission-email-notification-summary.js';
 import { ActivityEditorFeaturesMixin, Milestones } from '../mixins/d2l-activity-editor-features-mixin.js';
 import { bodyCompactStyles, bodySmallStyles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html } from 'lit-element/lit-element.js';
+import { accordionStyles } from '../styles/accordion-styles';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { ErrorHandlingMixin } from '../error-handling-mixin.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
@@ -37,6 +38,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 			labelStyles,
 			radioStyles,
 			selectStyles,
+			accordionStyles,
 			css`
 				:host {
 					display: block;
@@ -140,7 +142,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 	}
 	_getNotificationEmailTooltip() {
 		if (this._notificationEmailError) {
-			return html `
+			return html`
 				<d2l-tooltip id="notification-email-tooltip" for="notification-email" state="error" align="start" offset="10">
 					${this._notificationEmailError}
 				</d2l-tooltip>
@@ -221,7 +223,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 		if (!assignment ||
 			!assignment.submissionAndCompletionProps ||
 			!assignment.submissionAndCompletionProps.showFilesSubmissionLimit) {
-			return html ``;
+			return html``;
 		}
 
 		const unlimitedFilesPerSubmissionText = this.localize('UnlimitedFilesPerSubmission');
@@ -274,10 +276,10 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 
 	_renderAssignmentSubmissionNotificationEmail(assignment) {
 		if (!this._m4EmailNotificationEnabled || !assignment || !assignment.showNotificationEmail) {
-			return html ``;
+			return html``;
 		}
 
-		return html `
+		return html`
 		<div id="assignment-notification-email-container">
 			<div class="d2l-label-text">
 				${this.localize('hdrSubmissionNotificationEmail')}
@@ -308,7 +310,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 		if (!assignment ||
 			!assignment.submissionAndCompletionProps ||
 			!assignment.submissionAndCompletionProps.showSubmissionsRule) {
-			return html ``;
+			return html``;
 		}
 
 		let submissionsRuleContent;
@@ -325,14 +327,14 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 						>
 						${x.title}
 					</label>
-				`) }
+				`)}
 			`;
 		} else {
 			const found = assignment.submissionAndCompletionProps.submissionsRuleOptions.find(x => assignment.submissionAndCompletionProps.submissionsRule === x.value);
 			submissionsRuleContent = html`<div class="d2l-body-compact">${found.title}</div>`;
 		}
 
-		return html `
+		return html`
 			<div id="assignment-submissions-rule-container">
 				<label class="d2l-label-text" for="assignment-submissions-rule-container">
 					${this.localize('submissionsRule')}
@@ -386,7 +388,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 		return html``;
 	}
 	_renderAssignmentType() {
-		return html `
+		return html`
 			<div id="assignment-type-container">
 				<label class="d2l-label-text">
 					${this.localize('txtAssignmentType')}
@@ -408,7 +410,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 	}
 	_renderSubmissionEmailNotificationSummary(assignment) {
 		if (!this._m4EmailNotificationEnabled || !assignment || !assignment.showNotificationEmail) {
-			return html ``;
+			return html``;
 		}
 		return html`
 			<d2l-activity-submission-email-notification-summary
@@ -435,8 +437,8 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 		const assignment = store.get(this.href);
 		const data = e.target.value;
 		assignment &&
-		assignment.submissionAndCompletionProps &&
-		assignment.submissionAndCompletionProps.setSubmissionsRule(data);
+			assignment.submissionAndCompletionProps &&
+			assignment.submissionAndCompletionProps.setSubmissionsRule(data);
 	}
 
 }

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-evaluation-editor.js
@@ -11,6 +11,7 @@ import './d2l-assignment-turnitin-summary.js';
 import '../d2l-activity-accordion-collapse.js';
 import { ActivityEditorFeaturesMixin, Milestones } from '../mixins/d2l-activity-editor-features-mixin.js';
 import { css, html } from 'lit-element/lit-element.js';
+import { accordionStyles } from '../styles/accordion-styles';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { shared as activityStore } from '../state/activity-store.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
@@ -35,15 +36,8 @@ class ActivityAssignmentEvaluationEditor extends SkeletonMixin(ActivityEditorFea
 
 		return [
 			super.styles,
+			accordionStyles,
 			css`
-				:host {
-					display: block;
-				}
-
-				:host([hidden]) {
-					display: none;
-				}
-
 				.d2l-editors > *:not(:first-child) {
 					display: block;
 					margin-top: 1rem;

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-availability-editor.js
@@ -2,6 +2,7 @@ import '../d2l-activity-availability-dates-summary.js';
 import '../d2l-activity-availability-dates-editor.js';
 import '../d2l-activity-accordion-collapse.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { accordionStyles } from '../styles/accordion-styles';
 import { LocalizeActivityEditorMixin } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
@@ -19,15 +20,8 @@ class ContentAvailabilityEditor extends SkeletonMixin(LocalizeActivityEditorMixi
 	static get styles() {
 		return [
 			super.styles,
+			accordionStyles,
 			css`
-				:host {
-					display: block;
-				}
-
-				:host([hidden]) {
-					display: none;
-				}
-
 				.d2l-editor {
 					margin: 1rem 0;
 				}

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-availability-editor.js
@@ -1,10 +1,11 @@
 import '../d2l-activity-accordion-collapse.js';
 import '../d2l-activity-availability-dates-editor.js';
 import '../d2l-activity-availability-dates-summary.js';
-import { css, html } from 'lit-element/lit-element.js';
+import { accordionStyles } from '../styles/accordion-styles';
 import { ActivityEditorFeaturesMixin } from '../mixins/d2l-activity-editor-features-mixin.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { AsyncContainerMixin } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
+import { html } from 'lit-element/lit-element.js';
 import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang-mixin';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
@@ -24,15 +25,7 @@ class ActivityQuizAvailabilityEditor extends AsyncContainerMixin(LocalizeActivit
 
 		return [
 			super.styles,
-			css`
-				:host {
-					display: block;
-				}
-
-				:host([hidden]) {
-					display: none;
-				}
-			`
+			accordionStyles
 		];
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-secondary.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-secondary.js
@@ -1,4 +1,5 @@
 import './d2l-activity-quiz-availability-editor.js';
+import './d2l-activity-quiz-timing-and-display-editor';
 import '@brightspace-ui/core/components/colors/colors.js';
 import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
@@ -53,8 +54,13 @@ class QuizEditorSecondary extends ActivityEditorFeaturesMixin(AsyncContainerMixi
 			</d2l-activity-quiz-availability-editor>
 		`;
 
+		const timingAndDisplayAccordion = html`
+			<d2l-activity-quiz-timing-and-display-editor></d2l-activity-quiz-timing-and-display-editor>
+		`;
+
 		return html`
 			${availabilityAccordian}
+			${timingAndDisplayAccordion}
 		`;
 
 	}

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-secondary.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-secondary.js
@@ -55,7 +55,11 @@ class QuizEditorSecondary extends ActivityEditorFeaturesMixin(AsyncContainerMixi
 		`;
 
 		const timingAndDisplayAccordion = html`
-			<d2l-activity-quiz-timing-and-display-editor></d2l-activity-quiz-timing-and-display-editor>
+			<d2l-activity-quiz-timing-and-display-editor
+				.href="${this.activityUsageHref}"
+				.token="${this.token}"
+				?skeleton="${this.skeleton}">
+			</d2l-activity-quiz-timing-and-display-editor>
 		`;
 
 		return html`

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-timing-and-display-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-timing-and-display-editor.js
@@ -9,7 +9,6 @@ import { html } from 'lit-element/lit-element.js';
 import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang-mixin';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
-import { shared as store } from '../state/activity-store.js';
 
 class ActivityQuizTimingAndDisplayEditor extends AsyncContainerMixin(LocalizeActivityQuizEditorMixin(SkeletonMixin(ActivityEditorFeaturesMixin(ActivityEditorMixin(MobxLitElement))))) {
 
@@ -48,11 +47,6 @@ class ActivityQuizTimingAndDisplayEditor extends AsyncContainerMixin(LocalizeAct
 	}
 	// Returns true if any error states relevant to this accordion are set
 	_errorInAccordion() {
-		const activity = store.get(this.href);
-		if (!activity || !activity.dates) {
-			return false;
-		}
-
 		return false; // Todo: implement error handling
 	}
 }

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-timing-and-display-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-timing-and-display-editor.js
@@ -1,0 +1,63 @@
+import '../d2l-activity-accordion-collapse.js';
+import '../d2l-activity-availability-dates-editor.js';
+import '../d2l-activity-availability-dates-summary.js';
+import { accordionStyles } from '../styles/accordion-styles';
+import { ActivityEditorFeaturesMixin } from '../mixins/d2l-activity-editor-features-mixin.js';
+import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
+import { AsyncContainerMixin } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
+import { html } from 'lit-element/lit-element.js';
+import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang-mixin';
+import { MobxLitElement } from '@adobe/lit-mobx';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
+import { shared as store } from '../state/activity-store.js';
+
+class ActivityQuizTimingAndDisplayEditor extends AsyncContainerMixin(LocalizeActivityQuizEditorMixin(SkeletonMixin(ActivityEditorFeaturesMixin(ActivityEditorMixin(MobxLitElement))))) {
+
+	static get properties() {
+
+		return {
+			href: { type: String },
+			token: { type: Object }
+		};
+	}
+
+	static get styles() {
+
+		return [
+			super.styles,
+			accordionStyles
+		];
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+	}
+
+	render() {
+		return html`
+			<d2l-activity-accordion-collapse
+				?has-errors=${this._errorInAccordion()}
+				?skeleton="${this.skeleton}">
+
+				<span slot="header">
+					${this.localize('hdrTimingAndDisplay')}
+				</span>
+
+			</d2l-activity-accordion-collapse>
+		`;
+	}
+	// Returns true if any error states relevant to this accordion are set
+	_errorInAccordion() {
+		const activity = store.get(this.href);
+		if (!activity || !activity.dates) {
+			return false;
+		}
+
+		return false; // Todo: implement error handling
+	}
+}
+
+customElements.define(
+	'd2l-activity-quiz-timing-and-display-editor',
+	ActivityQuizTimingAndDisplayEditor
+);

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
@@ -4,4 +4,5 @@ export default {
 	"name": "Name", // Label for the name field when creating/editing an activity
 	"quizSaveError": "Your quiz wasn't saved. Please correct the fields outlined in red.", // Error message to inform the user that there was a problem saving the quiz, instructing them to correct invalid fields
 	"hdrAvailability": "Availability Dates & Conditions", // availability header
+	"hdrTimingAndDisplay": "Timing & Display" // timing/display header
 };

--- a/components/d2l-activity-editor/styles/accordion-styles.js
+++ b/components/d2l-activity-editor/styles/accordion-styles.js
@@ -1,0 +1,11 @@
+import { css } from 'lit-element';
+
+export const accordionStyles = css`
+	:host {
+		display: block;
+	}
+
+	:host([hidden]) {
+		display: none;
+	}
+`;


### PR DESCRIPTION
Based on [US121749](https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=/userstory/448916982360) which is adding a new Timing & Display accordion to quizzing. This story just covers the initial setup so the accordion appears in the UI with correct lang term but no functionality or summary.

I used the same pattern as before to share styles between the quizzing accordions.