### PR TITLE
Refactored shared checkbox styles

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-editor.js
@@ -1,5 +1,6 @@
-import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
+import { checkboxStyles } from '../styles/checkbox-styles.js';
+import { html } from 'lit-element/lit-element.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
@@ -13,25 +14,7 @@ class ActivityAssignmentAnnotationsEditor
 
 		return [
 			labelStyles,
-			css`
-			:host {
-				display: block;
-			}
-
-			:host([hidden]) {
-				display: none;
-			}
-
-			d2l-input-checkbox {
-				margin: 0;
-				padding-right: 1rem;
-			}
-
-			:host([dir="rtl"]) d2l-input-checkbox {
-				padding-left: 1rem;
-				padding-right: 0;
-			}
-			`
+			checkboxStyles
 		];
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-annotations-editor.js
@@ -1,6 +1,6 @@
+import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { checkboxStyles } from '../styles/checkbox-styles.js';
-import { html } from 'lit-element/lit-element.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
@@ -14,7 +14,12 @@ class ActivityAssignmentAnnotationsEditor
 
 		return [
 			labelStyles,
-			checkboxStyles
+			checkboxStyles,
+			css`
+				d2l-input-checkbox {
+					margin: 0;
+				}
+			`
 		];
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-anonymous-marking-editor.js
@@ -3,6 +3,7 @@ import 'd2l-inputs/d2l-input-checkbox-spacer.js';
 import { bodySmallStyles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
+import { checkboxStyles } from '@brightspace-ui/core/components/inputs/input-checkbox';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
@@ -16,26 +17,10 @@ class ActivityAssignmentAnonymousMarkingEditor
 		return [
 			bodySmallStyles,
 			labelStyles,
+			checkboxStyles,
 			css`
-			:host {
-				display: block;
-			}
-
-			:host([hidden]) {
-				display: none;
-			}
-
 			.d2l-body-small {
 				margin: 0 0 0.3rem 0;
-			}
-
-			d2l-input-checkbox {
-				padding-right: 1rem;
-			}
-
-			:host([dir="rtl"]) d2l-input-checkbox {
-				padding-left: 1rem;
-				padding-right: 0;
 			}
 
 			d2l-input-checkbox-spacer {

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-pager-and-alerts-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-pager-and-alerts-editor.js
@@ -1,5 +1,6 @@
-import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
+import { checkboxStyles } from '../styles/checkbox-styles.js';
+import { html } from 'lit-element/lit-element.js';
 import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang-mixin';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
@@ -10,26 +11,7 @@ class ActivityQuizDisablePagerAndAlertsEditor
 
 	static get styles() {
 
-		return [
-			css`
-			:host {
-				display: block;
-			}
-
-			:host([hidden]) {
-				display: none;
-			}
-
-			d2l-input-checkbox {
-				padding-right: 1rem;
-			}
-
-			:host([dir="rtl"]) d2l-input-checkbox {
-				padding-left: 1rem;
-				padding-right: 0;
-			}
-			`
-		];
+		return checkboxStyles;
 	}
 
 	constructor() {

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-right-click-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-right-click-editor.js
@@ -1,5 +1,6 @@
-import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
+import { checkboxStyles } from '../styles/checkbox-styles.js';
+import { html } from 'lit-element/lit-element.js';
 import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang-mixin';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
@@ -10,26 +11,7 @@ class ActivityQuizDisableRightClickEditor
 
 	static get styles() {
 
-		return [
-			css`
-			:host {
-				display: block;
-			}
-
-			:host([hidden]) {
-				display: none;
-			}
-
-			d2l-input-checkbox {
-				padding-right: 1rem;
-			}
-
-			:host([dir="rtl"]) d2l-input-checkbox {
-				padding-left: 1rem;
-				padding-right: 0;
-			}
-			`
-		];
+		return checkboxStyles;
 	}
 
 	constructor() {

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-hints-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-hints-editor.js
@@ -1,5 +1,6 @@
-import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
+import { checkboxStyles } from '../styles/checkbox-styles.js';
+import { html } from 'lit-element/lit-element.js';
 import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang-mixin';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
@@ -10,26 +11,7 @@ class ActivityQuizHintsEditor
 
 	static get styles() {
 
-		return [
-			css`
-			:host {
-				display: block;
-			}
-
-			:host([hidden]) {
-				display: none;
-			}
-
-			d2l-input-checkbox {
-				padding-right: 1rem;
-			}
-
-			:host([dir="rtl"]) d2l-input-checkbox {
-				padding-left: 1rem;
-				padding-right: 0;
-			}
-			`
-		];
+		return checkboxStyles;
 	}
 
 	constructor() {

--- a/components/d2l-activity-editor/styles/checkbox-styles.js
+++ b/components/d2l-activity-editor/styles/checkbox-styles.js
@@ -10,7 +10,6 @@ export const checkboxStyles = css`
 	}
 
 	d2l-input-checkbox {
-		margin: 0;
 		padding-right: 1rem;
 	}
 

--- a/components/d2l-activity-editor/styles/checkbox-styles.js
+++ b/components/d2l-activity-editor/styles/checkbox-styles.js
@@ -1,0 +1,21 @@
+import { css } from 'lit-element';
+
+export const checkboxStyles = css`
+	:host {
+		display: block;
+	}
+
+	:host([hidden]) {
+		display: none;
+	}
+
+	d2l-input-checkbox {
+		margin: 0;
+		padding-right: 1rem;
+	}
+
+	:host([dir="rtl"]) d2l-input-checkbox {
+		padding-left: 1rem;
+		padding-right: 0;
+	}
+`;


### PR DESCRIPTION
Clean up before adding another checkbox to quizzing.

Refactored shared checkbox styles following the pattern [documented by LitElement ](https://lit-element.polymer-project.org/guide/styles#sharing-styles). 