### PR TITLE
Identify links from quick-eval-widget as coming from quick-eval

### DIFF
--- a/components/d2l-quick-eval-widget/d2l-quick-eval-widget-controller.js
+++ b/components/d2l-quick-eval-widget/d2l-quick-eval-widget-controller.js
@@ -27,7 +27,9 @@ export async function fetchEvaluateAllHref(activityUsageEntity, token) {
 
 	const evaluationStatusEntity = await fetch(evalStatusLink, token);
 
-	return evaluationStatusEntity.getSubEntityByRel('https://assessments.api.brightspace.com/rels/assess-all-application').properties.path;
+	const url = new URL(evaluationStatusEntity.getSubEntityByRel('https://assessments.api.brightspace.com/rels/assess-all-application').properties.path);
+	url.searchParams.append('cft', 'qe');
+	return url;
 }
 
 export async function setToggleState(href, toggleState) {


### PR DESCRIPTION
Fix for 500 errors when clicking on discussions in quick-eval-widget