### PR TITLE
Switch test & release to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+on: pull_request
+jobs:
+  test:
+    name: Test
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Brightspace/third-party-actions@actions/checkout
+      - uses: Brightspace/third-party-actions@actions/setup-node
+      - name: Install dependencies
+        run: npm install
+      - name: Lint
+        run: npm run lint
+      - name: Unit Tests (Jest)
+        run: npm run test:js
+      - name: Unit Tests (Karma)
+        run: npm run test:karma
+      - name: Unit Tests (SauceLabs)
+        run: npm run test:polymer:sauce
+        env:
+          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY_DESIRE2LEARN }}
+          SAUCE_USERNAME: Desire2Learn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: pull_request
 jobs:
   test:
     name: Test
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: Brightspace/third-party-actions@actions/checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+on:
+  push:
+    branches:
+      - master
+      - '[0-9]+.x'
+      - '[0-9]+.[0-9]+.x'
+jobs:
+  release:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    name: Release
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: Brightspace/third-party-actions@actions/checkout
+        with:
+          persist-credentials: false
+      - name: Setup Node
+        uses: Brightspace/third-party-actions@actions/setup-node
+      - name: Install dependencies
+        run: npm install
+      - name: Semantic Release
+        uses: BrightspaceUI/actions/semantic-release@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,6 @@ install:
 - npm install
 jobs:
   include:
-  - stage: Code-tests
-    script:
-    - npm run lint
-    - |
-      if [ $TRAVIS_PULL_REQUEST != false ] && [ $TRAVIS_SECURE_ENV_VARS == true ]; then
-        echo "Pull request with secure environment variables, running Sauce tests...";
-        npm run test:polymer:sauce || travis_terminate 1;
-      else
-        echo "Not a pull request and/or no secure environment variables, running headless tests...";
-        npm run test:polymer:local || travis_terminate 1;
-      fi
-    - npm run test:js
-    - npm run test:karma
   - stage: Visual-difference-tests
     script:
     - |
@@ -29,21 +16,8 @@ jobs:
         echo "Running visual difference tests...";
         npm run test:diff || travis_terminate 1;
       fi
-  - stage: Update-version
-    script: frauci-update-version && export TRAVIS_TAG=$(frauci-get-version)
-deploy:
-  provider: releases
-  api_key: "$GITHUB_RELEASE_TOKEN"
-  on:
-    tags: true
 env:
   global:
