### PR TITLE
Set default start time to 12am for all availability editors

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-availability-editor.js
@@ -92,8 +92,7 @@ class ActivityAssignmentAvailabilityEditor extends SkeletonMixin(ActivityEditorF
 			<div class="d2l-editor">
 				<d2l-activity-availability-dates-editor
 					href="${this.href}"
-					.token="${this.token}"
-					startDateDefaultTime="00:00:00">
+					.token="${this.token}">
 				</d2l-activity-availability-dates-editor>
 			</div>
 		`;

--- a/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
@@ -9,17 +9,6 @@ import { shared as store } from './state/activity-store.js';
 
 class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeActivityEditorMixin(MobxLitElement))) {
 
-	static get properties() {
-		/*
-			Used to set the start time if something other than endOfDay is required. This is likely a temporary solution as eventually assignments will also adopt 12am as it's default start time and it will no longer need to be dynamic.
-		 */
-		return {
-			'startDateDefaultTime': {
-				type: String
-			}
-		};
-	}
-
 	static get styles() {
 		return [labelStyles, css`
 			:host([hidden]) {
@@ -56,7 +45,7 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeActiv
 			<d2l-input-date-time
 				id="start-date-input"
 				label="${this.localize('editor.startDate')}"
-				time-default-value=${this.startDateDefaultTime || 'endOfDay'}
+				time-default-value="startOfDay"
 				value="${startDate}"
 				@change="${this._onStartDatetimeChanged}">
 			</d2l-input-date-time>

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-availability-editor.js
@@ -72,8 +72,7 @@ class ActivityQuizAvailabilityEditor extends AsyncContainerMixin(LocalizeActivit
 			<div class="d2l-editor">
 				<d2l-activity-availability-dates-editor
 					href="${this.activityUsageHref}"
-					.token="${this.token}"
-					startDateDefaultTime="00:00:00">
+					.token="${this.token}">
 				</d2l-activity-availability-dates-editor>
 			</div>
 		`;


### PR DESCRIPTION
Setting start time to 12am for all availability editors. Removing unnecessary property as we all use the same start time now. 

Related PR: https://github.com/BrightspaceHypermediaComponents/activities/pull/1181

Rally ticket: https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F459132218232

@ronan-f adding you as reviewer as you recently set the start time for assignments/quizzes to 12am. Tested it in assignments and it works fine. 

### Gifs
Content experience:
![start-date-12am](https://user-images.githubusercontent.com/64804046/100144960-9c130980-2e65-11eb-83d9-878a5c90846b.gif)

Assignment experience:
 ![start-date-12am-assignments](https://user-images.githubusercontent.com/64804046/100145012-acc37f80-2e65-11eb-9fa9-d4d4caf2fdc6.gif)
