### PR TITLE
Us123065/add quizzing question mark dialog

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
@@ -20,7 +20,7 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 		return {
 			href: { type: String },
 			token: { type: Object },
-			_isDialogOpen: { type: Boolean }
+			_opened: { type: Boolean }
 		};
 	}
 
@@ -35,7 +35,7 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 
 	constructor() {
 		super();
-		this._isDialogOpen = false;
+		this._opened = false;
 	}
 
 	render() {
@@ -67,6 +67,14 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 		return false; // Todo: implement error handling
 	}
 
+	_handleClose() {
+		this._opened = false;
+	}
+
+	_open() {
+		this._opened = true;
+	}
+
 	_renderAutomaticGradesEditor() {
 		return html`
 			<d2l-activity-quiz-auto-set-graded-editor
@@ -88,7 +96,7 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 					<d2l-button-icon
 						text="${this.localize('autoSetGradedAccessibleHelpText')}"
 						icon="tier1:help"
-						@click="${this._setIsDialogOpen}">
+						@click="${this._open}">
 					</d2l-button-icon>
 				</span>
 			</div>
@@ -105,8 +113,8 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 	_renderDialog() {
 		return html`
 			<d2l-dialog
-				?opened="${this._isDialogOpen}"
-				@d2l-dialog-close="${this._setClosed}"
+				?opened="${this._opened}"
+				@d2l-dialog-close="${this._handleClose}"
 				title-text="${this.localize('autoSetGradedHelpDialogTitle')}">
 					<div>
 						<p>${this.localize('autoSetGradedHelpDialogParagraph1')}</p>
@@ -121,12 +129,6 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 					</d2l-button>
 			</d2l-dialog>
 		`;
-	}
-
-	_setIsDialogOpen(e) {
-		const isDialogOpen = e.target && e.target.type && e.target.type !== 'd2l-dialog-close';
-
-		this._isDialogOpen = isDialogOpen;
 	}
 
 }

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
@@ -1,6 +1,8 @@
 import '../d2l-activity-accordion-collapse.js';
 import './d2l-activity-quiz-auto-set-graded-editor.js';
 import './d2l-activity-quiz-auto-set-graded-summary.js';
+import '@brightspace-ui/core/components/button/button-icon.js';
+import '@brightspace-ui/core/components/dialog/dialog.js';
 import { accordionStyles } from '../styles/accordion-styles';
 import { ActivityEditorFeaturesMixin } from '../mixins/d2l-activity-editor-features-mixin.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
@@ -17,7 +19,8 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 
 		return {
 			href: { type: String },
-			token: { type: Object }
+			token: { type: Object },
+			isDialogOpen: { type: Boolean }
 		};
 	}
 
@@ -27,8 +30,12 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 			super.styles,
 			accordionStyles,
 			labelStyles,
-
 		];
+	}
+
+	constructor() {
+		super();
+		this.isDialogOpen = false;
 	}
 
 	connectedCallback() {
@@ -50,15 +57,15 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 				<li slot="summary-items">${this._renderAutoSetGradedSummary()}</li>
 
 				<div class="d2l-editors" slot="components">
-					<label class="d2l-label-text">
-						${this.localize('subHdrAutomaticGrades')}
-					</label>
+					${this._renderAutoSetGradedSubHeader()}
 					${this._renderAutomaticGradesEditor()}
 				</div>
-
 			</d2l-activity-accordion-collapse>
+
+			${this._renderDialog()}
 		`;
 	}
