### PR TITLE
Add due date to face create view for content modules + edit description and loading skeleton fix

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
@@ -45,9 +45,9 @@ class ContentEditorDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 					padding-bottom: 20px;
 				}
 				.duedate-field {
-					transition: opacity 650ms ease-in;
-					opacity: 1;
 					height: auto;
+					opacity: 1;
+					transition: opacity 650ms ease-in;
 					width: auto;
 				}
 				:host([showAddDueDateBtn]) .duedate-field {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
@@ -168,6 +168,8 @@ class ContentEditorDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 					</d2l-activity-due-date-editor>
 				</div>
 			`;
+		} else {
+			return html ``;
 		}
 	}
 
@@ -182,6 +184,8 @@ class ContentEditorDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 					${this._titleError}
 				</d2l-tooltip>
 			`;
+		} else {
+			return html ``;
 		}
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
@@ -27,7 +27,7 @@ class ContentEditorDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 		return {
 			_titleError: { type: String },
 			_hasDatePermissions: { type: Boolean },
-			showAddDueDateBtn: { type: Boolean, reflect: true }
+			_showAddDueDateBtn: { type: Boolean }
 		};
 	}
 
@@ -44,17 +44,6 @@ class ContentEditorDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 				:host > div {
 					padding-bottom: 20px;
 				}
-				.d2l-duedate-field {
-					height: auto;
-					opacity: 1;
-					transition: opacity 650ms ease-in;
-					width: auto;
-				}
-				:host([showAddDueDateBtn]) .d2l-duedate-field {
-					height: 0;
-					opacity: 0;
-					width: 0;
-				}
 			`
 		];
 	}
@@ -66,7 +55,7 @@ class ContentEditorDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 		this.skeleton = true;
 		this.saveOrder = 2000;
 		this._hasDatePermissions = false;
-		this.showAddDueDateBtn = true;
+		this._showAddDueDateBtn = true;
 	}
 
 	render() {
@@ -147,7 +136,7 @@ class ContentEditorDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 		const dueDate =  dates.dueDate ? dates.dueDate : null;
 		// if due date exists on the activity, show the field
 		if (dueDate) {
-			this.showAddDueDateBtn = false;
+			this._showAddDueDateBtn = false;
 		}
 	}
 
@@ -161,23 +150,23 @@ class ContentEditorDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 	}
 
 	_renderDueDate() {
+		// TODO - replace with shared component when one is created
 		if (this._hasDatePermissions) {
 			return html `
 				<div id="duedate-container">
 					<d2l-button-subtle
 						text="${this.localize('content.addDueDate')}"
 						@click=${this._showDueDate}
-						?hidden=${!this.showAddDueDateBtn}
+						?hidden=${!this._showAddDueDateBtn}
 					>
 					</d2l-button-subtle>
-					<div class="d2l-duedate-field">
-						<d2l-activity-due-date-editor
-							.href="${this.href}"
-							.token="${this.token}"
-							?skeleton="${this.skeleton}"
-						>
-						</d2l-activity-due-date-editor>
-					</div>
+					<d2l-activity-due-date-editor
+						.href="${this.href}"
+						.token="${this.token}"
+						?skeleton="${this.skeleton}"
+						?hidden=${this._showAddDueDateBtn}
+					>
+					</d2l-activity-due-date-editor>
 				</div>
 			`;
 		}
@@ -234,7 +223,7 @@ class ContentEditorDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 	}
 
 	_showDueDate() {
-		this.showAddDueDateBtn = false;
+		this._showAddDueDateBtn = false;
 	}
 }
 customElements.define('d2l-activity-content-editor-detail', ContentEditorDetail);

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
@@ -44,15 +44,15 @@ class ContentEditorDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 				:host > div {
 					padding-bottom: 20px;
 				}
-				.duedate-field {
+				.d2l-duedate-field {
 					height: auto;
 					opacity: 1;
 					transition: opacity 650ms ease-in;
 					width: auto;
 				}
-				:host([showAddDueDateBtn]) .duedate-field {
-					opacity: 0;
+				:host([showAddDueDateBtn]) .d2l-duedate-field {
 					height: 0;
+					opacity: 0;
 					width: 0;
 				}
 			`
@@ -170,7 +170,7 @@ class ContentEditorDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 						?hidden=${!this.showAddDueDateBtn}
 					>
 					</d2l-button-subtle>
