### PR TITLE
Returning entity.dirty() instead of entity.dirty

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-usage-conditions-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-usage-conditions-editor.js
@@ -41,7 +41,7 @@ class ActivityUsageConditionsEditor extends ActivityEditorMixin(MobxLitElement) 
 			return false;
 		}
 
-		return entity.dirty;
+		return entity.dirty();
 	}
 }
 


### PR DESCRIPTION
Fix defect which always renders dirty check dialog