### PR TITLE
Update @brightspace-ui/htmleditor component to v1

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -16,7 +16,8 @@ class ActivityHtmlNewEditor extends LocalizeActivityEditorMixin(LitElement) {
 		return html`
 			<d2l-htmleditor
 				html="${this.value}"
-				title="${this.ariaLabel}"
+				label="${this.ariaLabel}"
+				label-hidden
 				?disabled="${this.disabled}"
 				type="inline"
 				height="7rem"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@brightspace-ui-labs/edit-in-place": "^1.0.11",
     "@brightspace-ui-labs/list-item-accumulator": "^1",
     "@brightspace-ui/core": "^1.102.2",
-    "@brightspace-ui/htmleditor": "^0",
+    "@brightspace-ui/htmleditor": "^1",
     "@brightspace-ui/intl": "^3.0.1",
     "@d2l/d2l-attachment": "Brightspace/attachment#semver:^1",
     "@polymer/iron-resizable-behavior": "^3.0.0",


### PR DESCRIPTION
We introduced a breaking change here to align how labeling works with our other input components. Once this is merged, BSI will be updated accordingly to minimize violent explosions. 😅 