### PR TITLE
[Draft] Fix RTL horizontal scrollbar due to overflow from new date-time picker

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -39,6 +39,7 @@ class ActivityEditor extends ActivityEditorContainerMixin(ActivityEditorTelemetr
 				padding: 20px;
 			}
 			.d2l-secondary-panel {
+				overflow: hidden;
 				padding: 10px;
 			}
 			.d2l-secondary-scroll {


### PR DESCRIPTION
Need to look into `core`'s primary-secondary template to determine RCA.

Fixes: https://trello.com/c/DwgFvfRz/262-rtl-new-picker-causes-horizontal-scroll-in-rhp