### PR TITLE
Us123063/refactor dialog open state

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
@@ -5,6 +5,7 @@ import '@brightspace-ui/core/components/button/button-icon.js';
 import '@brightspace-ui/core/components/dialog/dialog.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { accordionStyles } from '../styles/accordion-styles';
+import { ActivityEditorDialogMixin } from '../mixins/d2l-activity-editor-dialog-mixin';
 import { ActivityEditorFeaturesMixin } from '../mixins/d2l-activity-editor-features-mixin.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { AsyncContainerMixin } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
@@ -13,14 +14,13 @@ import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
-class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(LocalizeActivityQuizEditorMixin(SkeletonMixin(ActivityEditorFeaturesMixin(ActivityEditorMixin(MobxLitElement))))) {
+class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(LocalizeActivityQuizEditorMixin(SkeletonMixin(ActivityEditorFeaturesMixin(ActivityEditorMixin(ActivityEditorDialogMixin(MobxLitElement)))))) {
 
 	static get properties() {
 
 		return {
 			href: { type: String },
 			token: { type: Object },
-			_opened: { type: Boolean }
 		};
 	}
 
@@ -36,11 +36,6 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 				}
 			`
 		];
-	}
-
-	constructor() {
-		super();
-		this._opened = false;
 	}
 
 	render() {
@@ -72,14 +67,6 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 		return false; // Todo: implement error handling
 	}
 
-	_handleClose() {
-		this._opened = false;
-	}
-
-	_open() {
-		this._opened = true;
-	}
-
 	_renderAutomaticGradesEditor() {
 		return html`
 			<d2l-activity-quiz-auto-set-graded-editor
@@ -101,7 +88,7 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 					<d2l-button-icon
 						text="${this.localize('autoSetGradedAccessibleHelpText')}"
 						icon="tier1:help"
-						@click="${this._open}">
+						@click="${this.open}">
 					</d2l-button-icon>
 				</span>
 			</div>
@@ -118,8 +105,8 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 	_renderDialog() {
 		return html`
 			<d2l-dialog
-				?opened="${this._opened}"
-				@d2l-dialog-close="${this._handleClose}"
+				?opened="${this.opened}"
+				@d2l-dialog-close="${this.handleClose}"
 				title-text="${this.localize('autoSetGradedHelpDialogTitle')}">
 					<div>
 						<p>${this.localize('autoSetGradedHelpDialogParagraph1')}</p>

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.js
@@ -1,0 +1,21 @@
+export const ActivityEditorDialogMixin = superclass => class extends superclass {
+
+	static get properties() {
+		return {
+			opened: { type: Boolean }
+		};
+	}
+
+	constructor() {
+		super();
+		this.opened = false;
+	}
+
+	handleClose() {
+		this.opened = false;
+	}
+
+	open() {
+		this.opened = true;
+	}
+};

--- a/test/d2l-activity-editor/index.html
+++ b/test/d2l-activity-editor/index.html
@@ -23,6 +23,7 @@
 			'd2l-activity-outcomes.html',
 			'mixins/d2l-activity-editor-container-mixin.html',
 			'mixins/d2l-activity-editor-mixin.html',
+			'mixins/d2l-activity-editor-dialog-mixin.html',
 			'd2l-activity-attachments/d2l-activity-attachment.html',
 			'd2l-activity-attachments/d2l-activity-attachments-list.html',
 			'd2l-activity-attachments/d2l-activity-attachments-picker.html',

--- a/test/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.html
+++ b/test/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-activity-editor-dialog-mixin tests</title>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+
+	</head>
+	<body>
+		<script type="module" src="./d2l-activity-editor-dialog-mixin.js"></script>
+	</body>
+</html>

--- a/test/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.js
+++ b/test/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.js
@@ -1,0 +1,23 @@
+import { defineCE, expect, fixture } from '@open-wc/testing';
+import { ActivityEditorDialogMixin } from '../../../components/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.js';
+
+const editor = defineCE(
+	class extends ActivityEditorDialogMixin(HTMLElement) {
+	}
+);
+
+describe('d2l-activity-editor-dialog-mixin', function() {
+	it('handles opening a dialog', async() => {
+		const el = await fixture(`<${editor}></${editor}>`);
+		el.open();
+
+		expect(el.opened).to.be.true;
+	});
+
+	it('handles closing a dialog', async() => {
+		const el = await fixture(`<${editor}></${editor}>`);
+		el.handleClose();
+
+		expect(el.opened).to.be.false;
+	});
+});

--- a/test/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.js
+++ b/test/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.js
@@ -9,6 +9,8 @@ const editor = defineCE(
 describe('d2l-activity-editor-dialog-mixin', function() {
 	it('handles opening a dialog', async() => {
 		const el = await fixture(`<${editor}></${editor}>`);
+		el.opened = false;
+
 		el.open();
 
 		expect(el.opened).to.be.true;
@@ -16,6 +18,8 @@ describe('d2l-activity-editor-dialog-mixin', function() {
 
 	it('handles closing a dialog', async() => {
 		const el = await fixture(`<${editor}></${editor}>`);
+		el.opened = true;
+
 		el.handleClose();
 
 		expect(el.opened).to.be.false;

--- a/test/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.js
+++ b/test/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.js
@@ -1,12 +1,35 @@
 import { defineCE, expect, fixture } from '@open-wc/testing';
 import { ActivityEditorDialogMixin } from '../../../components/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.js';
 
+const TYPE_FUNCTION = 'function';
+
 const editor = defineCE(
 	class extends ActivityEditorDialogMixin(HTMLElement) {
 	}
 );
 
 describe('d2l-activity-editor-dialog-mixin', function() {
+	it('exposes an opened property', async() => {
+		const el = await fixture(`<${editor}></${editor}>`);
+
+		expect(el.opened).to.not.be.undefined;
+		expect(typeof el.opened).to.equal('boolean');
+	});
+
+	it('exposes an open method', async() => {
+		const el = await fixture(`<${editor}></${editor}>`);
+
+		expect(el.open).to.not.be.undefined;
+		expect(typeof el.open).to.equal(TYPE_FUNCTION);
+	});
+
+	it('exposes a handleClose method', async() => {
+		const el = await fixture(`<${editor}></${editor}>`);
+
+		expect(el.handleClose).to.not.be.undefined;
+		expect(typeof el.open).to.equal(TYPE_FUNCTION);
+	});
+
 	it('handles opening a dialog', async() => {
 		const el = await fixture(`<${editor}></${editor}>`);
 		el.opened = false;


### PR DESCRIPTION
Added a mixin to handle opening/closing dialogs as part of a refactor for this story https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F461234358860.

The idea is that any component that wants to implement a dialog can extend this mixin and get the open/closing logic for free. I had a discussion with Martin on this and as he pointed out the dialog natively supports managing it's own open state but would require us to do stuff like this to open the dialog:

```javascript
document.querySelector('#open').addEventListener('click', async() => {
  const action = await document.querySelector('d2l-dialog').open();
  console.log('dialog action:', action);
});
```

which in my opinion is nowhere near as nice/clean as the declarative approach:

```javascript
<d2l-dialog ?opened="${this.opened}"></d2l-dialog>
```

This mixin lets us use the declarative approach while also not needing to repeat ourselves with open/close logic in multiple components. 