### PR TITLE
W2D: use title property instead of name for content

### DIFF
--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
@@ -234,11 +234,17 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 
 	/** Specific name of the activity */
 	get _name() {
-		return this._activity && this._activity.hasProperty('name') && !this.skeleton
-			? this._activity.properties.name
-			: this._activityProperties && !this.skeleton
-				? this.localize(this._activityProperties.type)
-				: '';
+		if (this._activity && !this.skeleton) {
+			if (this._activity.hasProperty('name')) {
+				return this._activity.properties.name;
+			} else if (this._activity.hasProperty('title')) {
+				return this._activity.properties.title;
+			}
+		}
+		if (this._activityProperties && !this.skeleton) {
+			return this.localize(this._activityProperties.type);
+		}
+		return '';
 	}
 
 	/** Organization code of the activity's associated organization */

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
@@ -285,11 +285,17 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 
 	/** Specific name of the activity */
 	get _name() {
-		return this._activity && this._activity.hasProperty('name') && !this.skeleton
-			? this._activity.properties.name
-			: this._activityProperties && !this.skeleton
-				? this.localize(this._activityProperties.type)
-				: '';
+		if (this._activity && !this.skeleton) {
+			if (this._activity.hasProperty('name')) {
+				return this._activity.properties.name;
+			} else if (this._activity.hasProperty('title')) {
+				return this._activity.properties.title;
+			}
+		}
+		if (this._activityProperties && !this.skeleton) {
+			return this.localize(this._activityProperties.type);
+		}
+		return '';
 	}
 
 	/** Organization code of the activity's associated organization */


### PR DESCRIPTION
Rally ticket: https://rally1.rallydev.com/#/357251704080ud/workviews?detail=%2Fuserstory%2F480172231796&view=b064b584-6337-43c1-b9a9-28047568284d

tl;dr some items (e.g. course content, surveys) have a `title` instead of a `name`, so we should check for that before defaulting to the `type`

I changed the ternary operators to if statements because there was yet another condition to check for, which made it more complex - this seems easier to follow, if also more wordy.