### PR TITLE
US123107: Support handling Audio/Video attachments as links which store URNs

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker.js
@@ -79,15 +79,25 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(SkeletonMixin(Locali
 	}
 
 	async _handlerAudioUploaded(e) {
-		const file = e.detail.files[0];
+		this._handlerAudioVideoUploaded(e, { storeCreateFileMethod: 'createAudio' });
+	}
 
-		const fileId = file.GetId();
-		const fileName = file.GetName();
-		const fileSystemType = file.GetFileSystemType();
+	async _handlerAudioVideoUploaded(e, { storeCreateFileMethod }) {
+		const attachment = e.detail.files[0];
 
-		const collection = store.get(this.href);
-		const previewUrl = await collection.getPreviewUrl(fileSystemType, fileId);
-		this._addToCollection(attachmentStore.createAudio(fileName, fileSystemType, fileId, previewUrl));
+		if (attachment.GetFileSystemType) {
+			const file = attachment;
+			const fileId = file.GetId();
+			const fileName = file.GetName();
+			const fileSystemType = file.GetFileSystemType();
+
+			const collection = store.get(this.href);
+			const previewUrl = await collection.getPreviewUrl(fileSystemType, fileId);
+			this._addToCollection(attachmentStore[storeCreateFileMethod](fileName, fileSystemType, fileId, previewUrl));
+		} else if (attachment.GetLocation) {
+			const link = attachment;
+			this._addToCollection(attachmentStore.createLink(link.GetName(), link.GetLocation(), link.GetUrn()));
+		}
 	}
 
 	async _handlerFilesUploaded(e) {
@@ -121,15 +131,7 @@ class ActivityAttachmentsPicker extends ActivityEditorMixin(SkeletonMixin(Locali
 	}
 
 	async _handlerVideoUploaded(e) {
-		const file = e.detail.files[0];
-
-		const fileId = file.GetId();
-		const fileName = file.GetName();
-		const fileSystemType = file.GetFileSystemType();
-
-		const collection = store.get(this.href);
-		const previewUrl = await collection.getPreviewUrl(fileSystemType, fileId);
-		this._addToCollection(attachmentStore.createVideo(fileName, fileSystemType, fileId, previewUrl));
+		this._handlerAudioVideoUploaded(e, { storeCreateFileMethod: 'createVideo' });
 	}
 
 	get _orgUnitId() {

--- a/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-store.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/state/attachment-store.js
@@ -21,8 +21,8 @@ export class AttachmentStore extends ObjectStore {
 	createGoogleDriveLink(name, url) {
 		return this._createLink(GoogleDriveAttachment, name, url);
 	}
-	createLink(name, url) {
-		return this._createLink(LinkAttachment, name, url);
+	createLink(name, url, urn) {
+		return this._createLink(LinkAttachment, name, url, urn);
 	}
 	createOneDriveLink(name, url) {
 		return this._createLink(OneDriveAttachment, name, url);
@@ -37,10 +37,10 @@ export class AttachmentStore extends ObjectStore {
 		this.put(tempId, file);
 		return file;
 	}
-	_createLink(Type, name, url) {
+	_createLink(Type, name, url, urn) {
 		const tempId = nextTempId();
 		const link = new Type(tempId);
-		link.initLink(name, url);
+		link.initLink(name, url, urn);
 		this.put(tempId, link);
 		return link;
 	}

--- a/components/d2l-activity-editor/d2l-activity-attachments/state/attachment.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/state/attachment.js
@@ -67,19 +67,20 @@ decorate(Attachment, {
 });
 
 export class LinkAttachment extends Attachment {
-	initLink(name, url) {
+	initLink(name, url, urn) {
 		this.editing = true;
 		this.creating = true;
 
 		this.attachment = {
 			id: this.href,
 			name: name,
-			url: url
+			url,
+			urn,
 		};
 	}
 
 	async save(entity) {
-		await entity.addLinkAttachment(this.attachment.name, this.attachment.url);
+		await entity.addLinkAttachment(this.attachment.name, this.attachment.urn || this.attachment.url);
 	}
 }
 

--- a/test/d2l-activity-editor/d2l-activity-attachments/state/attachment.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-attachments/state/attachment.spec.js
@@ -67,17 +67,50 @@ describe('Attachment', function() {
 	});
 
 	describe('LinkAttachment', () => {
-		it('initializes', () => {
+		it('initializes without urn', () => {
 			const link = new LinkAttachment('http://attachment/1', 'token');
 			link.initLink('Google Canada', 'http://google.ca');
 
 			expect(link.attachment.name).to.equal('Google Canada');
 			expect(link.attachment.id).to.equal('http://attachment/1');
 			expect(link.attachment.url).to.equal('http://google.ca');
+			expect(link.attachment.urn).to.equal(undefined);
 
 			expect(link.creating).to.be.true;
 			expect(link.editing).to.be.true;
 			expect(link.deleted).to.be.false;
+		});
+
+		it('initializes with urn', () => {
+			const link = new LinkAttachment('http://attachment/1', 'token');
+			link.initLink('Google Canada', 'http://google.ca', 'd2l:brightspace:foo:::bar:car');
+
+			expect(link.attachment.name).to.equal('Google Canada');
+			expect(link.attachment.id).to.equal('http://attachment/1');
+			expect(link.attachment.url).to.equal('http://google.ca');
+			expect(link.attachment.urn).to.equal('d2l:brightspace:foo:::bar:car');
+
+			expect(link.creating).to.be.true;
+			expect(link.editing).to.be.true;
+			expect(link.deleted).to.be.false;
+		});
+
+		it('saves the url when a urn is not provided', async() => {
+			const link = new LinkAttachment('http://attachment/1', 'token');
+			link.initLink('Google Canada', 'http://google.ca');
+
+			const entity = { addLinkAttachment: sinon.spy() };
+			await link.save(entity);
+			expect(entity.addLinkAttachment.args[0][1]).to.equal('http://google.ca');
+		});
+
+		it('saves the urn when it is provided', async() => {
+			const link = new LinkAttachment('http://attachment/1', 'token');
+			link.initLink('Google Canada', 'http://google.ca', 'd2l:brightspace:foo:::bar:car');
+
+			const entity = { addLinkAttachment: sinon.spy() };
+			await link.save(entity);
+			expect(entity.addLinkAttachment.args[0][1]).to.equal('d2l:brightspace:foo:::bar:car');
 		});
 	});
 

--- a/test/d2l-activity-editor/d2l-activity-attachments/state/attachment.store.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-attachments/state/attachment.store.spec.js
@@ -19,12 +19,23 @@ describe('Attachment Store', function() {
 	});
 
 	describe('Links', () => {
-		it('creates new', () => {
+		it('creates new without a urn', () => {
 			const link = store.createLink('Google Canada', 'http://google.ca');
 
 			expect(link).to.be.an.instanceof(LinkAttachment);
 			expect(link.attachment.name).to.equal('Google Canada');
 			expect(link.attachment.url).to.equal('http://google.ca');
+			expect(link.attachment.urn).to.equal(undefined);
+			expect(store.get(link.href)).to.equal(link);
+		});
+
+		it('creates new with a urn', () => {
+			const link = store.createLink('Google Canada', 'http://google.ca', 'd2l:brightspace:foo:::bar:car');
+
+			expect(link).to.be.an.instanceof(LinkAttachment);
+			expect(link.attachment.name).to.equal('Google Canada');
+			expect(link.attachment.url).to.equal('http://google.ca');
+			expect(link.attachment.urn).to.equal('d2l:brightspace:foo:::bar:car');
 			expect(store.get(link.href)).to.equal(link);
 		});
 	});


### PR DESCRIPTION
Current audio/video attachment experience is:

- user clicks on a video and must download an html file
- file contains a link, which they must click
- link takes them to a page in the lms to view the media

This PR adds support for handling links which store a URN which points to an audio or video resource. The new experience is:

- user clicks on a video and is taken to the media player in a new tab

Future work will add audio/video embedded player. Storing the media as URNs decouples the storage from the mode of playback.

Related: https://github.com/Brightspace/lms/pull/4695