### PR TITLE
Force date pickers to render in a column to avoid spacing bug

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
@@ -28,7 +28,6 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeActiv
 			:host {
 				display: flex;
 				flex-direction: column;
-				justify-content: flex;
 			}
 			#start-date-input {
 				padding-bottom: 20px;

--- a/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
@@ -25,6 +25,11 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeActiv
 			:host([hidden]) {
 				display: none;
 			}
+			:host {
+				display: flex;
+				justify-content: flex;
+				flex-direction: column;
+			}
 			#start-date-input {
 				padding-bottom: 20px;
 			}

--- a/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
@@ -27,8 +27,8 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeActiv
 			}
 			:host {
 				display: flex;
-				justify-content: flex;
 				flex-direction: column;
+				justify-content: flex;
 			}
 			#start-date-input {
 				padding-bottom: 20px;


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fdefect%2F458394411452

When a user has their font size set to small the date picker inputs render side by side instead of stacked which causes them to be misaligned. 

![image](https://user-images.githubusercontent.com/46040098/100011071-0e142180-2d86-11eb-8f2d-d6f57f9e9a3f.png)

This fix forces a single column, stacked layout regardless of font size which corrects this defect. I ran this change by Joseph to ensure it met the design doc and he was happy with it.

I had thought of applying media queries but this seemed like the simplest fix.

With this styling applied the layout should always display in a single column:

![image](https://user-images.githubusercontent.com/46040098/100011386-81b62e80-2d86-11eb-864c-7178f188d6f4.png)
