### PR TITLE
Dont reset isSaving to allow for saving state to persist beyond save function

### DIFF
--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
@@ -131,7 +131,6 @@ export const ActivityEditorContainerMixin = superclass => class extends Activity
 		await this._saveEditors(orderedEditors);
 
 		this.isError = false;
-		this.isSaving = false;
 		this.dispatchEvent(this.saveCompleteEvent);
 		this.logSaveEvent(this.href, this.type, this.telemetryId);
 	}


### PR DESCRIPTION
This allows us to display the opaque saving overlay for the entirety of saving, closing, and navigating away from the editor.