### PR TITLE
W2D: fix/remove extra padding for fullscreen view

### DIFF
--- a/components/d2l-work-to-do/d2l-work-to-do.js
+++ b/components/d2l-work-to-do/d2l-work-to-do.js
@@ -324,19 +324,19 @@ class WorkToDoWidget extends EntityMixinLit(LocalizeWorkToDoMixin(LitElement)) {
 				</d2l-button>`
 			: nothing;
 
+		const immersiveNav = () => {
+			return html`
+				<d2l-navigation-immersive back-link-href="${this._homeLinkHref}" back-link-text="${this.localize('backToD2L')}">
+					<div class="d2l-typography d2l-body-standard" slot="middle">
+						<p>${this.localize('myWorkToDo')}</p>
+					</div>
+				</d2l-navigation-immersive>`;
+		};
+
 		const fullscreenTemplate = () => {
 			if (!this._overdueCollection || !this._upcomingCollection || !this._maxCollection) {
 				return nothing;
 			}
-
-			const immersiveNav = () => {
-				return html`
-						<d2l-navigation-immersive back-link-href="${this._homeLinkHref}" back-link-text="${this.localize('backToD2L')}">
-							<div class="d2l-typography d2l-body-standard" slot="middle">
-								<p>${this.localize('myWorkToDo')}</p>
-							</div>
-						</d2l-navigation-immersive>`
-			};
 
 			return html`
 				${immersiveNav()}
@@ -364,6 +364,7 @@ class WorkToDoWidget extends EntityMixinLit(LocalizeWorkToDoMixin(LitElement)) {
 		`;
 
 		const detailedSkeleton = html`
+			${immersiveNav()}
 			<d2l-work-to-do-activity-list-header skeleton fullscreen></d2l-work-to-do-activity-list-header>
 			<d2l-list separators="none">
 				<d2l-work-to-do-activity-list-item-detailed skeleton href=' ' token=' '></d2l-work-to-do-activity-list-item-detailed>

--- a/components/d2l-work-to-do/d2l-work-to-do.js
+++ b/components/d2l-work-to-do/d2l-work-to-do.js
@@ -94,7 +94,7 @@ class WorkToDoWidget extends EntityMixinLit(LocalizeWorkToDoMixin(LitElement)) {
 				}
 				.d2l-work-to-do-fullscreen-container {
 					background-image: linear-gradient(to bottom, #f9fbff, #ffffff);
-					padding: 3.35rem 2rem 0 2rem;
+					padding: 0 2rem;
 				}
 				d2l-button {
 					padding: 1.8rem 0;
@@ -306,19 +306,7 @@ class WorkToDoWidget extends EntityMixinLit(LocalizeWorkToDoMixin(LitElement)) {
 				`;
 			});
 
-			const immersiveNav = (isFullscreen) => {
-				return isFullscreen
-					? html`
-						<d2l-navigation-immersive back-link-href="${this._homeLinkHref}" back-link-text="${this.localize('backToD2L')}">
-							<div class="d2l-typography d2l-body-standard" slot="middle">
-								<p>${this.localize('myWorkToDo')}</p>
-							</div>
-						</d2l-navigation-immersive>`
-					: nothing;
-			};
-
 			return html`
-				${immersiveNav(this.fullscreen)}
 				<div class="d2l-activity-collection-container-fullscreen">
 					<d2l-work-to-do-activity-list-header ?overdue=${isOverdue} count=${activities.length} fullscreen></d2l-work-to-do-activity-list-header>
 					<d2l-list>${groupedByDate}</d2l-list>
@@ -340,7 +328,20 @@ class WorkToDoWidget extends EntityMixinLit(LocalizeWorkToDoMixin(LitElement)) {
 			if (!this._overdueCollection || !this._upcomingCollection || !this._maxCollection) {
 				return nothing;
 			}
+
+			const immersiveNav = (isFullscreen) => {
+				return isFullscreen
+					? html`
+						<d2l-navigation-immersive back-link-href="${this._homeLinkHref}" back-link-text="${this.localize('backToD2L')}">
+							<div class="d2l-typography d2l-body-standard" slot="middle">
+								<p>${this.localize('myWorkToDo')}</p>
+							</div>
+						</d2l-navigation-immersive>`
+					: nothing;
+			};
+
 			return html`
+				${immersiveNav(this.fullscreen)}
 				<div class="d2l-work-to-do-fullscreen-container">
 					<div class="d2l-heading-1 d2l-work-to-do-fullscreen-title">${this.localize('myWorkToDo')}</div>
 					<div class="d2l-overdue-collection-fullscreen">

--- a/components/d2l-work-to-do/d2l-work-to-do.js
+++ b/components/d2l-work-to-do/d2l-work-to-do.js
@@ -329,19 +329,17 @@ class WorkToDoWidget extends EntityMixinLit(LocalizeWorkToDoMixin(LitElement)) {
 				return nothing;
 			}
 
-			const immersiveNav = (isFullscreen) => {
-				return isFullscreen
-					? html`
+			const immersiveNav = () => {
+				return html`
 						<d2l-navigation-immersive back-link-href="${this._homeLinkHref}" back-link-text="${this.localize('backToD2L')}">
 							<div class="d2l-typography d2l-body-standard" slot="middle">
 								<p>${this.localize('myWorkToDo')}</p>
 							</div>
 						</d2l-navigation-immersive>`
-					: nothing;
 			};
 
 			return html`
-				${immersiveNav(this.fullscreen)}
+				${immersiveNav()}
 				<div class="d2l-work-to-do-fullscreen-container">
 					<div class="d2l-heading-1 d2l-work-to-do-fullscreen-title">${this.localize('myWorkToDo')}</div>
 					<div class="d2l-overdue-collection-fullscreen">


### PR DESCRIPTION
See rally: https://rally1.rallydev.com/#/357251704080ud/custom/367300408400?Name=Full%20page%20padding&Priority=Normal&Project=%2Fproject%2F357251704080&Requirement=%2Fhierarchicalrequirement%2F463435916636&detail=%2Fdefect%2F482551412748&iteration=u&parentRef=%2Fhierarchicalrequirement%2F463435916636&rankTo=BOTTOM

I moved the immersive navbar to be at the top level of fullscreen view instead of having a duplicate for each collection component, which was causing it to set aside extra space for the navbar for each of these components. This also undoes #1318 , because now that we're putting the immersive navbar in the correct spot, it allocates its own space at the top of the page and we no longer need to add extra padding there ourselves.