### PR TITLE
US123218 Do not delete new activity after save-in-place

### DIFF
--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js
@@ -129,6 +129,7 @@ export const ActivityEditorContainerMixin = superclass => class extends Activity
 		this.dispatchEvent(this._saveCompleteEvent(saveInPlace));
 		if (saveInPlace) {
 			this.isSaving = false;
+			this.isNew = false;
 		}
 
 		this.logSaveEvent(this.href, this.type, this.telemetryId);


### PR DESCRIPTION
https://trello.com/c/bsg7Fb6D/290-save-in-place-saved-assignment-gets-deleted

The `isNew` property needs to be set to false on save-in-place, so that a net-new activity does not get deleted after clicking cancel or back _after_ saving-in-place.