### PR TITLE
Fix: links were not clickable in fullscreen view

### DIFF
--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
@@ -10,12 +10,12 @@ import { ActivityAllowList } from './env';
 import { classMap } from 'lit-html/directives/class-map';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { fetchEntity } from './state/fetch-entity';
-import { ListItemMixin } from '@brightspace-ui/core/components/list/list-item-mixin';
+import { ListItemLinkMixin } from '@brightspace-ui/core/components/list/list-item-link-mixin';
 import { LocalizeWorkToDoMixin } from './localization';
 import { nothing } from 'lit-html';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin';
 
-class ActivityListItemDetailed extends ListItemMixin(SkeletonMixin(EntityMixinLit(LocalizeWorkToDoMixin(LitElement)))) {
+class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMixinLit(LocalizeWorkToDoMixin(LitElement)))) {
 
 	static get properties() {
 		return {


### PR DESCRIPTION
Replicated fix from #1280 to fullscreen view. Tested by going to `/d2l/le/worktodo/view` manually on my test environment and confirmed that links (other than Content, known/separate issue) were working.

Rally case for context: https://rally1.rallydev.com/#/357251704080ud/custom/367300408400?detail=%2Fdefect%2F463973680764