### PR TITLE
Fix audio and video attachments not attaching

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -79,7 +79,7 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(SkeletonMixin(Locali
 	}
 
 	async _handlerAudioUploaded(e) {
-		const file = e.detail.file;
+		const file = e.detail.files[0];
 
 		const fileId = file.GetId();
 		const fileName = file.GetName();
@@ -121,7 +121,7 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(SkeletonMixin(Locali
 	}
 
 	async _handlerVideoUploaded(e) {
-		const file = e.detail.file;
+		const file = e.detail.files[0];
 
 		const fileId = file.GetId();
 		const fileName = file.GetName();


### PR DESCRIPTION
See: https://trello.com/c/9r5lB48J/274-face-assignments-audio-video-fails-to-attach
> I think it's because this is storing the file in an array in `files`
https://github.com/BrightspaceHypermediaComponents/activities/pull/1205/files#diff-bfdd45cba209e9d6b9a6c4035f88d0893b72255673353a34b4fd39f33d3cd951R131
and this is looking for it in
`e.detail.file` https://github.com/BrightspaceHypermediaComponents/activities/pull/1205/files#diff-8fb51195a645ae0ccaf34162ad052073e0ab93377c35b6b42001687672f2228aR82
It needs to be `const file = e.detail.files[0]`
Same for video
The change was merged in December, so the defect will appear in 20.21.1 builds, but not 20.20.12

![image](https://user-images.githubusercontent.com/8463897/101696824-8d168480-3a2b-11eb-9d91-9a91dbbced42.png)
