### PR TITLE
Activity header count should read "99+" in both views

### DIFF
--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-header.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-header.js
@@ -142,11 +142,9 @@ class ActivityListHeader extends SkeletonMixin(LocalizeWorkToDoMixin(LitElement)
 		if (this.skeleton) {
 			return '';
 		}
-		return this.fullscreen
-			? `${this.count}`
-			: this.count > Constants.MaxActivityCount
-				? `${Constants.MaxActivityCount}+`
-				: `${this.count}`;
+		return this.count > Constants.MaxActivityCount
+			? `${Constants.MaxActivityCount}+`
+			: `${this.count}`;
 	}
 
 	get _message() {


### PR DESCRIPTION
Previously we allowed the fullscreen view count to go above 99 (completely unbounded, but for consistency we would like for the count to stop at 99 just like it does in widget view.

See rally story: https://rally1.rallydev.com/#/357251704080ud/custom/367300408400?detail=%2Fuserstory%2F460541049668