-					<div class="duedate-field">
+					<div class="d2l-duedate-field">
 						<d2l-activity-due-date-editor
 							.href="${this.href}"
 							.token="${this.token}"

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
@@ -27,7 +27,7 @@ class ContentEditorDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 		return {
 			_titleError: { type: String },
 			_hasDatePermissions: { type: Boolean },
-			showAddDueDateBtn: { type: Boolean }
+			showAddDueDateBtn: { type: Boolean, reflect: true }
 		};
 	}
 
@@ -43,6 +43,17 @@ class ContentEditorDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 				}
 				:host > div {
 					padding-bottom: 20px;
+				}
+				.duedate-field {
+					transition: opacity 650ms ease-in;
+					opacity: 1;
+					height: auto;
+					width: auto;
+				}
+				:host([showAddDueDateBtn]) .duedate-field {
+					opacity: 0;
+					height: 0;
+					width: 0;
 				}
 			`
 		];
@@ -159,13 +170,14 @@ class ContentEditorDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 						?hidden=${!this.showAddDueDateBtn}
 					>
 					</d2l-button-subtle>
-					<d2l-activity-due-date-editor
-						.href="${this.href}"
-						.token="${this.token}"
-						?skeleton="${this.skeleton}"
-						?hidden=${this.showAddDueDateBtn}
-					>
-					</d2l-activity-due-date-editor>
+					<div class="duedate-field">
+						<d2l-activity-due-date-editor
+							.href="${this.href}"
+							.token="${this.token}"
+							?skeleton="${this.skeleton}"
+						>
+						</d2l-activity-due-date-editor>
+					</div>
 				</div>
 			`;
 		}

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
@@ -1,6 +1,7 @@
 import 'd2l-inputs/d2l-input-text.js';
 import 'd2l-tooltip/d2l-tooltip';
 import '../d2l-activity-html-editor';
+import '../d2l-activity-due-date-editor.js';
 import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
 import { CONTENT_TYPES, ContentEntity } from 'siren-sdk/src/activities/content/ContentEntity.js';
 import { css, html } from 'lit-element/lit-element.js';
@@ -72,6 +73,14 @@ class ContentEditorDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 				>
 				</d2l-input-text>
 				${this._renderTitleTooltip()}
+			</div>
+			<div id="duedate-container">
+				<d2l-activity-due-date-editor
+					.href="${this.href}"
+					.token="${this.token}"
+					?skeleton="${this.skeleton}"
+				>
+				</d2l-activity-due-date-editor>
 			</div>
 			<div id="content-description-container">
 				<label class="d2l-label-text d2l-skeletize" for="content-description">${this.localize('content.description')}</label>

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
@@ -133,9 +133,8 @@ class ContentEditorDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 		}
 		const dates = entity.dates;
 		this._hasDatePermissions = dates.canEditDates;
-		const dueDate =  dates.dueDate ? dates.dueDate : null;
 		// if due date exists on the activity, show the field
-		if (dueDate) {
+		if (dates.dueDate) {
 			this._showAddDueDateBtn = false;
 		}
 	}
@@ -156,15 +155,15 @@ class ContentEditorDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 				<div id="duedate-container">
 					<d2l-button-subtle
 						text="${this.localize('content.addDueDate')}"
-						@click=${this._showDueDate}
-						?hidden=${!this._showAddDueDateBtn}
+						@click="${this._showDueDate}"
+						?hidden="${!this._showAddDueDateBtn}"
 					>
 					</d2l-button-subtle>
 					<d2l-activity-due-date-editor
 						.href="${this.href}"
 						.token="${this.token}"
 						?skeleton="${this.skeleton}"
