### PR TITLE
W2D: show Start Dates in the future

### DIFF
--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
@@ -16,6 +16,7 @@ import { LocalizeWorkToDoMixin } from './localization';
 import { nothing } from 'lit-html';
 import { QuickEvalActivityAllowList } from '../d2l-quick-eval-widget/env';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin';
+import { formatDate } from '@brightspace-ui/intl/lib/dateTime';
 
 class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinLit(LocalizeWorkToDoMixin(LitElement)))) {
 
@@ -164,8 +165,15 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 
 		const dateTemplate = html `<d2l-activity-date href="${this.href}" .token="${this.token}" format="MMM d" ?hidden=${this.skeleton}></d2l-activity-date>`;
 
-		const separatorTemplate = !this.skeletize && this._date && (this._orgName || this._orgCode)
+		const separatorTemplate = !this.skeleton && this._date && (this._orgName || this._orgCode)
 			? html `<d2l-icon class="d2l-icon-bullet" icon="tier1:bullet"></d2l-icon>`
+			: nothing;
+
+		const startDateTemplate = !this.skeleton && !this._started
+			? html `
+			<div class="d2l-status-container">
+				<d2l-status-indicator state="none" text="${this._startDateFormatted}"></d2l-status-indicator>
+			</div>`
 			: nothing;
 
 		return html `${this._renderListItem({
@@ -194,9 +202,8 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 				</d2l-list-item-content>
 			`
 		})}
-		<div class="d2l-status-container">
-			<d2l-status-indicator state="none" text="Starts Aug. 15"></d2l-status-indicator>
-		</div>`;
+		${startDateTemplate}
+		`;
 	}
 
 	set actionHref(href) {  // This is a hack - Garbage setter function since list-mixin initializes value
@@ -231,6 +238,13 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 		return this._usage && this._usage.startDate()
 			? new Date(this._usage.startDate()) < new Date()
 			: true;
+	}
+
+	/** Start Date formatted like (Short month) (Day) e.g. "Aug 15" */
+	get _startDateFormatted() {
+		return `Starts ${this._usage && this._usage.startDate()
+			? formatDate(new Date(this._usage.startDate()), { format: 'shortMonthDay' })
+			: undefined}`;
 	}
 
 	/** String associated with icon catalogue for provided activity type */

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
@@ -1,6 +1,7 @@
 import '@brightspace-ui/core/components/colors/colors';
 import '@brightspace-ui/core/components/icons/icon';
 import '@brightspace-ui/core/components/list/list-item-content';
+import '@brightspace-ui/core/components/status-indicator/status-indicator.js';
 import '../d2l-activity-date/d2l-activity-date';
 import '../d2l-quick-eval-widget/d2l-quick-eval-widget-submission-icon';
 
@@ -78,6 +79,12 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 					overflow: hidden;
 					text-overflow: ellipsis;
 					white-space: nowrap;
