### PR TITLE
Added 12am as start date for assignment date picker

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
@@ -92,7 +92,8 @@ class ActivityAssignmentAvailabilityEditor extends SkeletonMixin(ActivityEditorF
 			<div class="d2l-editor">
 				<d2l-activity-availability-dates-editor
 					href="${this.href}"
-					.token="${this.token}">
+					.token="${this.token}"
+					startDateDefaultTime="00:00:00">
 				</d2l-activity-availability-dates-editor>
 			</div>
 		`;


### PR DESCRIPTION
Based on [US121708](https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=/userstory/448686592196).

I had thought of removing the `startDateDefaultTime` property completely and having the default start time set at the activity level to ensure consistency across all current/future activities however the content tool has their default set to 11:59pm and I did not want to introduce any changes that affect other teams.

