### PR TITLE
fix: US123716 new html editor was not rendering correctly in FACE pages.

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -45,6 +45,9 @@ class AssignmentEditorDetail extends AsyncContainerMixin(SkeletonMixin(SaveStatu
 				:host([hidden]) {
 					display: none;
 				}
+				:host([skeleton]) .d2l-skeletize::before {
+					z-index: 2;
+				}
 				#score-and-duedate-container {
 					display: flex;
 					flex-wrap: wrap;
@@ -168,7 +171,7 @@ class AssignmentEditorDetail extends AsyncContainerMixin(SkeletonMixin(SaveStatu
 						.richtextEditorConfig="${instructionsRichTextEditorConfig}"
 						@d2l-activity-text-editor-change="${this._saveInstructionsOnChange}"
 						ariaLabel="${this.localize('instructions')}"
-						?disabled="${!canEditInstructions}">
+						?disabled="${canEditInstructions == null ? false : !canEditInstructions}">
 					</d2l-activity-text-editor>
 				</div>
 			</div>
@@ -218,7 +221,7 @@ class AssignmentEditorDetail extends AsyncContainerMixin(SkeletonMixin(SaveStatu
 		if (!assignment) {
 			return;
 		}
-
+		this._saveOnChange('instructions');
 		await assignment.save();
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -171,7 +171,7 @@ class AssignmentEditorDetail extends AsyncContainerMixin(SkeletonMixin(SaveStatu
 						.richtextEditorConfig="${instructionsRichTextEditorConfig}"
 						@d2l-activity-text-editor-change="${this._saveInstructionsOnChange}"
 						ariaLabel="${this.localize('instructions')}"
-						?disabled="${canEditInstructions == null ? false : !canEditInstructions}">
+						?disabled="${canEditInstructions === null ? false : !canEditInstructions}">
 					</d2l-activity-text-editor>
 				</div>
 			</div>

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
@@ -122,7 +122,7 @@ class QuizEditorDetail extends ActivityEditorMixin(AsyncContainerMixin(SkeletonM
 						.richtextEditorConfig="${descriptionRichTextEditorConfig}"
 						@d2l-activity-text-editor-change="${this._saveDescriptionOnChange}"
 						ariaLabel="${this.localize('description')}"
-						?disabled="${!canEditDescription}">
+						?disabled="${canEditDescription == null ? false : !canEditDescription}">
 					</d2l-activity-text-editor>
 				</div>
 			</div>

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
@@ -122,7 +122,7 @@ class QuizEditorDetail extends ActivityEditorMixin(AsyncContainerMixin(SkeletonM
 						.richtextEditorConfig="${descriptionRichTextEditorConfig}"
 						@d2l-activity-text-editor-change="${this._saveDescriptionOnChange}"
 						ariaLabel="${this.localize('description')}"
-						?disabled="${canEditDescription == null ? false : !canEditDescription}">
+						?disabled="${canEditDescription === null ? false : !canEditDescription}">
 					</d2l-activity-text-editor>
 				</div>
 			</div>


### PR DESCRIPTION
After the addition of a `disabled` property, the new html editor was not rendered correctly on FACE pages. This happened because the value of the passed-in disabled property was based on a property that is initially `null`, which caused disabled to be initially true, which meant tinymce didn't have the proper component rendered on `init`. Ensuring disabled is initially set to false allows tinymce to initialize correctly.

![image](https://user-images.githubusercontent.com/1471557/105234109-99f4c080-5b1f-11eb-8c36-6707f674dc9d.png)
