### PR TITLE
US122707 Add quiz preview href

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
@@ -109,6 +109,7 @@ class QuizEditorDetail extends ActivityEditorMixin(AsyncContainerMixin(SkeletonM
 				<d2l-button-subtle
 					text=${this.localize('previewLabel')}
 					slot="action"
+					@click="${this._openPreview}"
 					icon="tier1:preview">
 				</d2l-button-subtle>
 			</d2l-activity-quiz-divider>
@@ -139,6 +140,15 @@ class QuizEditorDetail extends ActivityEditorMixin(AsyncContainerMixin(SkeletonM
 		}
 
 		await quiz.save();
+	}
+
+	_openPreview() {
+		const quiz = store.get(this.href);
+		if (!quiz || !quiz.previewHref) {
+			return;
+		}
+
+		window.open(quiz.previewHref);
 	}
 
 	async _setName(e) {

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz.js
@@ -31,7 +31,7 @@ export class Quiz {
 		this._entity = entity;
 		this.name = entity.name();
 		this.canEditName = entity.canEditName();
-		this.canEditShuffle =  entity.canEditShuffle();
+		this.canEditShuffle = entity.canEditShuffle();
 		this.isShuffleEnabled = entity.isShuffleEnabled();
 		this.canEditHints = entity.canEditHints();
 		this.hintsToolEnabled = entity.getHintsToolEnabled();
@@ -45,6 +45,7 @@ export class Quiz {
 		this.canEditPreventMovingBackwards = entity.canEditPreventMovingBackwards();
 		this.canEditNotificationEmail = entity.canEditNotificationEmail();
 		this.notificationEmail = entity.notificationEmail();
+		this.previewHref = entity.previewHref();
 	}
 
 	async save() {
@@ -133,6 +134,7 @@ decorate(Quiz, {
 	isPreventMovingBackwardsEnabled: observable,
 	canEditNotificationEmail: observable,
 	notificationEmail: observable,
+	previewHref: observable,
 	// actions
 	load: action,
 	setName: action,

--- a/test/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz.spec.js
@@ -37,7 +37,8 @@ describe('Quiz', function() {
 				canEditPreventMovingBackwards: () => true,
 				isPreventMovingBackwardsEnabled: () => false,
 				canEditNotificationEmail: () => true,
-				notificationEmail: () => 'hello@d2l.com'
+				notificationEmail: () => 'hello@d2l.com',
+				previewHref: () => 'http://test.desire2learn.d2l/d2l/lms/quizzing/user/quiz_summary.d2l?ou=6606&qi=46&isprv=1&fromQB=1&bp=1'
 			};
 		});
 
@@ -63,6 +64,7 @@ describe('Quiz', function() {
 		expect(QuizEntity.mock.calls[0][0]).to.equal(sirenEntity);
 		expect(QuizEntity.mock.calls[0][1]).to.equal('token');
 		expect(fetchEntity.mock.calls.length).to.equal(1);
+		expect(quiz.previewHref).to.equal('http://test.desire2learn.d2l/d2l/lms/quizzing/user/quiz_summary.d2l?ou=6606&qi=46&isprv=1&fromQB=1&bp=1');
 	});
 
 	it('setDisablePagerAndAlerts', async() => {


### PR DESCRIPTION
Part of https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F459179692392

For now it's assumed that users can always view a quiz preview...in future stories this will be restricted by permissions etc.

The siren-sdk PR that exposes preview href can be found [here](https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/238).