### PR TITLE
Fix: FACE Assignments - no help/info text below 'Individual Assignment'

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
@@ -70,11 +70,11 @@ class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 			return html``;
 		}
 
-		const isIndividualType = assignment.assignmentTypeProps.isIndividualAssignmentType;
 		const infoText = this._getInformationText(assignment);
+		const isIndividualType = assignment.assignmentTypeProps.isIndividualAssignmentType;
 		const canEditAssignmentType = assignment.assignmentTypeProps.canEditAssignmentType;
 		const groupTypeDisabled = assignment.assignmentTypeProps.isGroupAssignmentTypeDisabled;
-		const folderTypeText =	isIndividualType ? this.localize('txtIndividual') : this.localize('txtGroup');
+		const folderTypeText = isIndividualType ? this.localize('txtIndividual') : this.localize('txtGroup');
 		const groupTypeText = !isIndividualType && assignment.assignmentTypeProps.selectedGroupCategoryName
 			? this.localize('txtGroupCategoryWithName', 'groupCategory', assignment.assignmentTypeProps.selectedGroupCategoryName)
 			: '';

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
@@ -82,7 +82,7 @@ class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 		return html`
 			<div ?hidden=${canEditAssignmentType} id="read-only-assignment-type-container">
 				<div class="d2l-body-compact">${folderTypeText}</div>
-				<p slot="description" class="d2l-info-text-flush-left d2l-body-small">${infoText}</p>
+				<p class="d2l-info-text-flush-left d2l-body-small">${infoText}</p>
 				<div class="d2l-body-compact">${groupTypeText}</div>
 			</div>
 

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
@@ -45,7 +45,7 @@ class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 
 				.d2l-info-text {
 					margin: 0.1rem 0 0 0;
-					padding-left: 1.7rem;
+					padding-left: 1.8rem;
 				}
 
 				.d2l-info-text-flush-left {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
@@ -145,14 +145,18 @@ class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 			return;
 		}
 
+		const canEditAssignmentType = assignment.assignmentTypeProps.canEditAssignmentType;
 		const isIndividualAssignmentType = assignment.assignmentTypeProps.isIndividualAssignmentType;
 		const hasSubmissions = assignment.submissionAndCompletionProps.assignmentHasSubmissions;
+		const groupTypeDisabled = assignment.assignmentTypeProps.isGroupAssignmentTypeDisabled;
 
-		if (!hasSubmissions &&  isIndividualAssignmentType && assignment.assignmentTypeProps.groupCategories.length === 0) {
+		if (hasSubmissions) return; // don't display either of the information texts about groups
+
+		if (isIndividualAssignmentType && groupTypeDisabled && assignment.assignmentTypeProps.groupCategories.length === 0) {
 			return this.localize('folderTypeNoGroups'); // this only displays below the 'Individual Assignment' text
 		}
 
-		if (!hasSubmissions && !isIndividualAssignmentType) {
+		if (!isIndividualAssignmentType && canEditAssignmentType) {
 			return this.localize('folderTypeCreateGroups'); // this only displays below the 'Group Assignment' text
 		}
 

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-type-editor.js
@@ -48,6 +48,10 @@ class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 					padding-left: 1.7rem;
 				}
 
+				.d2l-info-text-flush-left {
+					margin: 0.5rem 0 0 0;
+				}
+
 				.d2l-individual-type {
 					margin: 0 0 0.5rem 0;
 				}
@@ -78,6 +82,7 @@ class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 		return html`
 			<div ?hidden=${canEditAssignmentType} id="read-only-assignment-type-container">
 				<div class="d2l-body-compact">${folderTypeText}</div>
+				<p slot="description" class="d2l-info-text-flush-left d2l-body-small">${infoText}</p>
 				<div class="d2l-body-compact">${groupTypeText}</div>
 			</div>
 
@@ -143,12 +148,12 @@ class AssignmentTypeEditor extends ActivityEditorMixin(RtlMixin(LocalizeActivity
 		const isIndividualAssignmentType = assignment.assignmentTypeProps.isIndividualAssignmentType;
 		const hasSubmissions = assignment.submissionAndCompletionProps.assignmentHasSubmissions;
 
-		if (!hasSubmissions && isIndividualAssignmentType && assignment.assignmentTypeProps.groupCategories.length === 0) {
-			return this.localize('folderTypeNoGroups');
+		if (!hasSubmissions &&  isIndividualAssignmentType && assignment.assignmentTypeProps.groupCategories.length === 0) {
+			return this.localize('folderTypeNoGroups'); // this only displays below the 'Individual Assignment' text
 		}
 
 		if (!hasSubmissions && !isIndividualAssignmentType) {
-			return this.localize('folderTypeCreateGroups');
+			return this.localize('folderTypeCreateGroups'); // this only displays below the 'Group Assignment' text
 		}
 
 		return;


### PR DESCRIPTION
https://trello.com/c/0kvcVuBm/3-course-with-no-groups-missing-no-groups-exist-create-new-groups-in-the-groups-tool-under-assignment-type

Should always show `No groups exist. Create new groups in the Groups tool.`, unless Groups exist.

Also nudged the `Create new groups in the Groups tool` to align with the Group Category dropdown selector.

![image](https://user-images.githubusercontent.com/15062048/100946247-d01aaa00-34b7-11eb-812c-78a3294cdc8e.png)
