### PR TITLE
W2D: content links now go directly to content

### DIFF
--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
@@ -198,9 +198,8 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 		if (!this._started || this.skeleton) {
 			return '';
 		}
-
-		if (this._activity && this._activity.hasLinkByType('text/html')) {
-			return this._activity.getLinkByType('text/html').href;
+		if (this._activity && this._activity.hasLinkByRel('alternate')) {
+			return this._activity.getLinkByRel('alternate').href;
 		}
 		else if (this.evaluateAllHref) {
 			return this.evaluateAllHref;

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
@@ -257,8 +257,8 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 			return '';
 		}
 
-		return this._activity && this._activity.hasLinkByType('text/html')
-			? this._activity.getLinkByType('text/html').href
+		return this._activity && this._activity.hasLinkByRel('alternate')
+			? this._activity.getLinkByRel('alternate').href
 			: '';
 	}
 


### PR DESCRIPTION
https://rally1.rallydev.com/#/357251704080ud/workviews?detail=%2Fuserstory%2F480173614388&view=b064b584-6337-43c1-b9a9-28047568284d

Context is in the Rally case as well, but broadly: we now have 3 different `text/html` links, so `getLinkByType` wasn't narrowing down enough to get us the link we actually want. I _think_ the one I get here, with the `alternate` href, is correct because in testing clicking that link would go directly to the piece of content.