### PR TITLE
DE42132: removing all traces of defaultPlaceHolderLink

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/constants.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/constants.js
@@ -3,5 +3,3 @@ export const ContentEditorConstants = Object.freeze({
 	TITLE_MAX_LENGTH: 150,
 	LINK_MAX_LENGTH: 1024
 });
-
-export const defaultPlaceholderLink = 'https://weblinks.api.brightspace.com/default-new-weblink';

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/state/content-web-link.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/state/content-web-link.js
@@ -1,6 +1,5 @@
 import { action, configure as configureMobx, decorate, observable } from 'mobx';
 import { ContentWebLinkEntity } from 'siren-sdk/src/activities/content/ContentWebLinkEntity.js';
-import { defaultPlaceholderLink } from '../../constants.js';
 import { fetchEntity } from '../../../state/fetch-entity.js';
 
 configureMobx({ enforceActions: 'observed' });
@@ -35,15 +34,7 @@ export class ContentWebLink {
 	load(webLinkEntity) {
 		this._contentWebLink = webLinkEntity;
 		this.title = webLinkEntity.title();
-
-		const entityUrlValue = webLinkEntity.url();
-		// in order to create a new weblink entity, we need to assign it a
-		// default 'garbage' url, however we want to display an empty url on first load.
-		// This does not change the actual entity.
-		this.link = entityUrlValue === defaultPlaceholderLink
-			? ''
-			: entityUrlValue;
-
+		this.link = webLinkEntity.url();
 		this.isExternalResource = webLinkEntity.isExternalResource();
 	}
 


### PR DESCRIPTION
Now that the [serializer returns an empty url](https://github.com/Brightspace/lms/pull/5624), we no longer need to check in the front end if the link is the default link.

Initial PR with discussion: https://github.com/BrightspaceHypermediaComponents/activities/pull/1403
PR modifying the serializer: https://github.com/Brightspace/lms/pull/5624