### PR TITLE
Moved management of _alignmentsHref to outcomes component

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-outcomes.js
+++ b/components/d2l-activity-editor/d2l-activity-outcomes.js
@@ -3,6 +3,7 @@ import '@brightspace-ui/core/components/dialog/dialog.js';
 import 'd2l-activity-alignments/d2l-select-outcomes-hierarchical.js';
 import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
+import { fetchEntity } from './state/fetch-entity.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
@@ -18,7 +19,8 @@ class ActivityOutcomes extends ActivityEditorMixin(RtlMixin(MobxLitElement)) {
 			alignButtonText: { type: String, attribute: 'align-button-text' },
 			_opened: { type: Boolean },
 			_outcomesTerm: { type: String },
-			_browseOutcomesText: { type: String }
+			_browseOutcomesText: { type: String },
+			_alignmentsHref: { type: String }
 		};
 	}
 
@@ -45,7 +47,6 @@ class ActivityOutcomes extends ActivityEditorMixin(RtlMixin(MobxLitElement)) {
 		this._browseOutcomesText = this._dispatchRequestProvider('d2l-provider-browse-outcomes-text');
 		this._outcomesTerm = this._dispatchRequestProvider('d2l-provider-outcomes-term');
 	}
-
 	render() {
 		const activity = store.get(this.href);
 		if (!activity) {
@@ -57,10 +58,14 @@ class ActivityOutcomes extends ActivityEditorMixin(RtlMixin(MobxLitElement)) {
 			alignmentsHref
 		} = activity;
 
-		if (!canUpdateAlignments && !this._hasAlignments || this._hasAlignments === undefined) {
+		if (!canUpdateAlignments && !this._hasAlignments) {
 			this.hidden = true;
 		} else {
 			this.hidden = false;
+		}
+
+		if (alignmentsHref) {
+			this._alignmentsHref = alignmentsHref;
 		}
 
 		return html`
@@ -72,7 +77,7 @@ class ActivityOutcomes extends ActivityEditorMixin(RtlMixin(MobxLitElement)) {
 				?opened="${this._opened}"
 				@d2l-dialog-close="${this._closeDialog}">
 				<d2l-select-outcomes-hierarchical
-					href="${alignmentsHref}"
+					href="${this.__alignmentsHref}"
 					.token="${this.token}"
 					.alignButtonText="${this.alignButtonText}"
 					@d2l-alignment-list-added="${this._onDialogAdd}"
@@ -81,6 +86,19 @@ class ActivityOutcomes extends ActivityEditorMixin(RtlMixin(MobxLitElement)) {
 			</d2l-dialog>` : null}
 		`;
 	}
+
+	set _alignmentsHref(value) {
+		const oldValue = this.__alignmentsHref;
+
+		if (oldValue !== value) {
+			this.__alignmentsHref = value;
+
+			if (this.token) {
+				this._fetch(() => fetchEntity(this.__alignmentsHref, this.token));
+			}
+		}
+	}
+
 	_alignmentTagsEmptyChanged(e) {
 		this._hasAlignments = !!(e.detail.entities && e.detail.entities.length);
 		this.requestUpdate();

--- a/components/d2l-activity-editor/d2l-activity-outcomes.js
+++ b/components/d2l-activity-editor/d2l-activity-outcomes.js
@@ -58,7 +58,7 @@ class ActivityOutcomes extends ActivityEditorMixin(RtlMixin(MobxLitElement)) {
 			alignmentsHref
 		} = activity;
 
-		if (!canUpdateAlignments && !this._hasAlignments) {
+		if (!canUpdateAlignments && !this._hasAlignments || this._hasAlignments === undefined) {
 			this.hidden = true;
 		} else {
 			this.hidden = false;


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=/defect/486581000692

Implemented Martin's solution for standards/alignments loading. Looking at the network tab I cannot see this adding any additional requests. 

The result is that the standards button renders in sync with the end of the skeleton loading but the tags are still slightly delayed:

![standardsLoading](https://user-images.githubusercontent.com/46040098/105416795-86b12600-5bef-11eb-9da7-bb344bb78261.gif)