### PR TITLE
Added help dialog for quizzing disable right click editor

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-pager-and-alerts-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-pager-and-alerts-editor.js
@@ -37,7 +37,7 @@ class ActivityQuizDisablePagerAndAlertsEditor
 				ariaLabel="${this.localize('disablePagerAndAlertsDescription')}"
 				?disabled="${!entity.canEditDisablePagerAndAlerts}">
 
-				<label class="d2l-input-checkbox-text">${this.localize('disablePagerAndAlertsDescription')}</label>
+				<label>${this.localize('disablePagerAndAlertsDescription')}</label>
 
 				<d2l-button-icon
 					text="${this.localize('disableAlertsAccessibleHelpText')}"

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-right-click-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-right-click-editor.js
@@ -20,8 +20,8 @@ class ActivityQuizDisableRightClickEditor
 				}
 
 				.d2l-input-checkbox-help {
-					margin: auto 0;
-					padding-right: 0.4em;
+					margin: auto 0.4em auto 0;
+					padding: 0;
 				}
 			`
 		];

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-right-click-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-right-click-editor.js
@@ -15,8 +15,8 @@ class ActivityQuizDisableRightClickEditor
 			checkboxStyles,
 			css`
 				.d2l-input-checkbox-help-container {
+					align-items: flex-start;
 					display: flex;
-					align-itmes: flex-start;
 				}
 
 				.d2l-input-checkbox-help {

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-right-click-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-right-click-editor.js
@@ -34,6 +34,11 @@ class ActivityQuizDisableRightClickEditor
 				ariaLabel="${this.localize('disableRightClickDescription')}"
 				?disabled="${!entity.canEditDisableRightClick}">
 				${this.localize('disableRightClickDescription')}
+				<d2l-button-icon
+					text="${this.localize('disableRightClickAccessibleHelpText')}"
+					icon="tier1:help"
+					@click="${this.open}">
+				</d2l-button-icon>
 			</d2l-input-checkbox>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-right-click-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-right-click-editor.js
@@ -1,4 +1,5 @@
 import { css, html } from 'lit-element/lit-element.js';
+import { ActivityEditorDialogMixin } from '../mixins/d2l-activity-editor-dialog-mixin.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { checkboxStyles } from '../styles/checkbox-styles.js';
 import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang-mixin';
@@ -7,7 +8,7 @@ import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { shared as store } from './state/quiz-store';
 
 class ActivityQuizDisableRightClickEditor
-	extends ActivityEditorMixin(RtlMixin(LocalizeActivityQuizEditorMixin(MobxLitElement))) {
+	extends ActivityEditorMixin(RtlMixin(LocalizeActivityQuizEditorMixin(ActivityEditorDialogMixin(MobxLitElement)))) {
 
 	static get styles() {
 		return [

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-right-click-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-right-click-editor.js
@@ -58,6 +58,8 @@ class ActivityQuizDisableRightClickEditor
 					@click="${this.open}">
 				</d2l-button-icon>
 			</div>
+
+			${this._renderDialog()}
 		`;
 		// return html `
 		//  	<d2l-input-checkbox-spacer
@@ -77,6 +79,24 @@ class ActivityQuizDisableRightClickEditor
 		// 		</d2l-button-icon>
 		// 	</d2l-input-checkbox>
 		// `;
+	}
+
+	_renderDialog() {
+		return html`
+			<d2l-dialog
+				?opened="${this.opened}"
+				@d2l-dialog-close="${this.handleClose}"
+				title-text="${this.localize('disableRightClickHelpDialogTitle')}">
+					<p>${this.localize('disableRightClickHelpDialogParagraph1')}</p>
+					<p>${this.localize('disableRightClickHelpDialogParagraph2')}</p>
+					<d2l-button
+						data-dialog-action="done"
+						slot="footer"
+						primary>
+						${this.localize('disableRightClickHelpDialogConfirmationText')}
+					</d2l-button>
+			</d2l-dialog>
+		`;
 	}
 
 	_setDisableRightClick(event) {

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-right-click-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-right-click-editor.js
@@ -61,24 +61,6 @@ class ActivityQuizDisableRightClickEditor
 
 			${this._renderDialog()}
 		`;
-		// return html `
-		//  	<d2l-input-checkbox-spacer
-		//  		class="d2l-body-small">
-		// 	</d2l-input-checkbox-spacer>
-			 
-		// 	<d2l-input-checkbox
-		// 		?checked="${entity.isDisableRightClickEnabled}"
-		// 		@change="${this._setDisableRightClick}"
-		// 		ariaLabel="${this.localize('disableRightClickDescription')}"
-		// 		?disabled="${!entity.canEditDisableRightClick}">
-		// 		${this.localize('disableRightClickDescription')}
-		// 		<d2l-button-icon
-		// 			text="${this.localize('disableRightClickAccessibleHelpText')}"
-		// 			icon="tier1:help"
-		// 			@click="${this.open}">
-		// 		</d2l-button-icon>
-		// 	</d2l-input-checkbox>
-		// `;
 	}
 
 	_renderDialog() {

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-right-click-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-right-click-editor.js
@@ -36,46 +36,46 @@ class ActivityQuizDisableRightClickEditor
 			return html``;
 		}
 
-		// return html`
-		// 	<d2l-input-checkbox-spacer
-		// 		class="d2l-body-small">
-		// 	</d2l-input-checkbox-spacer>
-
-		// 	<div class="d2l-input-checkbox-help-container">
-		// 		<d2l-input-checkbox
-		// 			class="d2l-input-checkbox-help"
-		// 			?checked="${entity.isDisableRightClickEnabled}"
-		// 			@change="${this._setDisableRightClick}"
-		// 			ariaLabel="${this.localize('disableRightClickDescription')}"
-		// 			?disabled="${!entity.canEditDisableRightClick}">
-		// 			${this.localize('disableRightClickDescription')}
-		// 		</d2l-input-checkbox>
-
-		// 		<d2l-button-icon
-		// 			text="${this.localize('disableRightClickAccessibleHelpText')}"
-		// 			icon="tier1:help"
-		// 			@click="${this.open}">
-		// 		</d2l-button-icon>
-		// 	</div>
-		// `;
-		return html `
-		 	<d2l-input-checkbox-spacer
-		 		class="d2l-body-small">
+		return html`
+			<d2l-input-checkbox-spacer
+				class="d2l-body-small">
 			</d2l-input-checkbox-spacer>
-			 
-			<d2l-input-checkbox
-				?checked="${entity.isDisableRightClickEnabled}"
-				@change="${this._setDisableRightClick}"
-				ariaLabel="${this.localize('disableRightClickDescription')}"
-				?disabled="${!entity.canEditDisableRightClick}">
-				${this.localize('disableRightClickDescription')}
+
+			<div class="d2l-input-checkbox-help-container">
+				<d2l-input-checkbox
+					class="d2l-input-checkbox-help"
+					?checked="${entity.isDisableRightClickEnabled}"
+					@change="${this._setDisableRightClick}"
+					ariaLabel="${this.localize('disableRightClickDescription')}"
+					?disabled="${!entity.canEditDisableRightClick}">
+					${this.localize('disableRightClickDescription')}
+				</d2l-input-checkbox>
+
 				<d2l-button-icon
 					text="${this.localize('disableRightClickAccessibleHelpText')}"
 					icon="tier1:help"
 					@click="${this.open}">
 				</d2l-button-icon>
-			</d2l-input-checkbox>
+			</div>
 		`;
+		// return html `
+		//  	<d2l-input-checkbox-spacer
+		//  		class="d2l-body-small">
+		// 	</d2l-input-checkbox-spacer>
+			 
+		// 	<d2l-input-checkbox
+		// 		?checked="${entity.isDisableRightClickEnabled}"
+		// 		@change="${this._setDisableRightClick}"
+		// 		ariaLabel="${this.localize('disableRightClickDescription')}"
+		// 		?disabled="${!entity.canEditDisableRightClick}">
+		// 		${this.localize('disableRightClickDescription')}
+		// 		<d2l-button-icon
+		// 			text="${this.localize('disableRightClickAccessibleHelpText')}"
+		// 			icon="tier1:help"
+		// 			@click="${this.open}">
+		// 		</d2l-button-icon>
+		// 	</d2l-input-checkbox>
+		// `;
 	}
 
 	_setDisableRightClick(event) {

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-right-click-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-right-click-editor.js
@@ -1,6 +1,6 @@
+import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { checkboxStyles } from '../styles/checkbox-styles.js';
-import { html } from 'lit-element/lit-element.js';
 import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang-mixin';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
@@ -10,7 +10,20 @@ class ActivityQuizDisableRightClickEditor
 	extends ActivityEditorMixin(RtlMixin(LocalizeActivityQuizEditorMixin(MobxLitElement))) {
 
 	static get styles() {
-		return checkboxStyles;
+		return [
+			checkboxStyles,
+			css`
+				.d2l-input-checkbox-help-container {
+					display: flex;
+					align-itmes: center;
+				}
+
+				.d2l-input-checkbox-help {
+					margin: auto 0;
+					padding-right: 0.4em;
+				}
+			`
+		];
 	}
 
 	constructor() {
@@ -23,11 +36,33 @@ class ActivityQuizDisableRightClickEditor
 			return html``;
 		}
 
-		return html`
-			<d2l-input-checkbox-spacer
-				class="d2l-body-small">
-			</d2l-input-checkbox-spacer>
+		// return html`
+		// 	<d2l-input-checkbox-spacer
+		// 		class="d2l-body-small">
+		// 	</d2l-input-checkbox-spacer>
 
+		// 	<div class="d2l-input-checkbox-help-container">
+		// 		<d2l-input-checkbox
+		// 			class="d2l-input-checkbox-help"
+		// 			?checked="${entity.isDisableRightClickEnabled}"
+		// 			@change="${this._setDisableRightClick}"
+		// 			ariaLabel="${this.localize('disableRightClickDescription')}"
+		// 			?disabled="${!entity.canEditDisableRightClick}">
+		// 			${this.localize('disableRightClickDescription')}
+		// 		</d2l-input-checkbox>
+
+		// 		<d2l-button-icon
+		// 			text="${this.localize('disableRightClickAccessibleHelpText')}"
+		// 			icon="tier1:help"
+		// 			@click="${this.open}">
+		// 		</d2l-button-icon>
+		// 	</div>
+		// `;
+		return html `
+		 	<d2l-input-checkbox-spacer
+		 		class="d2l-body-small">
+			</d2l-input-checkbox-spacer>
+			 
 			<d2l-input-checkbox
 				?checked="${entity.isDisableRightClickEnabled}"
 				@change="${this._setDisableRightClick}"

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-right-click-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-disable-right-click-editor.js
@@ -15,7 +15,7 @@ class ActivityQuizDisableRightClickEditor
 			css`
 				.d2l-input-checkbox-help-container {
 					display: flex;
-					align-itmes: center;
+					align-itmes: flex-start;
 				}
 
 				.d2l-input-checkbox-help {

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
@@ -42,5 +42,9 @@ export default {
 	"disableAlertsHelpDialogContent": "If you turn on this option, learners cannot access the Brightspace Email, Instant Messages, or their alerts if they have a quiz attempt in progress.", // content that appears when the disable alerts help dialog is rendered
 	"disableAlertsHelpDialogConfirmationText": "OK", // copy that appears on the disable alerts help dialog confirmation button
 	"disableAlertsAccessibleHelpText": "Get help on - Disable Email, Instant Messages and alerts", // accessible help text for disable alerts question mark button
-	"disableRightClickAccessibleHelpText": "Get help on - Disable Right Click" // accessible help text for disable right click question mark button
+	"disableRightClickAccessibleHelpText": "Get help on - Disable Right Click", // accessible help text for disable right click question mark button
+	"disableRightClickHelpDialogTitle": "Information: Disable Right Click", // title that appears when the disable right click help dialog is rendered
+	"disableRightClickHelpDialogParagraph1": "This feature prohibits learners from printing quiz questions by right-clicking on a question while an attempt is in progress.  But learners will still be able to screen capture the quiz through other technologies outside of the browser.", // content for paragraph 1 of disable right click help dialog
+	"disableRightClickHelpDialogParagraph2": "Certain accessibility workflows will be blocked because the learner cannot copy and pasted the question text.", // content for paragraph 2 of disable right click help dialog
+	"disableRightClickHelpDialogConfirmationText": "OK", // copy that appears on the disable right click help dialog confirmation button
 };

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
@@ -41,5 +41,6 @@ export default {
 	"disableAlertsHelpDialogTitle": "Information: Disable Email, Instant Messages and Alerts", // title that appears when the disable alerts help dialog is rendered
 	"disableAlertsHelpDialogContent": "If you turn on this option, learners cannot access the Brightspace Email, Instant Messages, or their alerts if they have a quiz attempt in progress.", // content that appears when the disable alerts help dialog is rendered
 	"disableAlertsHelpDialogConfirmationText": "OK", // copy that appears on the disable alerts help dialog confirmation button
-	"disableAlertsAccessibleHelpText": "Get help on - Disable Email, Instant Messages and alerts" // accessible help text for disable alerts question mark button
+	"disableAlertsAccessibleHelpText": "Get help on - Disable Email, Instant Messages and alerts", // accessible help text for disable alerts question mark button
+	"disableRightClickAccessibleHelpText": "Get help on - Disable Right Click" // accessible help text for disable right click question mark button
 };


### PR DESCRIPTION
### Summary of Changes
* Added help dialog using Mixin for state management
* Laid out `d2l-input-checkbox` and `d2l-icon-button` side by side to fix alignment issues caused by the height of icon button being taller than the text
![image](https://user-images.githubusercontent.com/10677430/102386248-b2534780-3f83-11eb-964a-e41de1f1c0ef.png)
* Added custom css


### Concerns
(Credits to @ronan-f for looking into this with me!)
* This solution does not work well with long lang terms (see this [PR](https://github.com/BrightspaceHypermediaComponents/activities/pull/1267)) as it lays out the question mark icon button side by side instead of wrapping it to the end of text
![image](https://user-images.githubusercontent.com/10677430/102388029-07905880-3f86-11eb-9862-9332625123d7.png)
* There's extra spacing on the top and bottom due to the height of the icon button being taller
![image](https://user-images.githubusercontent.com/10677430/102384774-ee85a880-3f81-11eb-82c1-9e720025541a.png)


### Rally Task
https://rally1.rallydev.com/#/29180338367d/dashboard?detail=%2Fuserstory%2F461234386024