### PR TITLE
fix: Add alignment to tooltip for ActivityAttachmentsPickerPresentational

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker-presentational.js
+++ b/components/d2l-activity-editor/d2l-activity-attachments/d2l-activity-attachments-picker-presentational.js
@@ -151,6 +151,7 @@ class ActivityAttachmentsPickerPresentational extends SkeletonMixin(LocalizeActi
 				</d2l-button-icon>
 				<d2l-tooltip
 					for="add-file-button"
+					align="start"
 					aria-hidden="true"
 					disable-focus-lock>${this.localize('attachments.addFile')}</d2l-tooltip>
 					<!-- Important: keep tooltip content inline, otherwise screenreader gets confused -->


### PR DESCRIPTION
Fix issue where Primary-Secondary template separator would cut off the tooltip of the add-attachment button

Before:
![image](https://user-images.githubusercontent.com/32204301/103573503-59990f80-4e9c-11eb-8ac8-c416fa83ad8e.png)
After:
![image](https://user-images.githubusercontent.com/32204301/103573419-33736f80-4e9c-11eb-82a7-9838ea611385.png)
