### PR TITLE
DE42132: Clicking Back/Cancel on modified saved weblinks/modules launches warning popup

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/state/content-module.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/state/content-module.js
@@ -42,6 +42,7 @@ export class ContentModule {
 		}
 		await this._contentModule.setModuleTitle(this.title);
 		await this._contentModule.setModuleDescription(this.descriptionRichText);
+		await this.fetch();
 	}
 
 	setDescription(richText) {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/state/content-web-link.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/state/content-web-link.js
@@ -46,6 +46,7 @@ export class ContentWebLink {
 		await this._contentWebLink.setWebLinkTitle(this.title);
 		await this._contentWebLink.setWebLinkUrl(this.link);
 		await this._contentWebLink.setWebLinkExternalResource(this.isExternalResource);
+		await this.fetch();
 	}
 
 	setExternalResource(value) {


### PR DESCRIPTION
This is something I noticed for both weblinks and modules while [making this PR](https://github.com/BrightspaceHypermediaComponents/activities/pull/1403) for [this defect](https://rally1.rallydev.com/#/289692574792/custom/355050439968?detail=%2Fdefect%2F486166661432&fdp=true) (which was specific to new weblinks).

If you go to an existing weblink OR module, modify it in someway, hit 'Save', then press 'Cancel' or 'Back', a popup launches saying "Are you sure you want to discard your changes?", even though there are no changes to be discarded.

This is because the loaded entity doesn't have the updated saved values. Any comparison done (which, if there is a difference found between the saved values and values in the inputs, launches the popup) will always be with the values on page load, not the ones that are saved.

Similar to what they do in Assignments, I added a call to re-fetch the entity when a module or weblink is saved.