+
 	// Returns true if any error states relevant to this accordion are set
 	_errorInAccordion() {
 		return false; // Todo: implement error handling
@@ -66,13 +73,31 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 
 	_renderAutomaticGradesEditor() {
 		return html`
-		<d2l-activity-quiz-auto-set-graded-editor
-			href="${this.href}"
-			.token="${this.token}">
-		</d2l-activity-quiz-auto-set-graded-editor>
+			<d2l-activity-quiz-auto-set-graded-editor
+				href="${this.href}"
+				.token="${this.token}">
+			</d2l-activity-quiz-auto-set-graded-editor>
 	`;
 	}
 
+	_renderAutoSetGradedSubHeader() {
+		return html`
+			<div>
+				<span>
+					<label class="d2l-label-text">
+						${this.localize('subHdrAutomaticGrades')}
+					</label>
+				</span>
+				<span>
+					<d2l-button-icon
+						text="${this.localize('autoSetGradedAccessibleHelpText')}"
+						icon="tier1:help"
+						@click="${this._setIsDialogOpen}">
+					</d2l-button-icon>
+				</span>
+			</div>
+		`;
+	}
 	_renderAutoSetGradedSummary() {
 		return html`
 			<d2l-activity-quiz-auto-set-graded-summary
@@ -81,6 +106,36 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 			</d2l-activity-quiz-auto-set-graded-summary>
 		`;
 	}
+	_renderDialog() {
+		return html`
+			<d2l-dialog
+				?opened="${this.isDialogOpen}"
+				@d2l-dialog-close="${this._setClosed}"
+				title-text="${this.localize('autoSetGradedHelpDialogTitle')}">
+					<div>
+						<p>${this.localize('autoSetGradedHelpDialogParagraph1')}</p>
+						<p>${this.localize('autoSetGradedHelpDialogParagraph2')}</p>
+						<p>${this.localize('autoSetGradedHelpDialogParagraph3')}</p>
+					</div>
+					<d2l-button
+						data-dialog-action="done"
+						slot="footer"
+						primary>
+						${this.localize('autoSetGradedHelpDialogConfirmationText')}
+					</d2l-button>
+			</d2l-dialog>
+		`;
+	}
+
+	_setClosed() {
+		this.isDialogOpen = false;
+	}
+	_setIsDialogOpen(e) {
+		const isDialogOpen = e.target && e.target.type && e.target.type !== 'd2l-dialog-close';
+
+		this.isDialogOpen = isDialogOpen;
+	}
+
 }
 
 customElements.define(

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
@@ -3,12 +3,12 @@ import './d2l-activity-quiz-auto-set-graded-editor.js';
 import './d2l-activity-quiz-auto-set-graded-summary.js';
 import '@brightspace-ui/core/components/button/button-icon.js';
 import '@brightspace-ui/core/components/dialog/dialog.js';
+import { css, html } from 'lit-element/lit-element.js';
 import { accordionStyles } from '../styles/accordion-styles';
 import { ActivityEditorFeaturesMixin } from '../mixins/d2l-activity-editor-features-mixin.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { AsyncContainerMixin } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
-import { html } from 'lit-element/lit-element.js';
-import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
+import { heading4Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang-mixin';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
@@ -29,7 +29,12 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 		return [
 			super.styles,
 			accordionStyles,
-			labelStyles,
+			heading4Styles,
+			css`
+				.d2l-heading-4 {
+					display: inline;
+				}
+			`
 		];
 	}
 
@@ -88,9 +93,9 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 		return html`
 			<div>
 				<span>
-					<label class="d2l-label-text">
+					<h3 class="d2l-heading-4">
 						${this.localize('subHdrAutomaticGrades')}
-					</label>
+					</h3>
 				</span>
 				<span>
 					<d2l-button-icon

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
@@ -38,10 +38,6 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 		this._isDialogOpen = false;
 	}
 
-	connectedCallback() {
-		super.connectedCallback();
-	}
-
 	render() {
 		return html`
 			<d2l-activity-accordion-collapse

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
@@ -127,9 +127,6 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 		`;
 	}
 
-	_setClosed() {
-		this.isDialogOpen = false;
-	}
 	_setIsDialogOpen(e) {
 		const isDialogOpen = e.target && e.target.type && e.target.type !== 'd2l-dialog-close';
 

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
@@ -20,7 +20,7 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 		return {
 			href: { type: String },
 			token: { type: Object },
-			isDialogOpen: { type: Boolean }
+			_isDialogOpen: { type: Boolean }
 		};
 	}
 
@@ -35,7 +35,7 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 
 	constructor() {
 		super();
-		this.isDialogOpen = false;
+		this._isDialogOpen = false;
 	}
 
 	connectedCallback() {
@@ -109,7 +109,7 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 	_renderDialog() {
 		return html`
 			<d2l-dialog
-				?opened="${this.isDialogOpen}"
+				?opened="${this._isDialogOpen}"
 				@d2l-dialog-close="${this._setClosed}"
 				title-text="${this.localize('autoSetGradedHelpDialogTitle')}">
 					<div>
@@ -130,7 +130,7 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 	_setIsDialogOpen(e) {
 		const isDialogOpen = e.target && e.target.type && e.target.type !== 'd2l-dialog-close';
 
-		this.isDialogOpen = isDialogOpen;
+		this._isDialogOpen = isDialogOpen;
 	}
 
 }

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
@@ -30,5 +30,12 @@ export default {
 	"subHdrAutomaticGrades": "Automatic Grade", // Title for automatic grade tool
 	"autoSetGradedDescription": "Allow attempt to be set as graded immediately upon completion", // description for automatic grade checkbox
 	"autoSetGradedSummary": "Automatically grade", // summary for auto set graded checkbox
-	"passwordDescription": "Only users who enter this password will be granted access to write this quiz."
+	"passwordDescription": "Only users who enter this password will be granted access to write this quiz.", // description for password input
+	"autoSetGradedAccessibleHelpText": "Information: Automatic Grade", // accessible help text for autoSetGraded question mark button
+	"autoSetGradedHelpDialogTitle": "Information: Automatic Grade", // title that appears when the autoSetGraded help dialog is rendered
+	"autoSetGradedHelpDialogConfirmationText": "OK", // title that appears on the autoSetGraded help dialog confirmation button
+	"autoSetGradedHelpDialogParagraph1": "When this setting is turned on users can see their score as soon as they submit their attempt. The score displayed is only what the system can auto-grade.", // content for paragraph 1 of autoSetGraded help dialog
+	"autoSetGradedHelpDialogParagraph2": "This setting must be turned on for grades to be automatically sent to the grade book, and for the default submission view to be released to users when they complete an attempt.", // content for paragraph 2 of autoSetGraded help dialog
+	"autoSetGradedHelpDialogParagraph3": "Note: Written Response questions will be marked as 0 until manually graded.", // content for paragraph 3 of autoSetGraded help dialog
+
 };


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F461235145752

Added a `d2l-dialog` component which opens upon clicking the help/question mark button beside the sub header in the automatic grade editor.

![image](https://user-images.githubusercontent.com/46040098/101705557-061dd800-3a3c-11eb-96a1-7dbf2d4287b3.png)
