### PR TITLE
US121861 Quizzes: Add summarizer for disable pager and alerts

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-pager-and-alerts-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-pager-and-alerts-summary.js
@@ -1,0 +1,32 @@
+import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin';
+import { html } from 'lit-element/lit-element';
+import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang-mixin.js';
+import { MobxLitElement } from '@adobe/lit-mobx';
+import { shared as store } from './state/quiz-store';
+
+class ActivityQuizDisablePagerAndAlertsSummary
+	extends ActivityEditorMixin(LocalizeActivityQuizEditorMixin(MobxLitElement)) {
+
+	constructor() {
+		super(store);
+	}
+
+	render() {
+		const activity = store.get(this.href);
+		if (!activity) {
+			return html``;
+		}
+
+		const isDisablePagerAndAlertsEnabled = activity.isDisablePagerAndAlertsEnabled;
+		if (!isDisablePagerAndAlertsEnabled) {
+			return html``;
+		}
+
+		return html`${this.localize('disablePagerAndAlertsSummary')}`;
+	}
+}
+
+customElements.define(
+	'd2l-activity-quiz-disable-pager-and-alerts-summary',
+	ActivityQuizDisablePagerAndAlertsSummary
+);

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-timing-and-display-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-timing-and-display-editor.js
@@ -1,5 +1,6 @@
 import '../d2l-activity-accordion-collapse.js';
 import './d2l-activity-quiz-disable-pager-and-alerts-editor.js';
+import './d2l-activity-quiz-disable-pager-and-alerts-summary.js';
 import './d2l-activity-quiz-disable-right-click-editor.js';
 import './d2l-activity-quiz-disable-right-click-summary.js';
 import './d2l-activity-quiz-hints-editor.js';
@@ -49,6 +50,7 @@ class ActivityQuizTimingAndDisplayEditor extends AsyncContainerMixin(LocalizeAct
 
 				<li slot="summary-items">${this._renderAllowHintsSummary()}</li>
 				<li slot="summary-items">${this._renderDisableRightClickSummary()}</li>
+				<li slot="summary-items">${this._renderDisablePagerAndAlertsSummary()}</li>
 
 				<div class="d2l-editors" slot="components">
 					<label class="d2l-label-text">
@@ -82,6 +84,15 @@ class ActivityQuizTimingAndDisplayEditor extends AsyncContainerMixin(LocalizeAct
 				href="${this.href}"
 				.token="${this.token}">
 			</d2l-activity-quiz-disable-pager-and-alerts>
+		`;
+	}
+
+	_renderDisablePagerAndAlertsSummary() {
+		return html`
+			<d2l-activity-quiz-disable-pager-and-alerts-summary
+				href="${this.href}"
+				.token="${this.token}">
+			</d2l-activity-quiz-disable-pager-and-alerts-summary>
 		`;
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
@@ -14,4 +14,5 @@ export default {
 	"disableRightClickDescription": "Disable right click", // description for disable right click
 	"disableRightClickSummary": "Right clicks disabled", // summary text when right clicks are disabled
 	"disablePagerAndAlertsDescription": "Block alerts and communication during quiz attempts", // description for disable pager and alerts / block communications during a quiz
+	"disablePagerAndAlertsSummary": "Alerts and communication blocked", // summary text when pager and alerts / communications are disabled
 };


### PR DESCRIPTION
[US121861](https://rally1.rallydev.com/#/detail/userstory/449846810872?fdp=true): [ui] Summarizer: block alerts

```
Summarizer text displays, "Alerts and communication blocked" when block alerts and communications is checked.

Rules below:

Accordion:  Timing & Display
Not active / default text:  Show nothing

Active state:
"Alerts and communication blocked"

Other:
Ensure summarizer text is skeletonized on load
"Alerts and communication blocked" will be the third summary text item on the accordion.
Summary text order should match field ordering i.e. should appear beneath "Hints allowed" and/or "Right clicks disabled" if they are shown.
```