### PR TITLE
Us122707/add preview quiz permissions

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
@@ -75,6 +75,7 @@ class QuizEditorDetail extends ActivityEditorMixin(AsyncContainerMixin(SkeletonM
 		const {
 			name,
 			canEditName,
+			canPreviewQuiz
 		} = quiz || {};
 
 		return html`
@@ -110,6 +111,7 @@ class QuizEditorDetail extends ActivityEditorMixin(AsyncContainerMixin(SkeletonM
 					text=${this.localize('previewLabel')}
 					slot="action"
 					@click="${this._openPreview}"
+					?disabled="${!canPreviewQuiz}"
 					icon="tier1:preview">
 				</d2l-button-subtle>
 			</d2l-activity-quiz-divider>

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz.js
@@ -46,6 +46,7 @@ export class Quiz {
 		this.canEditNotificationEmail = entity.canEditNotificationEmail();
 		this.notificationEmail = entity.notificationEmail();
 		this.previewHref = entity.previewHref();
+		this.canPreviewQuiz = entity.canPreviewQuiz();
 	}
 
 	async save() {
@@ -135,6 +136,7 @@ decorate(Quiz, {
 	canEditNotificationEmail: observable,
 	notificationEmail: observable,
 	previewHref: observable,
+	canPreviewQuiz: observable,
 	// actions
 	load: action,
 	setName: action,

--- a/test/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz.spec.js
@@ -38,7 +38,8 @@ describe('Quiz', function() {
 				notificationEmail: () => 'hello@d2l.com',
 				previewHref: () => 'http://test.desire2learn.d2l/d2l/lms/quizzing/user/quiz_summary.d2l?ou=6606&qi=46&isprv=1&fromQB=1&bp=1',
 				canEditPassword: () => true,
-				password: () => 'hello'
+				password: () => 'hello',
+				canPreviewQuiz: () => true
 			};
 		});
 
@@ -67,6 +68,8 @@ describe('Quiz', function() {
 		expect(QuizEntity.mock.calls[0][1]).to.equal('token');
 		expect(fetchEntity.mock.calls.length).to.equal(1);
 		expect(quiz.previewHref).to.equal('http://test.desire2learn.d2l/d2l/lms/quizzing/user/quiz_summary.d2l?ou=6606&qi=46&isprv=1&fromQB=1&bp=1');
+		expect(quiz.canPreviewQuiz).to.equal(true);
+
 	});
 
 	it('setName', async() => {


### PR DESCRIPTION
Disabling preview quiz button based on whether or not a user has required permissions. Part of https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F459179692392

Siren-sdk PR which exposes this can be viewed [here](https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/239).