### PR TITLE
add hidden span for name column

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-submissions-table.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions-table.js
@@ -170,6 +170,7 @@ class D2LQuickEvalSubmissionsTable extends QuickEvalLogging(QuickEvalLocalize(Po
 													aria-label$="[[_localizeSortText(header.key)]]"
 													aria-live="assertive"
 												>
+													<span hidden="true" aria-hidden="[[!header.nameColumn]]">[[_localizeSortText(header.key)]]</span>
 													<span aria-hidden="true">[[localize(header.key)]]</span>
 												</d2l-table-col-sort-button>
 												<template is="dom-if" if="[[header.suffix]]">

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -562,8 +562,8 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 			key: 'displayName',
 			meta: { firstThenLast: true },
 			headers: [
-				{ key: 'firstName', sortClass: 'first-name', suffix: ',', canSort: false, sorted: false, desc: false },
-				{ key: 'lastName', sortClass: 'last-name', canSort: false, sorted: false, desc: false }
+				{ key: 'firstName', sortClass: 'first-name', suffix: ',', canSort: false, sorted: false, desc: false, nameColumn: true },
+				{ key: 'lastName', sortClass: 'last-name', canSort: false, sorted: false, desc: false, nameColumn: true }
 			],
 			type: 'user',
 			widthOverride: masterTeacher ? 25 : 30


### PR DESCRIPTION
[DE36105](https://rally1.rallydev.com/#/detail/defect/336288465200?fdp=true): A11y - Quick Eval Submissions Table - Screen reader is not reading out the header names when more than one sortable object in the header (e.g. First name, Last name)