### PR TITLE
Dispatching async event when loading alignments

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -129,6 +129,7 @@ class AssignmentEditorDetail extends AsyncContainerMixin(SkeletonMixin(SaveStatu
 								and so it cannot be plugged into Dropbox to check Assignment permissions.
 				*/ html`
 					<d2l-activity-outcomes
+						?hidden="${this.skeleton}"
 						class="d2l-editor-layout-section"
 						href="${this.activityUsageHref}"
 						.token="${this.token}"

--- a/components/d2l-activity-editor/d2l-activity-outcomes.js
+++ b/components/d2l-activity-editor/d2l-activity-outcomes.js
@@ -4,6 +4,7 @@ import 'd2l-activity-alignments/d2l-select-outcomes-hierarchical.js';
 import { ActivityEditorFeaturesMixin, Milestones } from './mixins/d2l-activity-editor-features-mixin.js';
 import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
+import { AsyncStateEvent } from '@brightspace-ui/core/helpers/asyncStateEvent';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
@@ -47,6 +48,7 @@ class ActivityOutcomes extends ActivityEditorFeaturesMixin(ActivityEditorMixin(R
 		this._featureEnabled = this._isMilestoneEnabled(Milestones.M3Outcomes);
 		this._browseOutcomesText = this._dispatchRequestProvider('d2l-provider-browse-outcomes-text');
 		this._outcomesTerm = this._dispatchRequestProvider('d2l-provider-outcomes-term');
+		this._loadingAlignments = this._dispatchLoadingAlignments();
 	}
 
 	render() {
@@ -86,12 +88,28 @@ class ActivityOutcomes extends ActivityEditorFeaturesMixin(ActivityEditorMixin(R
 		`;
 	}
 	_alignmentTagsEmptyChanged(e) {
+		this._loadingAlignments.resolve();
 		this._hasAlignments = !!(e.detail.entities && e.detail.entities.length);
 		this.requestUpdate();
 	}
 	_closeDialog() {
 		this._opened = false;
 	}
+
+	_dispatchLoadingAlignments() {
+		let res;
+
+		const promise = new Promise(resolve => res = resolve);
+		promise.resolve = res;
+
+		const event = new AsyncStateEvent(promise);
+		this.dispatchEvent(event);
+
+		return promise;
+
+		// dispatches an async event which can be resolved when alignments have finished loading
+	}
+
 	_dispatchRequestProvider(key) {
 		const event = new CustomEvent('d2l-request-provider', {
 			detail: { key: key },

--- a/components/d2l-activity-editor/d2l-activity-outcomes.js
+++ b/components/d2l-activity-editor/d2l-activity-outcomes.js
@@ -54,7 +54,6 @@ class ActivityOutcomes extends ActivityEditorFeaturesMixin(ActivityEditorMixin(R
 	render() {
 		const activity = store.get(this.href);
 		if (!activity || !this._featureEnabled) {
-			this.hidden = true;
 			return html``;
 		}
 
@@ -62,12 +61,6 @@ class ActivityOutcomes extends ActivityEditorFeaturesMixin(ActivityEditorMixin(R
 			canUpdateAlignments,
 			alignmentsHref
 		} = activity;
-
-		if (!canUpdateAlignments && !this._hasAlignments || this._hasAlignments === undefined) {
-			this.hidden = true;
-		} else {
-			this.hidden = false;
-		}
 
 		return html`
 			${this._renderTags()}


### PR DESCRIPTION
Based on [this trello card](https://trello.com/c/Yx8JT17F/7-face-standards-link-has-an-extra-delay-in-showing-up-exceeding-testcafe-timeout).

This PR is designed to address the skeleton loading of standards and ensure we the assignment detail component stays in "skeleton mode" until alignments have finished loading.

This is accomplished by dispatching a 'pending' event which is handled by the `asyncContainerMixin` so that the detail component knows to continue displaying the skeleton view.

After a discussion with @emil-furniss we also thought that it made sense for `d2l-activity-assignment-editor-detail` to control the hidden state of `d2l-activity-outcomes` and have that based on the skeleton state rather than `d2l-activity-outcomes` trying to manage it's own hidden state internally. I've added those changes here as well.