-						?hidden=${this._showAddDueDateBtn}
+						?hidden="${this._showAddDueDateBtn}"
 					>
 					</d2l-activity-due-date-editor>
 				</div>

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
@@ -60,8 +60,15 @@ class ContentEditorDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 
 	render() {
 		const contentEntity = store.getContentActivity(this.href);
-		const title = contentEntity && contentEntity.entityType === CONTENT_TYPES.module ? contentEntity.moduleTitle : '';
-		const descriptionRichText = contentEntity && contentEntity.entityType === CONTENT_TYPES.module ? contentEntity.moduleDescriptionRichText : '';
+		let title = '';
+		let descriptionRichText = undefined;
+		this.skeleton = true;
+		if (contentEntity) {
+			// Show loading skeleton until we have the content entity loaded into state
+			this.skeleton = false;
+			title = contentEntity.entityType === CONTENT_TYPES.module ? contentEntity.moduleTitle : '';
+			descriptionRichText = contentEntity.entityType === CONTENT_TYPES.module ? contentEntity.moduleDescriptionRichText : undefined;
+		}
 		this._getDueDateAndPermission();
 
 		return html`

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
@@ -86,8 +86,8 @@ class ContentEditorDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 				<label class="d2l-label-text d2l-skeletize" for="content-description">${this.localize('content.description')}</label>
 				<div class="d2l-skeletize">
 					<d2l-activity-html-editor
-						id='content-description'
-						ariaLabel="content-description"
+						.ariaLabel="content-description"
+						.key="content-description"
 						.value="${descriptionRichText}"
 						@d2l-activity-html-editor-change="${this._onRichtextChange}"
 						.richtextEditorConfig="${{}}"
@@ -150,43 +150,43 @@ class ContentEditorDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 
 	_renderDueDate() {
 		// TODO - replace with shared component when one is created
-		if (this._hasDatePermissions) {
-			return html `
-				<div id="duedate-container">
-					<d2l-button-subtle
-						text="${this.localize('content.addDueDate')}"
-						@click="${this._showDueDate}"
-						?hidden="${!this._showAddDueDateBtn}"
-					>
-					</d2l-button-subtle>
-					<d2l-activity-due-date-editor
-						.href="${this.href}"
-						.token="${this.token}"
-						?skeleton="${this.skeleton}"
-						?hidden="${this._showAddDueDateBtn}"
-					>
-					</d2l-activity-due-date-editor>
-				</div>
-			`;
-		} else {
+		if (!this._hasDatePermissions) {
 			return html ``;
 		}
+
+		return html `
+			<div id="duedate-container">
+				<d2l-button-subtle
+					text="${this.localize('content.addDueDate')}"
+					@click="${this._showDueDate}"
+					?hidden="${!this._showAddDueDateBtn}"
+				>
+				</d2l-button-subtle>
+				<d2l-activity-due-date-editor
+					.href="${this.href}"
+					.token="${this.token}"
+					?skeleton="${this.skeleton}"
+					?hidden="${this._showAddDueDateBtn}"
+				>
+				</d2l-activity-due-date-editor>
+			</div>
+		`;
 	}
 
 	_renderTitleTooltip() {
-		if (this._titleError) {
-			return html`
-				<d2l-tooltip
-					id="title-tooltip"
-					for="content-title"
-					position="bottom"
-					?showing="${!!this._titleError}">
-					${this._titleError}
-				</d2l-tooltip>
-			`;
-		} else {
+		if (!this._titleError) {
 			return html ``;
 		}
+
+		return html`
+			<d2l-tooltip
+				id="title-tooltip"
+				for="content-title"
+				position="bottom"
+				?showing="${!!this._titleError}">
+				${this._titleError}
+			</d2l-tooltip>
+		`;
 	}
 
 	_saveDescription(richText) {

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -119,4 +119,5 @@ export default {
 	"content.description": "Description", // Text label for description input field
 	"content.availabilityHeader": "Availability Dates", // availability header
 	"content.saveError": "Your content item wasn't saved. Please correct the fields outlined in red.", // Error message to inform the user that there was a problem saving the content item, instructing them to correct invalid fields
+	"content.addDueDate": "Add Due Date" // Text label for name input field
 };


### PR DESCRIPTION
### Notes
- When creating a new content item, the user should see the subtle button saying "Add Due Date". Once clicked, the due date field will appear.
- When editing, the user should see the "Add Due Date" button if a due date has not yet been added. Otherwise, the due date field should appear and show the selected due date. Note that this has not properly been tested yet since we haven't implemented loading in the edit view. Will be confirmed and fixed if necessary once this is implemented.
- The due date field does indeed appear to save on the activity-usage entity and should be visible in areas where implemented. 

UPDATE: refactored some logic so we see loading skeletons until content entity is loaded into state so you don't see a weird delay before the field value appears. Also had to set initial value of description value to `undefined` so the html editor would properly load in the value when grabbing the value from state.

### GIFS
Note: no animations/transitions are included in this implementation. 
![add-due-date](https://user-images.githubusercontent.com/64804046/98376073-00823c00-2011-11eb-8def-ffa58097f459.gif)

### Screenshots
Screenshot below shows that a successful PATCH request was sent with the entered due date value.
![save-date-request](https://user-images.githubusercontent.com/64804046/98171858-67431080-1ebe-11eb-8cdb-6be118678f1d.PNG)