### PR TITLE
Changed css selectors to target slotted elements

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-accordion-collapse.js
+++ b/components/d2l-activity-editor/d2l-activity-accordion-collapse.js
@@ -49,19 +49,19 @@ class ActivityAccordionCollapse extends SkeletonMixin(LitElement) {
 					padding: 0;
 				}
 
-				ul.d2l-activity-summarizer-summary > li {
-					margin-bottom: 8px;
-				}
-
-				ul.d2l-activity-summarizer-summary > li:last-child {
-					margin-bottom: 0;
-				}
-
 				:host([skeleton]) .d2l-activity-summarizer-summary.d2l-skeletize::before {
 					width: 60%;
 				}
 				:host([skeleton]) .d2l-activity-summarizer-summary.d2l-skeletize {
 					height: 1rem;
+				}
+
+				::slotted(li) {
+					margin-bottom: 8px;
+				}
+
+				::slotted(li:last-of-type) {
+					margin-bottom: 0;
 				}
 			`
 		];


### PR DESCRIPTION
Defect fix based on this trello item https://trello.com/c/pXTHX0jK/266-fix-summarizer-spacing.

I believe this defect was introduced during [a refactor](https://github.com/BrightspaceHypermediaComponents/activities/pull/1152/files) to create an accordion wrapper which meant that the css selectors were no longer targeting the slotted `li` elements. From a quick [bit of reading](https://developer.mozilla.org/en-US/docs/Web/CSS/::slotted)/experimenting with the `::slotted()` selector I tried this approach which seems to correctly target the `li` elements. 

Not sure if there's a preferred way to target slotted elements. 

Before 

![image](https://user-images.githubusercontent.com/46040098/100022915-dd89b300-2d98-11eb-92d5-cfcab7d08276.png)


After

![image](https://user-images.githubusercontent.com/46040098/100023044-1cb80400-2d99-11eb-90d2-60f1bcc31af0.png)

