### PR TITLE
Fix for DE41702 - make links clickable in work-to-do widget

### DIFF
--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
@@ -9,12 +9,12 @@ import { ActivityAllowList } from './env';
 import { classMap } from 'lit-html/directives/class-map';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { fetchEntity } from './state/fetch-entity';
-import { ListItemMixin } from '@brightspace-ui/core/components/list/list-item-mixin';
+import { ListItemLinkMixin } from '@brightspace-ui/core/components/list/list-item-link-mixin';
 import { LocalizeWorkToDoMixin } from './localization';
 import { nothing } from 'lit-html';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin';
 
-class ActivityListItemBasic extends ListItemMixin(SkeletonMixin(EntityMixinLit(LocalizeWorkToDoMixin(LitElement)))) {
+class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinLit(LocalizeWorkToDoMixin(LitElement)))) {
 
 	static get properties() {
 		return {


### PR DESCRIPTION
[DE41702 - Links are not clickable in the widget](https://rally1.rallydev.com/#/357251704080ud/workviews?detail=%2Fdefect%2F463973680764&view=1dbdf7ff-337f-4c24-b34a-19155082c9dc)

It looks like Linking was moved to a separate mixin recently: https://github.com/BrightspaceUI/core/commit/cb806eb6347b3331a024ebb63ca588d463a6252b

So this should restore the original behavior. Demo:
![image](https://user-images.githubusercontent.com/50635849/102388510-dde42b00-3f9f-11eb-858e-c2000d240161.png)
