### PR TITLE
Fix hover state of w2d list items

### DIFF
--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
@@ -61,11 +61,10 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 					text-overflow: ellipsis;
 					white-space: nowrap;
 				}
-				.d2l-activity-icon-container.d2l-hovering,
-				.d2l-activity-icon-container.d2l-focusing,
-				.d2l-activity-name-container.d2l-hovering,
-				.d2l-activity-name-container.d2l-focusing {
-					--d2l-list-item-content-text-decoration: underline;
+				.d2l-hovering .d2l-activity-icon-container.has-action,
+				.d2l-focusing .d2l-activity-icon-container.has-action,
+				.d2l-hovering .d2l-activity-name-container.has-action,
+				.d2l-focusing .d2l-activity-name-container.has-action {
 					color: var(--d2l-color-celestine);
 				}
 				.d2l-icon-bullet {
@@ -83,7 +82,7 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 					padding: 0.1rem 0;
 				}
 				d2l-list-item-generic-layout {
-					background: transparent;
+					background: transparent !important; /* !important is temporary until the actionHref attribute reflection is fixed */
 				}
 				#content {
 					width: 100%;
@@ -137,6 +136,7 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 			'd2l-focusing': this._focusingLink,
 			'd2l-hovering': this._hoveringLink,
 			'd2l-skeletize': true,
+			'has-action': this.actionHref,
 		};
 
 		const nameClasses = {
@@ -144,7 +144,8 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 			'd2l-focusing': this._focusingLink,
 			'd2l-hovering': this._hoveringLink,
 			'd2l-skeletize': true,
-			'd2l-skeletize-60': true
+			'd2l-skeletize-60': true,
+			'has-action': this.actionHref,
 		};
 
 		const secondaryClasses = {

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
@@ -61,10 +61,10 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 					text-overflow: ellipsis;
 					white-space: nowrap;
 				}
-				.d2l-hovering .d2l-activity-icon-container.has-action,
-				.d2l-focusing .d2l-activity-icon-container.has-action,
-				.d2l-hovering .d2l-activity-name-container.has-action,
-				.d2l-focusing .d2l-activity-name-container.has-action {
+				.d2l-hovering .d2l-activity-icon-container.d2l-has-action,
+				.d2l-focusing .d2l-activity-icon-container.d2l-has-action,
+				.d2l-hovering .d2l-activity-name-container.d2l-has-action,
+				.d2l-focusing .d2l-activity-name-container.d2l-has-action {
 					color: var(--d2l-color-celestine);
 				}
 				.d2l-icon-bullet {
@@ -136,7 +136,7 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 			'd2l-focusing': this._focusingLink,
 			'd2l-hovering': this._hoveringLink,
 			'd2l-skeletize': true,
-			'has-action': this.actionHref,
+			'd2l-has-action': this.actionHref,
 		};
 
 		const nameClasses = {
@@ -145,7 +145,7 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 			'd2l-hovering': this._hoveringLink,
 			'd2l-skeletize': true,
 			'd2l-skeletize-60': true,
-			'has-action': this.actionHref,
+			'd2l-has-action': this.actionHref,
 		};
 
 		const secondaryClasses = {


### PR DESCRIPTION
On hover, w2d list items should have blue text, icon, and underline.

There seems to be a bug with list item mixins that always attaches the `action-href` attribute to items regardless of the value of `actionHref`. It also looks like it should be a string but is acting like a boolean. Very possible the issue is on the w2d side and it's not just keeping it in sync properly. This will be investigated separately.

Fixes:
https://rally1.rallydev.com/#/357251704080/custom/367300408400?detail=%2Fuserstory%2F464524577208&fdp=true?fdp=true

Follow-up:
https://rally1.rallydev.com/#/357251704080/search?detail=%2Fdefect%2Fa485c086-0783-44b4-9c8c-67d820148a06&keywords=background%20hover&fdp=true?fdp=true