### PR TITLE
US120979 - Email Notification Validation

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -9,21 +9,20 @@ import { bodyCompactStyles, bodySmallStyles, labelStyles } from '@brightspace-ui
 import { css, html } from 'lit-element/lit-element.js';
 import { accordionStyles } from '../styles/accordion-styles';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
-import { ErrorHandlingMixin } from '../error-handling-mixin.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
+import { NotificationEmailMixin } from '../notification-email-mixin.js';
 import { radioStyles } from '@brightspace-ui/core/components/inputs/input-radio-styles.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import { shared as store } from './state/assignment-store.js';
 
-class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(ActivityEditorFeaturesMixin(ActivityEditorMixin(ErrorHandlingMixin(RtlMixin(LocalizeActivityAssignmentEditorMixin(MobxLitElement)))))) {
+class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(ActivityEditorFeaturesMixin(ActivityEditorMixin(NotificationEmailMixin(RtlMixin(LocalizeActivityAssignmentEditorMixin(MobxLitElement)))))) {
 
 	static get properties() {
 
 		return {
-			_notificationEmailError: { type: String },
 			href: { type: String },
 			token: { type: Object },
 			_m4EmailNotificationEnabled: { type: Boolean }
@@ -117,21 +116,6 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 		await assignment.save();
 	}
 
-	_checkNotificationEmail(e) {
-		const errorProperty = '_notificationEmailError';
-		const invalidNotificationEmailErrorLangterm = 'invalidNotificationEmailError';
-		const tooltipId = 'notification-email-tooltip';
-
-		const notificationEmail = e.target.value;
-		const isEmpty = (notificationEmail || '').length === 0;
-
-		const matches = /^(\s?[^\s,]+@[^\s,]+\.[^\s,]+\s?,)*(\s?[^\s,]+@[^\s,]+\.[^\s,]+)$/.exec(notificationEmail);
-		if (!isEmpty && matches === null) {
-			this.setError(errorProperty, invalidNotificationEmailErrorLangterm, tooltipId);
-		} else {
-			this.clearError(errorProperty);
-		}
-	}
 	_getCompletionTypeOptions(assignment) {
 		const completionTypeOptions = assignment && assignment.submissionAndCompletionProps ? assignment.submissionAndCompletionProps.completionTypeOptions : [];
 		const completionType = assignment && assignment.submissionAndCompletionProps ? assignment.submissionAndCompletionProps.completionType : '0';
@@ -140,15 +124,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 			${completionTypeOptions.map(option => html`<option value=${option.value} ?selected=${String(option.value) === completionType}>${option.title}</option>`)}
 		`;
 	}
-	_getNotificationEmailTooltip() {
-		if (this._notificationEmailError) {
-			return html`
-				<d2l-tooltip id="notification-email-tooltip" for="notification-email" state="error" align="start" offset="10">
-					${this._notificationEmailError}
-				</d2l-tooltip>
-			`;
-		}
-	}
+
 	_getSelectedCompletionType(assignment) {
 		if (!assignment ||
 			!assignment.submissionAndCompletionProps ||
@@ -279,6 +255,8 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 			return html``;
 		}
 
+		const elemId = 'assignment-notification-email';
+
 		return html`
 		<div id="assignment-notification-email-container">
 			<div class="d2l-label-text">
@@ -289,19 +267,19 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 			</p>
 
 			<d2l-input-text
-				id="notification-email"
+				id="${elemId}"
 				label="${this.localize('hdrSubmissionNotificationEmail')}"
 				label-hidden
 				value="${assignment.notificationEmail}"
 				maxlength="1024"
 				?disabled="${!assignment.canEditNotificationEmail}"
 				@change="${this._onNotificationEmailChanged}"
-				@blur="${this._checkNotificationEmail}"
-				aria-invalid="${this._notificationEmailError ? 'true' : ''}"
+				@blur="${this.checkNotificationEmail}"
+				aria-invalid="${this.notificationEmailError ? 'true' : ''}"
 				skip-alert
 				novalidate
 			></d2l-input-text>
-			${this._getNotificationEmailTooltip()}
+			${this.getNotificationEmailTooltip(elemId)}
 		</div>
 	`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -9,9 +9,9 @@ import { bodyCompactStyles, bodySmallStyles, labelStyles } from '@brightspace-ui
 import { css, html } from 'lit-element/lit-element.js';
 import { accordionStyles } from '../styles/accordion-styles';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
+import { ActivityEditorNotificationEmailMixin } from '../mixins/d2l-activity-editor-notification-email-mixin.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
-import { ActivityEditorNotificationEmailMixin } from '../mixins/d2l-activity-editor-notification-email-mixin.js';
 import { radioStyles } from '@brightspace-ui/core/components/inputs/input-radio-styles.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -11,14 +11,14 @@ import { accordionStyles } from '../styles/accordion-styles';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
-import { NotificationEmailMixin } from '../notification-email-mixin.js';
+import { ActivityEditorNotificationEmailMixin } from '../mixins/d2l-activity-editor-notification-email-mixin.js';
 import { radioStyles } from '@brightspace-ui/core/components/inputs/input-radio-styles.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import { shared as store } from './state/assignment-store.js';
 
-class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(ActivityEditorFeaturesMixin(ActivityEditorMixin(NotificationEmailMixin(RtlMixin(LocalizeActivityAssignmentEditorMixin(MobxLitElement)))))) {
+class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(ActivityEditorFeaturesMixin(ActivityEditorMixin(ActivityEditorNotificationEmailMixin(RtlMixin(LocalizeActivityAssignmentEditorMixin(MobxLitElement)))))) {
 
 	static get properties() {
 

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
@@ -47,5 +47,4 @@ export default {
 	"assignmentLocked": "Some settings are locked because submissions have been received.",
 	"hdrSubmissionNotificationEmail": "Notification Email",
 	"hlpSubmissionNotificationEmail": "Enter an email or multiple emails separated by a comma, to receive notifications when an assignment is submitted.",
-	"invalidNotificationEmailError": "Please enter a valid email address"
 };

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-notification-email-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-notification-email-editor.js
@@ -1,21 +1,14 @@
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
-import { ErrorHandlingMixin } from '../error-handling-mixin.js';
 import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang-mixin';
 import { MobxLitElement } from '@adobe/lit-mobx';
+import { NotificationEmailMixin } from '../notification-email-mixin.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { shared as store } from './state/quiz-store';
 import '@brightspace-ui/core/components/inputs/input-text.js';
-import 'd2l-tooltip/d2l-tooltip';
 
 class ActivityQuizNotificationEmailEditor
-	extends ActivityEditorMixin(ErrorHandlingMixin(RtlMixin(LocalizeActivityQuizEditorMixin(MobxLitElement)))) {
-
-	static get properties() {
-		return {
-			_notificationEmailError: { type: String }
-		};
-	}
+	extends ActivityEditorMixin(NotificationEmailMixin(RtlMixin(LocalizeActivityQuizEditorMixin(MobxLitElement)))) {
 
 	static get styles() {
 		return [
@@ -42,49 +35,25 @@ class ActivityQuizNotificationEmailEditor
 			return html``;
 		}
 
+		const elemId = "quiz-notification-email";
+
 		return html`
 			<div>
 				<d2l-input-text
-					id="quiz-notification-email"
+					id="${elemId}"
 					label="${this.localize('emailNotificationDescription')}"
 					value="${entity.notificationEmail}"
 					maxlength="1024"
 					?disabled="${!entity.canEditNotificationEmail}"
 					@change="${this._onNotificationEmailChanged}"
-					@blur="${this._checkNotificationEmail}"
-					aria-invalid="${this._notificationEmailError ? 'true' : ''}"
+					@blur="${this.checkNotificationEmail}"
+					aria-invalid="${this.notificationEmailError ? 'true' : ''}"
 					skip-alert
 					novalidate>
 				</d2l-input-text>
-				${this._getNotificationEmailTooltip()}
+				${this.getNotificationEmailTooltip(elemId)}
 			</div>
 		`;
-	}
-
-	_checkNotificationEmail(e) {
-		const errorProperty = '_notificationEmailError';
-		const invalidNotificationEmailErrorLangterm = 'invalidNotificationEmailError';
-		const tooltipId = 'quiz-notification-email-tooltip';
-
-		const notificationEmail = e.target.value;
-		const isEmpty = (notificationEmail || '').length === 0;
-
-		const matches = /^(\s?[^\s,]+@[^\s,]+\.[^\s,]+\s?,)*(\s?[^\s,]+@[^\s,]+\.[^\s,]+)$/.exec(notificationEmail);
-		if (!isEmpty && matches === null) {
-			this.setError(errorProperty, invalidNotificationEmailErrorLangterm, tooltipId);
-		} else {
-			this.clearError(errorProperty);
-		}
-	}
-
-	_getNotificationEmailTooltip() {
-		if (this._notificationEmailError) {
-			return html`
-				<d2l-tooltip id="quiz-notification-email-tooltip" for="quiz-notification-email" state="error" align="start" offset="10">
-					${this._notificationEmailError}
-				</d2l-tooltip>
-			`;
-		}
 	}
 
 	_onNotificationEmailChanged(event) {

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-notification-email-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-notification-email-editor.js
@@ -1,15 +1,23 @@
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
+import { ErrorHandlingMixin } from '../error-handling-mixin.js';
 import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang-mixin';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { shared as store } from './state/quiz-store';
+import '@brightspace-ui/core/components/inputs/input-text.js';
+import 'd2l-tooltip/d2l-tooltip';
 
 class ActivityQuizNotificationEmailEditor
-	extends ActivityEditorMixin(RtlMixin(LocalizeActivityQuizEditorMixin(MobxLitElement))) {
+	extends ActivityEditorMixin(ErrorHandlingMixin(RtlMixin(LocalizeActivityQuizEditorMixin(MobxLitElement)))) {
+
+	static get properties() {
+		return {
+			_notificationEmailError: { type: String }
+		};
+	}
 
 	static get styles() {
-
 		return [
 			css`
 			:host {
@@ -35,16 +43,48 @@ class ActivityQuizNotificationEmailEditor
 		}
 
 		return html`
-			<d2l-input-text
-				label="${this.localize('emailNotificationDescription')}"
-				value="${entity.notificationEmail}"
-				maxlength="1024"
-				?disabled="${!entity.canEditNotificationEmail}"
-				@change="${this._onNotificationEmailChanged}"
-				skip-alert
-				novalidate>
-			</d2l-input-text>
+			<div>
+				<d2l-input-text
+					id="quiz-notification-email"
+					label="${this.localize('emailNotificationDescription')}"
+					value="${entity.notificationEmail}"
+					maxlength="1024"
+					?disabled="${!entity.canEditNotificationEmail}"
+					@change="${this._onNotificationEmailChanged}"
+					@blur="${this._checkNotificationEmail}"
+					aria-invalid="${this._notificationEmailError ? 'true' : ''}"
+					skip-alert
+					novalidate>
+				</d2l-input-text>
+				${this._getNotificationEmailTooltip()}
+			</div>
 		`;
+	}
+
+	_checkNotificationEmail(e) {
+		const errorProperty = '_notificationEmailError';
+		const invalidNotificationEmailErrorLangterm = 'invalidNotificationEmailError';
+		const tooltipId = 'quiz-notification-email-tooltip';
+
+		const notificationEmail = e.target.value;
+		const isEmpty = (notificationEmail || '').length === 0;
+
+		const matches = /^(\s?[^\s,]+@[^\s,]+\.[^\s,]+\s?,)*(\s?[^\s,]+@[^\s,]+\.[^\s,]+)$/.exec(notificationEmail);
+		if (!isEmpty && matches === null) {
+			this.setError(errorProperty, invalidNotificationEmailErrorLangterm, tooltipId);
+		} else {
+			this.clearError(errorProperty);
+		}
+	}
+
+	_getNotificationEmailTooltip() {
+		if (this._notificationEmailError) {
+			return html`
+				<d2l-tooltip id="quiz-notification-email-tooltip" for="quiz-notification-email" state="error" align="start" offset="10">
+					${this._notificationEmailError}
+				</d2l-tooltip>
+			`;
+		}
 	}
 
 	_onNotificationEmailChanged(event) {

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-notification-email-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-notification-email-editor.js
@@ -2,13 +2,13 @@ import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang-mixin';
 import { MobxLitElement } from '@adobe/lit-mobx';
-import { NotificationEmailMixin } from '../notification-email-mixin.js';
+import { ActivityEditorNotificationEmailMixin } from '../mixins/d2l-activity-editor-notification-email-mixin.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { shared as store } from './state/quiz-store';
 import '@brightspace-ui/core/components/inputs/input-text.js';
 
 class ActivityQuizNotificationEmailEditor
-	extends ActivityEditorMixin(NotificationEmailMixin(RtlMixin(LocalizeActivityQuizEditorMixin(MobxLitElement)))) {
+	extends ActivityEditorMixin(ActivityEditorNotificationEmailMixin(RtlMixin(LocalizeActivityQuizEditorMixin(MobxLitElement)))) {
 
 	static get styles() {
 		return [

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-notification-email-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-notification-email-editor.js
@@ -1,11 +1,11 @@
+import '@brightspace-ui/core/components/inputs/input-text.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
+import { ActivityEditorNotificationEmailMixin } from '../mixins/d2l-activity-editor-notification-email-mixin.js';
 import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang-mixin';
 import { MobxLitElement } from '@adobe/lit-mobx';
-import { ActivityEditorNotificationEmailMixin } from '../mixins/d2l-activity-editor-notification-email-mixin.js';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { shared as store } from './state/quiz-store';
-import '@brightspace-ui/core/components/inputs/input-text.js';
 
 class ActivityQuizNotificationEmailEditor
 	extends ActivityEditorMixin(ActivityEditorNotificationEmailMixin(RtlMixin(LocalizeActivityQuizEditorMixin(MobxLitElement)))) {
@@ -35,7 +35,7 @@ class ActivityQuizNotificationEmailEditor
 			return html``;
 		}
 
-		const elemId = "quiz-notification-email";
+		const elemId = 'quiz-notification-email';
 
 		return html`
 			<div>

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
@@ -15,6 +15,6 @@ export default {
 	"disableRightClickSummary": "Right clicks disabled", // summary text when right clicks are disabled
 	"disablePagerAndAlertsDescription": "Block alerts and communication during quiz attempts", // description for disable pager and alerts / block communications during a quiz
 	"disablePagerAndAlertsSummary": "Alerts and communication blocked", // summary text when pager and alerts / communications are disabled
-	"emailNotificationDescription": "Email Notification", // description for email notification
+	"emailNotificationDescription": "Notification Email", // description for notification email
 	"emailNotificationSummary": "Attempt notification by email", // summary for email notification
 };

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
@@ -17,4 +17,5 @@ export default {
 	"disablePagerAndAlertsSummary": "Alerts and communication blocked", // summary text when pager and alerts / communications are disabled
 	"emailNotificationDescription": "Email Notification", // description for email notification
 	"emailNotificationSummary": "Attempt notification by email", // summary for email notification
+	"invalidNotificationEmailError": "Please enter a valid email address", // error tooltip when email is invalid
 };

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
@@ -17,5 +17,4 @@ export default {
 	"disablePagerAndAlertsSummary": "Alerts and communication blocked", // summary text when pager and alerts / communications are disabled
 	"emailNotificationDescription": "Email Notification", // description for email notification
 	"emailNotificationSummary": "Attempt notification by email", // summary for email notification
-	"invalidNotificationEmailError": "Please enter a valid email address", // error tooltip when email is invalid
 };

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -74,6 +74,7 @@ export default {
 	"editor.discardChangesQuestion": "Are you sure you want to discard your changes?", // Discard Changes User Prompt
 	"editor.yesLabel": "Yes",
 	"editor.noLabel": "No",
+	"editor.invalidNotificationEmailError": "Please enter a valid email address", // error tooltip when email is invalid
 
 	"rubrics.btnAddRubric": "Add rubric", //text for add rubric button
 	"rubrics.btnCreateNew": "Create New", //Text for create new dropdown

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-notification-email-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-notification-email-mixin.js
@@ -1,9 +1,9 @@
-import { ErrorHandlingMixin } from './error-handling-mixin.js';
+import { ErrorHandlingMixin } from '../error-handling-mixin.js';
 import { html } from 'lit-element/lit-element.js';
-import { LocalizeActivityEditorMixin } from './mixins/d2l-activity-editor-lang-mixin.js';
+import { LocalizeActivityEditorMixin } from './d2l-activity-editor-lang-mixin.js';
 import 'd2l-tooltip/d2l-tooltip';
 
-export const NotificationEmailMixin = superclass => class extends ErrorHandlingMixin(LocalizeActivityEditorMixin(superclass)) {
+export const ActivityEditorNotificationEmailMixin = superclass => class extends ErrorHandlingMixin(LocalizeActivityEditorMixin(superclass)) {
 
     static get properties() {
 		return {

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-notification-email-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-notification-email-mixin.js
@@ -1,17 +1,17 @@
+import 'd2l-tooltip/d2l-tooltip';
 import { ErrorHandlingMixin } from '../error-handling-mixin.js';
 import { html } from 'lit-element/lit-element.js';
 import { LocalizeActivityEditorMixin } from './d2l-activity-editor-lang-mixin.js';
-import 'd2l-tooltip/d2l-tooltip';
 
 export const ActivityEditorNotificationEmailMixin = superclass => class extends ErrorHandlingMixin(LocalizeActivityEditorMixin(superclass)) {
 
-    static get properties() {
+	static get properties() {
 		return {
 			notificationEmailError: { type: String }
 		};
 	}
 
-    checkNotificationEmail(e) {
+	checkNotificationEmail(e) {
 		const errorProperty = 'notificationEmailError';
 		const invalidNotificationEmailErrorLangterm = 'editor.invalidNotificationEmailError';
 		const tooltipId = 'notification-email-tooltip';
@@ -35,5 +35,5 @@ export const ActivityEditorNotificationEmailMixin = superclass => class extends 
 				</d2l-tooltip>
 			`;
 		}
-    }
+	}
 };

--- a/components/d2l-activity-editor/notification-email-mixin.js
+++ b/components/d2l-activity-editor/notification-email-mixin.js
@@ -1,0 +1,39 @@
+import { ErrorHandlingMixin } from './error-handling-mixin.js';
+import { html } from 'lit-element/lit-element.js';
+import { LocalizeActivityEditorMixin } from './mixins/d2l-activity-editor-lang-mixin.js';
+import 'd2l-tooltip/d2l-tooltip';
+
+export const NotificationEmailMixin = superclass => class extends ErrorHandlingMixin(LocalizeActivityEditorMixin(superclass)) {
+
+    static get properties() {
+		return {
+			notificationEmailError: { type: String }
+		};
+	}
+
+    checkNotificationEmail(e) {
+		const errorProperty = 'notificationEmailError';
+		const invalidNotificationEmailErrorLangterm = 'editor.invalidNotificationEmailError';
+		const tooltipId = 'notification-email-tooltip';
+
+		const notificationEmail = e.target.value;
+		const isEmpty = (notificationEmail || '').length === 0;
+
+		const matches = /^(\s?[^\s,]+@[^\s,]+\.[^\s,]+\s?,)*(\s?[^\s,]+@[^\s,]+\.[^\s,]+)$/.exec(notificationEmail);
+		if (!isEmpty && matches === null) {
+			this.setError(errorProperty, invalidNotificationEmailErrorLangterm, tooltipId);
+		} else {
+			this.clearError(errorProperty);
+		}
+	}
+
+	getNotificationEmailTooltip(id) {
+		if (this.notificationEmailError) {
+			return html`
+				<d2l-tooltip id="notification-email-tooltip" for="${id}" state="error" align="start" offset="10">
+					${this.notificationEmailError}
+				</d2l-tooltip>
+			`;
+		}
+    }
+};


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F438838254780

Created a `d2l-activity-editor-notification-email-mixin` to handle some notification error duplication between the Assignments and Quizzing notification email fields.