### PR TITLE
Changed date pickers to render as disabed if user lacks permissions

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
@@ -37,17 +37,14 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeActiv
 			endDateError
 		} = this._getDateValues();
 
-		if (!canEditDates) {
-			return html``;
-		}
-
 		return html`
 			<d2l-input-date-time
 				id="start-date-input"
 				label="${this.localize('editor.startDate')}"
 				time-default-value="startOfDay"
 				value="${startDate}"
-				@change="${this._onStartDatetimeChanged}">
+				@change="${this._onStartDatetimeChanged}"
+				?disabled="${!canEditDates}">
 			</d2l-input-date-time>
 			<d2l-validation-custom
 				for="start-date-input"
@@ -59,7 +56,8 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeActiv
 				label="${this.localize('editor.endDate')}"
 				time-default-value="endOfDay"
 				value="${endDate}"
-				@change="${this._onEndDatetimeChanged}">
+				@change="${this._onEndDatetimeChanged}"
+				?disabled="${!canEditDates}">
 			</d2l-input-date-time>
 			<d2l-validation-custom
 				for="end-date-input"

--- a/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-availability-dates-editor.js
@@ -98,7 +98,6 @@ class ActivityAvailabilityDatesEditor extends (ActivityEditorMixin(LocalizeActiv
 
 		if (!dates.canEditDates) {
 			datesEntity.canEditDates = false;
-			return datesEntity;
 		}
 
 		if (dates.startDateErrorTerm) {

--- a/components/d2l-activity-editor/d2l-activity-due-date-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-due-date-editor.js
@@ -33,10 +33,6 @@ class ActivityDueDateEditor extends SkeletonMixin(ActivityEditorMixin(LocalizeAc
 			dueDateError
 		} = this._getDateValues();
 
-		if (!canEditDates) {
-			return html``;
-		}
-
 		return html`
 		 	<d2l-input-date-time
 				?skeleton="${this.skeleton}"
@@ -44,7 +40,8 @@ class ActivityDueDateEditor extends SkeletonMixin(ActivityEditorMixin(LocalizeAc
 				label="${this.localize('editor.dueDate')}"
 				time-default-value="endOfDay"
 				value="${dueDate}"
-				@change="${this._onDatetimeChanged}">
+				@change="${this._onDatetimeChanged}"
+				?disabled="${!canEditDates}">
 			</d2l-input-date-time>
 			<d2l-validation-custom
 				for="due-date-input"

--- a/components/d2l-activity-editor/d2l-activity-due-date-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-due-date-editor.js
@@ -76,7 +76,6 @@ class ActivityDueDateEditor extends SkeletonMixin(ActivityEditorMixin(LocalizeAc
 
 		if (!dates.canEditDates) {
 			datesEntity.canEditDates = false;
-			return datesEntity;
 		}
 
 		if (dates.dueDateErrorTerm) {

--- a/test/d2l-activity-editor/d2l-activity-availability-dates-editor.test.js
+++ b/test/d2l-activity-editor/d2l-activity-availability-dates-editor.test.js
@@ -44,7 +44,7 @@ describe('d2l-activity-availability-dates-editor', function() {
 		});
 	});
 
-	describe('inputs hidden', function() {
+	describe('inputs disabled', function() {
 		beforeEach(async() => {
 			dates.setCanEditDates(false);
 			await elementUpdated(el);
@@ -53,9 +53,9 @@ describe('d2l-activity-availability-dates-editor', function() {
 			endDateInput = el.shadowRoot.querySelector('#end-date-input');
 		});
 
-		it('hides both availability date inputs if not allowed to edit', async() => {
-			expect(startDateInput).to.not.exist;
-			expect(endDateInput).to.not.exist;
+		it('renders disabled date inputs if not allowed to edit', async() => {
+			expect(startDateInput).to.have.attr('disabled');
+			expect(endDateInput).to.have.attr('disabled');
 		});
 	});
 


### PR DESCRIPTION
Based on this trello card: https://trello.com/c/79bACFo0/301-when-missing-delivery-permissions-date-fields-are-hidden-instead-of-disabled

The idea is that if a user doesn't have permissions to edit dates then it will show as a read only picker instead of not rendering at all. 

Without content:

![image](https://user-images.githubusercontent.com/46040098/105550578-6f893b80-5cb6-11eb-8e28-6d2d9fb6fc31.png)

With content:

![image](https://user-images.githubusercontent.com/46040098/105552327-9cd6e900-5cb8-11eb-9281-c94f996b3a50.png)


I noticed `d2l-activity-availability-dates-editor` is being used by Assignments, Quizzing and Content so should probably get someone from the Content team on this PR as well. 
