### PR TITLE
Added prevent default to skip default behaviour

### DIFF
--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.js
@@ -15,7 +15,8 @@ export const ActivityEditorDialogMixin = superclass => class extends superclass 
 		this.opened = false;
 	}
 
-	open() {
+	open(event) {
+		event.preventDefault();
 		this.opened = true;
 	}
 };

--- a/test/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.js
+++ b/test/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.js
@@ -32,9 +32,11 @@ describe('d2l-activity-editor-dialog-mixin', function() {
 
 	it('handles opening a dialog', async() => {
 		const el = await fixture(`<${editor}></${editor}>`);
+		const event = { preventDefault: () => {} };
+
 		el.opened = false;
 
-		el.open();
+		el.open(event);
 
 		expect(el.opened).to.be.true;
 	});


### PR DESCRIPTION
@dustxd and I noticed that certain buttons had a default action attached depending on how they were rendered which caused funky behaviour especially with the checkboxes. In our case we rendered a "?" button as a child of a `d2l-input-checkbox` component. This meant that it inherited a click handler which caused the value of the checkbox to change when clicking on the "?" button. Preventing the default action and instead only running the dialog open open code fixed the problem. 

An alternative to this would be to change the how our elements are rendered/structured but we found that meant we'd have to write a bunch of custom css to get things to look the same. This _seemed_ like a simpler solution.

We don't need the same thing on the close handler as the close event is predictably managed by the dialog itself and does not depend on a custom click handler like on open.