### PR TITLE
fix: FACE Assignments activity-outcomes rendering

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-outcomes.js
+++ b/components/d2l-activity-editor/d2l-activity-outcomes.js
@@ -57,14 +57,14 @@ class ActivityOutcomes extends ActivityEditorFeaturesMixin(ActivityEditorMixin(R
 			return html``;
 		}
 
-		if (!this._hasAlignments) {
-			this.hidden = true;
-		}
-
 		const {
 			canUpdateAlignments,
 			alignmentsHref
 		} = activity;
+
+		if (!this._hasAlignments && !canUpdateAlignments) {
+			this.hidden = true;
+		}
 
 		return html`
 			${this._renderTags()}

--- a/components/d2l-activity-editor/d2l-activity-outcomes.js
+++ b/components/d2l-activity-editor/d2l-activity-outcomes.js
@@ -57,6 +57,10 @@ class ActivityOutcomes extends ActivityEditorFeaturesMixin(ActivityEditorMixin(R
 			return html``;
 		}
 
+		if (!this._hasAlignments) {
+			this.hidden = true;
+		}
+
 		const {
 			canUpdateAlignments,
 			alignmentsHref


### PR DESCRIPTION
https://trello.com/c/F5wKvedY/287-face-assignments-outcomes-editor-taking-up-page-space-when-not-displayed

When there are no alignments and user lacks permissions to update alignments, hide the activity-outcomes component to prevent styles (`padding-bottom: 20px`) being applied to an editor component with no content. This fixes the spacing problem it otherwise creates.