### PR TITLE
fix: US124019 remove scroll bar from all activity-editor pages

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
@@ -43,8 +43,6 @@ class ContentEditor extends LocalizeActivityEditorMixin(RtlMixin(ActivityEditorM
 
 	constructor() {
 		super(store);
-		// Only show the scrollbar when necessary
-		document.body.style.overflow = 'auto';
 	}
 
 	connectedCallback() {

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -59,6 +59,8 @@ class ActivityEditor extends ActivityEditorContainerMixin(ActivityEditorTelemetr
 
 	constructor() {
 		super();
+		// Only show the scrollbar when necessary
+		document.body.style.overflow = 'auto';
 
 		this._backdropShown = false;
 		this._saveToastVisible = null;


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367ud/iterationstatus?detail=%2Fuserstory%2F483572068152&fdp=true

This moves the setting of the body's overflow style to the activity-editor, since we want this fix in all activity-editor pages, not just activity-content-editor. 