### PR TITLE
fix: DE42230: Allow rel path for w2d entity fetch.

### DIFF
--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
@@ -201,11 +201,16 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 
 		if (this.evaluateAllHref) {
 			return this.evaluateAllHref;
-		}
-		else if (this._activity && this._activity.hasLinkByRel('alternate')) {
+		} else if (
+			this._activity
+			&& this._activityProperties
+			&& this._activityProperties.linkRel
+			&& this._activity.hasLinkByRel(this._activityProperties.linkRel)) {
+
+			return this._activity.getLinkByRel(this._activityProperties.linkRel).href;
+		} else if (this._activity && this._activity.hasLinkByRel('alternate')) {
 			return this._activity.getLinkByRel('alternate').href;
-		}
-		else {
+		} else {
 			return '';
 		}
 	}
@@ -276,20 +281,30 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 		for (const allowed in allowList) {
 			if (entity.hasClass(allowList[allowed].class)) {
 				this._activityProperties = allowList[allowed];
-				const source = (
-					entity.hasLinkByRel(allowList[allowed].rel)
-					&& entity.getLinkByRel(allowList[allowed].rel)
-					|| {}).href;
-				if (source) {
-					await fetchEntity(source, this.token)
-						.then((sirenEntity) => {
-							if (sirenEntity) {
-								this._activity = sirenEntity;
-							}
-						});
+				const relList = [].concat(this._activityProperties.rel);
+
+				const foundEntity = await this._followRelPath(relList, entity);
+
+				if (foundEntity) {
+					this._activity = foundEntity;
 				}
 			}
 		}
+	}
+
+	async _followRelPath(relList, entity) {
+		if (relList.length === 0) return entity;
+
+		const source = (
+			entity.hasLinkByRel(relList[0])
+			&& entity.getLinkByRel(relList[0])
+			|| {}).href;
+
+		if (source) {
+			return await this._followRelPath(relList.slice(1), await fetchEntity(source, this.token));
+		}
+
+		return null;
 	}
 
 	/**

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
@@ -6,7 +6,7 @@ import '../d2l-quick-eval-widget/d2l-quick-eval-widget-submission-icon';
 
 import { css, html, LitElement } from 'lit-element/lit-element';
 import { ActivityUsageEntity } from 'siren-sdk/src/activities/ActivityUsageEntity';
-import { ActivityAllowList, HideOrgNameClasses } from './env';
+import { ActivityAllowList, HideOrgInfoClasses } from './env';
 import { classMap } from 'lit-html/directives/class-map';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { fetchEntity } from './state/fetch-entity';
@@ -292,8 +292,15 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 		}
 	}
 
+	/**
+	 * Follows a list of rels beginning at a specific entity.
+	 * @async
+	 * @param {String[]} relList List of rels to follow
+	 * @param {object} entity Beginning entity
+	 * @returns {object|null|undefined} The entity at the end of the rel path. {null|undefined} if an entity in the chain is missing or doesn't have the next rel.
+	 */
 	async _followRelPath(relList, entity) {
-		if (relList.length === 0) return entity;
+		if (!entity || relList.length === 0) return entity;
 
 		const source = (
 			entity.hasLinkByRel(relList[0])
@@ -315,7 +322,7 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 		if (!this._usage) return;
 
 		const entity = this._usage._entity;
-		const hiddenClass = HideOrgNameClasses.find(hiddenClass => entity.hasClass(hiddenClass));
+		const hiddenClass = HideOrgInfoClasses.find(hiddenClass => entity.hasClass(hiddenClass));
 
 		if (!hiddenClass) {
 			const organizationHref = this._usage.organizationHref();

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
@@ -6,7 +6,7 @@ import '../d2l-quick-eval-widget/d2l-quick-eval-widget-submission-icon';
 
 import { css, html, LitElement } from 'lit-element/lit-element';
 import { ActivityUsageEntity } from 'siren-sdk/src/activities/ActivityUsageEntity';
-import { ActivityAllowList } from './env';
+import { ActivityAllowList, HideOrgNameClasses } from './env';
 import { classMap } from 'lit-html/directives/class-map';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { fetchEntity } from './state/fetch-entity';
@@ -314,12 +314,17 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 	async _loadOrganization() {
 		if (!this._usage) return;
 
-		const organizationHref = this._usage.organizationHref();
-		if (organizationHref) {
-			await fetchEntity(organizationHref, this.token)
-				.then((organization) => {
-					this._organization = organization;
-				});
+		const entity = this._usage._entity;
+		const hiddenClass = HideOrgNameClasses.find(hiddenClass => entity.hasClass(hiddenClass));
+
+		if (!hiddenClass) {
+			const organizationHref = this._usage.organizationHref();
+			if (organizationHref) {
+				await fetchEntity(organizationHref, this.token)
+					.then((organization) => {
+						this._organization = organization;
+					});
+			}
 		}
 	}
 }

--- a/components/d2l-work-to-do/env/index.js
+++ b/components/d2l-work-to-do/env/index.js
@@ -15,6 +15,13 @@ export const Constants = {
 	PageSize: 20,
 };
 
+/**
+ * class [string]: Used to match the entity class
+ * icon [string]: Icon to display in the list
+ * rel [string | string[]]: Rel link to follow to fetch the entity, if an array it will follow the chain.
+ * linkRel [string | undefined]: Rel to use when getting the href for the item, default is 'alternate'.
+ * type: [string]: Name of the entity type to localize
+ */
 export const ActivityAllowList = {
 	userAssignmentActivity: {
 		class: Classes.activities.userAssignmentActivity,
@@ -37,7 +44,8 @@ export const ActivityAllowList = {
 	userCourseOfferingActivity: {
 		class: Classes.activities.userCourseOfferingActivity,
 		icon: 'tier2:syllabus',
-		rel: Rels.courseOfferingInfoPage,
+		rel: [ Rels.userEnrollment, Rels.organization ],
+		linkRel: Rels.organizationHomepage,
 		type: 'Course'
 	},
 	userDiscussionActivity: {

--- a/components/d2l-work-to-do/env/index.js
+++ b/components/d2l-work-to-do/env/index.js
@@ -75,7 +75,7 @@ export const ActivityAllowList = {
 };
 
 /** Entity classes that hides the org name in the supporting info */
-export const HideOrgNameClasses = [ Classes.activities.userCourseOfferingActivity ];
+export const HideOrgInfoClasses = [ Classes.activities.userCourseOfferingActivity ];
 
 export function getUpcomingWeekLimit() {
 	if (window.D2L && window.D2L.workToDoOptions && window.D2L.workToDoOptions.upcomingWeekLimit) {

--- a/components/d2l-work-to-do/env/index.js
+++ b/components/d2l-work-to-do/env/index.js
@@ -74,6 +74,9 @@ export const ActivityAllowList = {
 	}
 };
 
+/** Entity classes that hides the org name in the supporting info */
+export const HideOrgNameClasses = [ Classes.activities.userCourseOfferingActivity ];
+
 export function getUpcomingWeekLimit() {
 	if (window.D2L && window.D2L.workToDoOptions && window.D2L.workToDoOptions.upcomingWeekLimit) {
 		return window.D2L.workToDoOptions.upcomingWeekLimit;


### PR DESCRIPTION
https://rally1.rallydev.com/#/357251704080d/custom/367300408400?detail=%2Fdefect%2F486936639864&fdp=true?fdp=true

Allow for a list of rels to sequentially follow when fetching an item's entity.
This is to allow for following entities like user enrollments that link to an organization.
Added linkRel to environment to specify a REL that the item's href should use.
Added config to hide org information for some entity classes, and hide the information for course offerings.