### PR TITLE
Added poc mixin to handle dialog state

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
@@ -38,11 +38,6 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 		];
 	}
 
-	constructor() {
-		super();
-		this._opened = false;
-	}
-
 	render() {
 		return html`
 			<d2l-activity-accordion-collapse
@@ -93,7 +88,7 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 					<d2l-button-icon
 						text="${this.localize('autoSetGradedAccessibleHelpText')}"
 						icon="tier1:help"
-						@click="${this._open}">
+						@click="${this.open}">
 					</d2l-button-icon>
 				</span>
 			</div>
@@ -110,8 +105,8 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 	_renderDialog() {
 		return html`
 			<d2l-dialog
-				?opened="${this._opened}"
-				@d2l-dialog-close="${this._handleClose}"
+				?opened="${this.opened}"
+				@d2l-dialog-close="${this.handleClose}"
 				title-text="${this.localize('autoSetGradedHelpDialogTitle')}">
 					<div>
 						<p>${this.localize('autoSetGradedHelpDialogParagraph1')}</p>

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
@@ -5,6 +5,7 @@ import '@brightspace-ui/core/components/button/button-icon.js';
 import '@brightspace-ui/core/components/dialog/dialog.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { accordionStyles } from '../styles/accordion-styles';
+import { ActivityEditorDialogMixin } from '../mixins/d2l-activity-editor-dialog-mixin';
 import { ActivityEditorFeaturesMixin } from '../mixins/d2l-activity-editor-features-mixin.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { AsyncContainerMixin } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
@@ -13,14 +14,13 @@ import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
-class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(LocalizeActivityQuizEditorMixin(SkeletonMixin(ActivityEditorFeaturesMixin(ActivityEditorMixin(MobxLitElement))))) {
+class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(LocalizeActivityQuizEditorMixin(SkeletonMixin(ActivityEditorFeaturesMixin(ActivityEditorMixin(ActivityEditorDialogMixin(MobxLitElement)))))) {
 
 	static get properties() {
 
 		return {
 			href: { type: String },
 			token: { type: Object },
-			_opened: { type: Boolean }
 		};
 	}
 
@@ -70,14 +70,6 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 	// Returns true if any error states relevant to this accordion are set
 	_errorInAccordion() {
 		return false; // Todo: implement error handling
-	}
-
-	_handleClose() {
-		this._opened = false;
-	}
-
-	_open() {
-		this._opened = true;
 	}
 
 	_renderAutomaticGradesEditor() {

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.js
@@ -2,20 +2,20 @@ export const ActivityEditorDialogMixin = superclass => class extends superclass 
 
 	static get properties() {
 		return {
-			_opened: { type: Boolean }
+			opened: { type: Boolean }
 		};
 	}
 
 	constructor() {
 		super();
-		this._opened = false;
+		this.opened = false;
 	}
 
-	_handleClose() {
-		this._opened = false;
+	handleClose() {
+		this.opened = false;
 	}
 
-	_open() {
-		this._opened = true;
+	open() {
+		this.opened = true;
 	}
 };

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.js
@@ -1,0 +1,21 @@
+export const ActivityEditorDialogMixin = superclass => class extends superclass {
+
+	static get properties() {
+		return {
+			_opened: { type: Boolean }
+		};
+	}
+
+	constructor() {
+		super();
+		this._opened = false;
+	}
+
+	_handleClose() {
+		this._opened = false;
+	}
+
+	_open() {
+		this._opened = true;
+	}
+};


### PR DESCRIPTION
An idea for a mixin which can clean up some of the logic regarding opening/closing dialogs. The idea is to prevent us from having to implement logic to manage the open/closed state of the dialog in each component that uses it and instead inherit that behavior from a shared mixin. 