+				}
+				.d2l-status-container {
+					clear: both;
+					margin-top: -0.1rem;
+					margin-left: 2.1rem;
+					margin-bottom: 0.5rem;
 				}
 				[slot="content"] {
 					padding: 0.1rem 0;
@@ -161,7 +168,7 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 			? html `<d2l-icon class="d2l-icon-bullet" icon="tier1:bullet"></d2l-icon>`
 			: nothing;
 
-		return this._renderListItem({
+		return html `${this._renderListItem({
 			illustration: this.submissionCount ? html`
 					<d2l-quick-eval-widget-submission-icon style="overflow: visible;"
 						class="class=${classMap(iconClasses)}"
@@ -186,7 +193,10 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 					</div>
 				</d2l-list-item-content>
 			`
-		});
+		})}
+		<div class="d2l-status-container">
+			<d2l-status-indicator state="none" text="Starts Aug. 15"></d2l-status-indicator>
+		</div>`;
 	}
 
 	set actionHref(href) {  // This is a hack - Garbage setter function since list-mixin initializes value

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
@@ -82,10 +82,8 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 					white-space: nowrap;
 				}
 				.d2l-status-container {
-					clear: both;
-					margin-top: -0.1rem;
-					margin-left: 2.1rem;
-					margin-bottom: 0.5rem;
+					margin-top: 0.1rem;
+					margin-bottom: 0.1rem;
 				}
 				[slot="content"] {
 					padding: 0.1rem 0;
@@ -176,7 +174,7 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 			</div>`
 			: nothing;
 
-		return html `${this._renderListItem({
+		return this._renderListItem({
 			illustration: this.submissionCount ? html`
 					<d2l-quick-eval-widget-submission-icon style="overflow: visible;"
 						class="class=${classMap(iconClasses)}"
@@ -198,12 +196,11 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 						${dateTemplate}
 						${separatorTemplate}
 						${this._orgName || this._orgCode}
+						${startDateTemplate}
 					</div>
 				</d2l-list-item-content>
 			`
-		})}
-		${startDateTemplate}
-		`;
+		});
 	}
 
 	set actionHref(href) {  // This is a hack - Garbage setter function since list-mixin initializes value

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
@@ -82,8 +82,8 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 					white-space: nowrap;
 				}
 				.d2l-status-container {
-					margin-top: 0.1rem;
 					margin-bottom: 0.1rem;
+					margin-top: 0.1rem;
 				}
 				[slot="content"] {
 					padding: 0.1rem 0;

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
@@ -239,9 +239,10 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 
 	/** Start Date formatted like (Short month) (Day) e.g. "Aug 15" */
 	get _startDateFormatted() {
-		return `Starts ${this._usage && this._usage.startDate()
-			? formatDate(new Date(this._usage.startDate()), { format: 'shortMonthDay' })
-			: undefined}`;
+		return this.localize('StartsWithDate', 'startDate',
+			this._usage && this._usage.startDate()
+				? formatDate(new Date(this._usage.startDate()), { format: 'shortMonthDay' })
+				: '');
 	}
 
 	/** String associated with icon catalogue for provided activity type */

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
@@ -248,7 +248,7 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 						${this._orgName || this._orgCode}
 					</div>
 					<div id="content-supporting-info-container" slot="supporting-info" class=${classMap(supportingClasses)}>
-					${this._description}
+						${this._description}
 					</div>
 				</d2l-list-item-content>
 			`

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
@@ -336,9 +336,10 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 
 	/** Start Date formatted like (Short month) (Day) e.g. "Aug 15" */
 	get _startDateFormatted() {
-		return `Starts ${this._usage && this._usage.startDate()
-			? formatDate(new Date(this._usage.startDate()), { format: 'shortMonthDay' })
-			: undefined}`;
+		return this.localize('StartsWithDate', 'startDate',
+			this._usage && this._usage.startDate()
+				? formatDate(new Date(this._usage.startDate()), { format: 'shortMonthDay' })
+				: '');
 	}
 
 	get _type() {

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
@@ -100,12 +100,10 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 					overflow: hidden;
 					text-overflow: ellipsis;
 				}
-				.d2l-supporting-info-show-start-date {
-					display: flex;
-					flex-direction: column;
-				}
 				.d2l-status-container {
+					display: inline;
 					margin-bottom: 0.5rem;
+					margin-right: 0.2rem;
 					margin-top: -0.5rem;
 				}
 				[slot="content"] {
@@ -202,8 +200,8 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 
 		const supportingClasses = {
 			'd2l-body-compact': true,
+			'd2l-supporting-info-content-container': true,
 			'd2l-skeletize-paragraph-2': true,
-			'd2l-supporting-info-show-start-date': !this._started
 		};
 
 		const dateTemplate = this.includeDate
@@ -244,15 +242,13 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 						${this._name}
 					</div>
 					<div class=${classMap(secondaryClasses)} slot="secondary">
+						${startDateTemplate}
 						${this._type}
 						${separatorTemplate}
 						${this._orgName || this._orgCode}
 					</div>
 					<div id="content-supporting-info-container" slot="supporting-info" class=${classMap(supportingClasses)}>
-						<div class="d2l-supporting-info-content-container">
-							${this._description}
-						</div>
-						${startDateTemplate}
+					${this._description}
 					</div>
 				</d2l-list-item-content>
 			`

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
@@ -14,6 +14,7 @@ import { ListItemLinkMixin } from '@brightspace-ui/core/components/list/list-ite
 import { LocalizeWorkToDoMixin } from './localization';
 import { nothing } from 'lit-html';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin';
+import { formatDate } from '@brightspace-ui/intl/lib/dateTime';
 
 class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMixinLit(LocalizeWorkToDoMixin(LitElement)))) {
 
@@ -98,6 +99,14 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 					max-width: inherit;
 					overflow: hidden;
 					text-overflow: ellipsis;
+				}
+				.d2l-supporting-info-show-start-date {
+					display: flex;
+					flex-direction: column;
+				}
+				.d2l-status-container {
+					margin-top: -0.5rem;
+					margin-bottom: 0.5rem;
 				}
 				[slot="content"] {
 					padding: 0;
@@ -193,8 +202,9 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 
 		const supportingClasses = {
 			'd2l-body-compact': true,
-			'd2l-supporting-info-content-container': true,
-			'd2l-skeletize-paragraph-2': true
+			/* 'd2l-supporting-info-content-container': true, */
+			'd2l-skeletize-paragraph-2': true,
+			'd2l-supporting-info-show-start-date': !this._started
 		};
 
 		const dateTemplate = this.includeDate
@@ -215,6 +225,15 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 			? html `<d2l-icon class="d2l-icon-bullet" icon="tier1:bullet"></d2l-icon>`
 			: nothing;
 
+		//display: -webkit-box;
+
+		const startDateTemplate = !this.skeleton && !this._started
+			? html `
+			<div class="d2l-status-container">
+				<d2l-status-indicator state="none" text="${this._startDateFormatted}"></d2l-status-indicator>
+			</div>`
+			: nothing;
+
 		const listItemTemplate = this._renderListItem({
 			illustration: html`
 				<d2l-icon
@@ -233,9 +252,12 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 						${this._orgName || this._orgCode}
 					</div>
 					<div id="content-supporting-info-container" slot="supporting-info" class=${classMap(supportingClasses)}>
-						${this._description}
+						<div class="d2l-supporting-info-content-container">
+							${this._description}
+						</div>
+						${startDateTemplate}
 					</div>
-				</d2l-list-item-content>
+					</d2l-list-item-content>
 			`
 		});
 
@@ -270,9 +292,10 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 	}
 
 	get _description() {
-		return this._activity && this._activity.hasProperty('description') && !this.skeleton
-			? this._activity.properties.description
-			: '';
+		return 'A long description that should take up multiple lines. This probably isn\'t long enough yet. It should take a few more words. Are we there yet? This should actually be more than two lines to be totally accurate. This would be much easier if I just gave the item itself a description, but it\'s hard-coded now.';
+		// return this._activity && this._activity.hasProperty('description') && !this.skeleton
+		// 	? this._activity.properties.description
+		// 	: '';
 	}
 
 	/** String associated with icon catalogue for provided activity type */
@@ -317,6 +340,13 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 		return this._usage && this._usage.startDate()
 			? new Date(this._usage.startDate()) < new Date()
 			: true;
+	}
+
+	/** Start Date formatted like (Short month) (Day) e.g. "Aug 15" */
+	get _startDateFormatted() {
+		return `Starts ${this._usage && this._usage.startDate()
+			? formatDate(new Date(this._usage.startDate()), { format: 'shortMonthDay' })
+			: undefined}`;
 	}
 
 	get _type() {

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
@@ -202,7 +202,6 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 
 		const supportingClasses = {
 			'd2l-body-compact': true,
-			/* 'd2l-supporting-info-content-container': true, */
 			'd2l-skeletize-paragraph-2': true,
 			'd2l-supporting-info-show-start-date': !this._started
 		};
@@ -255,7 +254,7 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 						</div>
 						${startDateTemplate}
 					</div>
-					</d2l-list-item-content>
+				</d2l-list-item-content>
 			`
 		});
 
@@ -290,10 +289,9 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 	}
 
 	get _description() {
-		return 'A long description that should take up multiple lines. This probably isn\'t long enough yet. It should take a few more words. Are we there yet? This should actually be more than two lines to be totally accurate. This would be much easier if I just gave the item itself a description, but it\'s hard-coded now.';
-		// return this._activity && this._activity.hasProperty('description') && !this.skeleton
-		// 	? this._activity.properties.description
-		// 	: '';
+		return this._activity && this._activity.hasProperty('description') && !this.skeleton
+			? this._activity.properties.description
+			: '';
 	}
 
 	/** String associated with icon catalogue for provided activity type */

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
@@ -105,8 +105,8 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 					flex-direction: column;
 				}
 				.d2l-status-container {
-					margin-top: -0.5rem;
 					margin-bottom: 0.5rem;
+					margin-top: -0.5rem;
 				}
 				[slot="content"] {
 					padding: 0;

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
@@ -225,8 +225,6 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 			? html `<d2l-icon class="d2l-icon-bullet" icon="tier1:bullet"></d2l-icon>`
 			: nothing;
 
-		//display: -webkit-box;
-
 		const startDateTemplate = !this.skeleton && !this._started
 			? html `
 			<div class="d2l-status-container">

--- a/components/d2l-work-to-do/lang/en.js
+++ b/components/d2l-work-to-do/lang/en.js
@@ -17,6 +17,7 @@ export const val = {
 	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
 	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
 	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
 	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
 	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
 	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work

--- a/components/d2l-work-to-do/lang/es.js
+++ b/components/d2l-work-to-do/lang/es.js
@@ -17,6 +17,7 @@ export const val = {
 	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
 	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
 	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
 	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
 	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
 	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work

--- a/components/d2l-work-to-do/lang/fr.js
+++ b/components/d2l-work-to-do/lang/fr.js
@@ -17,6 +17,7 @@ export const val = {
 	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
 	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
 	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
 	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
 	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
 	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work

--- a/components/d2l-work-to-do/lang/ja.js
+++ b/components/d2l-work-to-do/lang/ja.js
@@ -17,6 +17,7 @@ export const val = {
 	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
 	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
 	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
 	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
 	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
 	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work

--- a/components/d2l-work-to-do/lang/ko.js
+++ b/components/d2l-work-to-do/lang/ko.js
@@ -17,6 +17,7 @@ export const val = {
 	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
 	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
 	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
 	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
 	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
 	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work

--- a/components/d2l-work-to-do/lang/nl.js
+++ b/components/d2l-work-to-do/lang/nl.js
@@ -17,6 +17,7 @@ export const val = {
 	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
 	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
 	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
 	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
 	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
 	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work

--- a/components/d2l-work-to-do/lang/pt.js
+++ b/components/d2l-work-to-do/lang/pt.js
@@ -17,6 +17,7 @@ export const val = {
 	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
 	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
 	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
 	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
 	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
 	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work

--- a/components/d2l-work-to-do/lang/sv.js
+++ b/components/d2l-work-to-do/lang/sv.js
@@ -17,6 +17,7 @@ export const val = {
 	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
 	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
 	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
 	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
 	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
 	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work

--- a/components/d2l-work-to-do/lang/tr.js
+++ b/components/d2l-work-to-do/lang/tr.js
@@ -17,6 +17,7 @@ export const val = {
 	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
 	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
 	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
 	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
 	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
 	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work

--- a/components/d2l-work-to-do/lang/zh-tw.js
+++ b/components/d2l-work-to-do/lang/zh-tw.js
@@ -17,6 +17,7 @@ export const val = {
 	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
 	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
 	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
 	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
 	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
 	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work

--- a/components/d2l-work-to-do/lang/zh.js
+++ b/components/d2l-work-to-do/lang/zh.js
@@ -17,6 +17,7 @@ export const val = {
 	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
 	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
 	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
 	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
 	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
 	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work


### PR DESCRIPTION
For context, we want to show "Starts (Month) (Date)" for items that start in the future, because otherwise people who see them in W2D would be confused why they aren't clickable. 

See: https://rally1.rallydev.com/#/357251704080d/workviews?detail=%2Fuserstory%2F483215752572&view=b064b584-6337-43c1-b9a9-28047568284d&fdp=true?fdp=true

Note: the `d2l-status-indicator` component doesn't exactly match the mockups (note that the production version has the text in all caps). I'm inclined to use the component as-is because it's probably consistent with other, similar places in Brightspace