-  - OWNER_NAME: Brightspacehypermediacomponents
-  - REPO_NAME: activities
-  - DEFAULT_INCREMENT: patch
-  - SAUCE_USERNAME: Desire2Learn
-  # SAUCE_ACCESS_KEY
-  - secure: uI1bP8ViYhpBhMczmiqmDowwG5cqmqL1xr+RGRwbqxQiTbnDcGI77H/DEnbuKDYcSMZ/a4qqwN1DMoUWmD+n23oxUKSDr6dR0tP/6++Y0wykPU+79UX4SdTM2UvW4arcsU9Yy7MG7H+HsM8IaHqDUw+V/hIThK0/axE9qEUZyb2s3IQSbt6sJxDvFDlyeqMny9VABlV/PIG4IPJ4PsWPjSVFGAWUPE+64h2STxvRixd8DI6n53PqGZEXl5huWgKosfnmXS+S37gjGJXJmZj/kCLvvAoQi3L6k/Hlf/8QwCdnHkCjN8In8I278S+zBGQsBMhxUVuTbbUbNuf71oKaYutF0uYMCH+CPb7LcNbpC9sDFdxZXCLyMVQOAw38473SVXui2INxzq4lGI5Pf4PGhqh3gacg5PLg4QjDyRbI8Qx9axzn5vaFotgvW0t3ZSynNfhxOnPhUs7nQoJjhcJPRRBzGI33XSQzwZGOBLUiXrwGTyKTy6hHjGYV+EolH08mtCzXfGBdvTXbOf3e0AwNm7s00CO6ablwvtdSzfRDnKX0A+rMlbcJZp+4gTiqZV/jLMXTUoyteeZ6hn2C04z7xh0BiytpcW+Nx1VkCVr6JukgtzzA5HQAMub7ofklGvkACYn/IWATPlItMgRFg1Wydy6d4n3qSts50Qmyhq1W1NM=
   # GITHUB_RELEASE_TOKEN (859f......865e)
   - secure: QP5YZ7oT1NAyyLDhNG/kHii+SasV5zR/9XO5ePl2ThAevdpEgrLLk1A76NV0XZMMSRIdvgzMZIvPqHWfA81I2O7QCzXOJKQ+xj8hanGqUUNlGxgDMo8FGmqf7OWyxw+XHoM5E0P20yntmDQnCsYnuPvTwYyZ/6ujQgTbPli2ewvoZL+Doh+RnOHmc7R8HbdpU2Cv42PIZr/H/nW6tpuliP1fNrMvKwzjbRu+zh/ag62CkPOk0jbu6klXTwdwytb0jseY7Y/ybJ/0kOZGmgCguH3Lb2kj4Uncp78aQiAZFyCIurb6iXVZ5K7YtABbpWj2sRtMkJwQedTSCUY7PI8FTuvNowZ9URmJ5d4FAAbo03D6jgur4SHxakyV+iQj5z0vfmw5bJT/ykJzXFgyRTkjy/zznZE3arDeyRiLPKGmlKSYDS51eXUhJ2yqgFtsw3ArCqIoIm3xxe9Qy2DNsJllf/SGIhcGhPXIlG4Mj/59OiqNVJuXORJkwuj4SNK4ujkTGkHWYgwGEglhF9nCSPBOrITaFtyfECNvHc9HM/SeYyaDjMqrvXnGusoU6BKhxqiwhb2LhqrK9SRq6ibeP9ykjvi3PkrmbyVHKTAzXHxKJ5uS1orwQ7oOnC4p751pjZB570wIg4ENUsPML/EwbtfsqWjCYnzGZqOgP8mYDXDprr8=
   # VISUAL_DIFF_S3_ID

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # d2l-activities
-[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=BrightspaceHypermediaComponents/activities)](https://dependabot.com)
-[![Build status](https://travis-ci.com/brightspaceHypermediaComponents/activities.svg?branch=master)](https://travis-ci.com/brightspaceHypermediaComponents/activities)
 
 Web components to be used with activities entities!
 
@@ -46,9 +44,6 @@ Quick Eval should be pulled directly from `my-unassessed-activities`:
 <d2l-quick-eval href="https://activities.[[apiUrl]]/my-unassessed-activities" token="token"></d2l-quick-eval>
 ```
 
-[ci-url]: https://travis-ci.org/BrightspaceUI/activities
-[ci-image]: https://travis-ci.org/BrightspaceUI/activities.svg?branch=master
-
 ### Visual Difference Testing
 
 In order to do visual difference testing, you must generate the "golden" images first, as the baseline to compare to.
@@ -74,8 +69,40 @@ The currently generated test images are stored at the following path: `\test\<co
 
 On a test failure, the difference between the goldens and the current images will be stored in the `current` directory with the `-diff` suffix before the file extension. Example: `d2l-quick-eval-search-results-summary-container-many-no-more-diff.png`.
 
-## Versioning, Releasing & Deploying
+## Versioning & Releasing
 
- By default, when a pull request is merged the patch version in the `package.json` will be incremented, a tag will be created, and a Github release will be created.
+> TL;DR: Commits prefixed with `fix:` and `feat:` will trigger patch and minor releases when merged to `master`. Read on for more details...
 
- Include `[increment major]`, `[increment minor]` or `[skip version]` in your merge commit message to change the default versioning behavior.
+The [sematic-release GitHub Action](https://github.com/BrightspaceUI/actions/tree/master/semantic-release) is called from the `release.yml` GitHub Action workflow to handle version changes and releasing.
+
+### Version Changes
+
+All version changes should obey [semantic versioning](https://semver.org/) rules:
+1. **MAJOR** version when you make incompatible API changes,
+2. **MINOR** version when you add functionality in a backwards compatible manner, and
+3. **PATCH** version when you make backwards compatible bug fixes.
+
+The next version number will be determined from the commit messages since the previous release. Our semantic-release configuration uses the [Angular convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular) when analyzing commits:
+* Commits which are prefixed with `fix:` or `perf:` will trigger a `patch` release. Example: `fix: validate input before using`
+* Commits which are prefixed with `feat:` will trigger a `minor` release. Example: `feat: add toggle() method`
+* To trigger a MAJOR release, include `BREAKING CHANGE:` with a space or two newlines in the footer of the commit message
+* Other suggested prefixes which will **NOT** trigger a release: `build:`, `ci:`, `docs:`, `style:`, `refactor:` and `test:`. Example: `docs: adding README for new component`
+
+To revert a change, add the `revert:` prefix to the original commit message. This will cause the reverted change to be omitted from the release notes. Example: `revert: fix: validate input before using`.
+
+### Releases
+
+When a release is triggered, it will:
+* Update the version in `package.json`
+* Tag the commit
+* Create a GitHub release (including release notes)
+
+### Releasing from Maintenance Branches
+
+Occasionally you'll want to backport a feature or bug fix to an older release. `semantic-release` refers to these as [maintenance branches](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#maintenance-branches).
+
+Maintenance branch names should be of the form: `+([0-9])?(.{+([0-9]),x}).x`.
+
+Regular expressions are complicated, but this essentially means branch names should look like:
+* `1.15.x` for patch releases on top of the `1.15` release (after version `1.16` exists)
+* `2.x` for feature releases on top of the `2` release (after version `3` exists)

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "gulp-rename": "^2.0.0",
     "jest": "^26.0.1",
     "karma": "^5.1.0",
-    "karma-sauce-launcher": "^4.1.5",
+    "karma-sauce-launcher": "^2",
     "lie": "^3.3.0",
     "mocha": "^7.1.0",
     "polymer-cli": "^1.9.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "eslint-plugin-html": "^6.0.0",
     "eslint-plugin-lit": "^1.2.0",
     "eslint-plugin-sort-class-members": "^1.6.0",
-    "frau-ci": "^1.40.0",
     "gulp": "^4.0.0",
     "gulp-cli": "^2.0.1",
     "gulp-ejs": "^5.1.0",

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -14,17 +14,17 @@
       "browsers": [
         {
           "browserName": "chrome",
-          "platform": "OS X 10.13",
+          "platform": "OS X 10.15",
           "version": ""
         },
         {
           "browserName": "firefox",
-          "platform": "OS X 10.13",
+          "platform": "OS X 10.15",
           "version": ""
         },
         {
           "browserName": "safari",
-          "platform": "OS X 10.13",
+          "platform": "OS X 10.15",
           "version": ""
         }
       ]


### PR DESCRIPTION
As discussed in Slack, this converts the Test & Release workflows from Travis CI -> GitHub Actions. @svanherk is still working on a visual-diff action, but I think this can run in hybrid mode (most things in GHAs, Visual Diff in Travis) temporarily. We shall see!

Look over the instructions in the README to make sure everything is clear. `semantic-release` is going to be a change from your current workflow where the patch version increases automatically each time you merge. You'll need to start including `feat: blah blah` or `fix: blah blah` in your commit messages or squash merge commits to trigger releases.

Also your workflow for release branches will need to change slightly as the branch names semantic-release uses need to be of the form `1.x` or `1.5.x` so keep that in mind.