### PR TITLE
Immersive navbar top padding

### DIFF
--- a/components/d2l-work-to-do/d2l-work-to-do.js
+++ b/components/d2l-work-to-do/d2l-work-to-do.js
@@ -94,7 +94,7 @@ class WorkToDoWidget extends EntityMixinLit(LocalizeWorkToDoMixin(LitElement)) {
 				}
 				.d2l-work-to-do-fullscreen-container {
 					background-image: linear-gradient(to bottom, #f9fbff, #ffffff);
-					padding: 3.35rem 2rem 0;
+					padding: 3.35rem 2rem 0 2rem;
 				}
 				d2l-button {
 					padding: 1.8rem 0;

--- a/components/d2l-work-to-do/d2l-work-to-do.js
+++ b/components/d2l-work-to-do/d2l-work-to-do.js
@@ -94,7 +94,7 @@ class WorkToDoWidget extends EntityMixinLit(LocalizeWorkToDoMixin(LitElement)) {
 				}
 				.d2l-work-to-do-fullscreen-container {
 					background-image: linear-gradient(to bottom, #f9fbff, #ffffff);
-					padding: 0 2rem;
+					padding: 67px 2rem 0;
 				}
 				d2l-button {
 					padding: 1.8rem 0;

--- a/components/d2l-work-to-do/d2l-work-to-do.js
+++ b/components/d2l-work-to-do/d2l-work-to-do.js
@@ -94,7 +94,7 @@ class WorkToDoWidget extends EntityMixinLit(LocalizeWorkToDoMixin(LitElement)) {
 				}
 				.d2l-work-to-do-fullscreen-container {
 					background-image: linear-gradient(to bottom, #f9fbff, #ffffff);
-					padding: 67px 2rem 0;
+					padding: 3.35rem 2rem 0;
 				}
 				d2l-button {
 					padding: 1.8rem 0;


### PR DESCRIPTION
Immersive navbar was overlapping the title of the fullscreen view instead of pushing the content down, so I added padding to compensate. I'm sure there's a cleaner way to do this, but I couldn't think of one and wanted to get this out ASAP.

See rally story: https://rally1.rallydev.com/#/357251704080ud/custom/367300408400?detail=%2Fuserstory%2F460369362992