### PR TITLE
DE42174 Fix score-out-of throwing error on save after save-in-place

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -270,6 +270,10 @@ class ActivityScoreEditor extends SkeletonMixin(ActivityEditorMixin(LocalizeActi
 				this._setNewGradeName(this.activityName);
 			}
 		});
+
+		if (changedProperties.size === 0) {
+			this._setNewGradeName(this.activityName);
+		}
 	}
 
 	_addOrRemoveMenuItem() {


### PR DESCRIPTION
On save-in-place, the activity-usage entity is reloaded which re-instantiates the ActivityScoreGrade (from [here](https://github.com/BrightspaceHypermediaComponents/activities/blob/4af04474a3b577b096853529283f81446763b24f/components/d2l-activity-editor/state/activity-usage.js#L39)). This clears the state, so that the `ActivityScoreGrade.newGradeName` is `undefined` if the score-out-of is [saved](https://github.com/BrightspaceHypermediaComponents/activities/blob/4af04474a3b577b096853529283f81446763b24f/components/d2l-activity-editor/state/activity-usage.js#L187) after that.

Calling save with an undefined `newGradeName` throws a 400 error.

Since no props on the components are actually changing, this resets the `newGradeName` when the d2l-activity-score-editor component is updated without any changed properties.

Would love to hear if there is a more elegant way to handle this?

Ultimately this is a side-effect of the activity-usage needing to know about an assignment-activity property - the name. So that when the ActivityScoreGrade state is instantiated with the activity-usage entity, it can't know the assignment name. We're relying on the UI to [pass that value around](https://github.com/BrightspaceHypermediaComponents/activities/blob/master/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js#L148) and set it when the `activityName` [prop value changes](https://github.com/BrightspaceHypermediaComponents/activities/blob/master/components/d2l-activity-editor/d2l-activity-score-editor.js#L258).