### PR TITLE
DE42177 - tooltip is out of position when saved and there is an error

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-title.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-title.js
@@ -106,7 +106,7 @@ class ContentEditorTitle extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivi
 			timeOut.after(ContentEditorConstants.DEBOUNCE_TIMEOUT),
 			() => {
 				if (isTitleEmpty) {
-					this.setError('_titleError', 'content.emptyNameField', 'title-tooltip');
+					this.setError('_titleError', 'content.emptyNameField');
 				}
 				else {
 					this.clearError('_titleError');

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-editor-link.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-editor-link.js
@@ -135,7 +135,7 @@ class ContentEditorLink extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 			timeOut.after(ContentEditorConstants.DEBOUNCE_TIMEOUT),
 			() => {
 				if (invalidWeblinkError) {
-					this.setError('_linkError', invalidWeblinkError, 'link-tooltip');
+					this.setError('_linkError', invalidWeblinkError);
 				}
 				else {
 					this.clearError('_linkError');

--- a/components/d2l-activity-editor/error-handling-mixin.js
+++ b/components/d2l-activity-editor/error-handling-mixin.js
@@ -5,11 +5,11 @@ export const ErrorHandlingMixin = superclass => class extends LocalizeMixin(supe
 	clearError(errorProperty) {
 		this[errorProperty] = '';
 	}
-	async setError(errorProperty, langterm, tooltipId) {
+	async setError(errorProperty, langterm, tooltipIdToForceShow) {
 		this[errorProperty] = this.localize(langterm);
 
 		await this.updateComplete;
-		this._showTooltip(tooltipId);
+		this._showTooltip(tooltipIdToForceShow);
 	}
 
 	_showTooltip(tooltipId) {


### PR DESCRIPTION
[Rally defect link](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F486456166756&fdp=true?fdp=true)

The `ErrorHandlingMixin.setError()` function lets you provide a `tooltipId` that it will show even if the input no longer has focus and isn't being hovered. This means that the tooltip is rendered before the `d2l-activity-editor` re-renders itself and adds the alert, so the tooltip stays in the spot it was originally rendered.

Here I'm not passing in the `tooltipId` to the `ErrorHandlingMixin.setError()` function so that the tooltip is not rendered if the user isn't focused on the input or hovering over it. When the error happens, the `d2l-activity-editor` component (through the `ActivityEditorContainerMixin`) still focuses on the input on save when there's an error, so the tooltip still shows up when you save, but in the right position.

I'm also changing `d2l-activity-content-editor-title` because the same issue happens there as well.

![DE42177_tooltip](https://user-images.githubusercontent.com/64805612/105503887-1eb51b00-5c95-11eb-990b-74097c160eb6.gif)


