### PR TITLE
DE42132: Clicking Back/Cancel on unmodified new weblinks launches warning popup

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/state/content-web-link.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/state/content-web-link.js
@@ -37,12 +37,17 @@ export class ContentWebLink {
 		this.title = webLinkEntity.title();
 
 		const entityUrlValue = webLinkEntity.url();
-		// in order to create a new weblink entity, we need to assign it a
-		// default 'garbage' url, however we want to display an empty url on first load.
-		// This does not change the actual entity.
-		this.link = entityUrlValue === defaultPlaceholderLink
-			? ''
-			: entityUrlValue;
+		if(entityUrlValue === defaultPlaceholderLink) {
+			// in order to create a new weblink entity, we need to assign it a
+			// default 'garbage' url, however we want to display an empty url on first load.
+			this.link = '';
+			// we also need to modify the entity to have no url which is needed for
+			// the dirty() method. this does not save the entity.
+			this._contentWebLink._entity.properties.url = '';
+		}
+		else {
+			this.link = entityUrlValue;
+		}
 
 		this.isExternalResource = webLinkEntity.isExternalResource();
 	}

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/state/content-web-link.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/state/content-web-link.js
@@ -37,7 +37,7 @@ export class ContentWebLink {
 		this.title = webLinkEntity.title();
 
 		const entityUrlValue = webLinkEntity.url();
-		if(entityUrlValue === defaultPlaceholderLink) {
+		if (entityUrlValue === defaultPlaceholderLink) {
 			// in order to create a new weblink entity, we need to assign it a
 			// default 'garbage' url, however we want to display an empty url on first load.
 			this.link = '';


### PR DESCRIPTION
This PR [address this defect](https://rally1.rallydev.com/#/289692574792/custom/355050439968?detail=%2Fdefect%2F486166661432&fdp=true).

When creating a new weblink then immediately hitting 'Back' or 'Cancel', a popup is launched saying "Are you sure you want to discard your changes?".

This is because when new weblinks are created, we initially set them to a default 'garbage' url. We stopped this url from being displayed to the user by clearing the link when the page is loaded (which shows an empty textbox). However, this causes a difference between the entity and what is on the page. When the `dirty()` method is called when you press 'Cancel' or 'Back', it returns true because of the difference between the default url and the empty link, which triggers the popup.

This change modifies the entity to also have an empty url for new weblinks. So when a new weblink is made, there are no changes found and the popup won't trigger.