### PR TITLE
fix: preview web links skeleton

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-url-preview.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-url-preview.js
@@ -49,13 +49,13 @@ class ContentWebLinkUrlPreview extends SkeletonMixin(LocalizeActivityEditorMixin
 		attachment.url = this.entity.link;
 
 		return html`
-	    <label class="d2l-label-text">${this.localize('content.previewLabel')}</label>
-		<d2l-labs-attachment
-			?hidden="${this.skeleton}"
-			.attachmentId="${attachment.id}"
-			.attachment="${attachment}"
-		>
-		</d2l-labs-attachment>
+			<label class="d2l-label-text">${this.localize('content.previewLabel')}</label>
+			<d2l-labs-attachment
+				?hidden="${this.skeleton}"
+				.attachmentId="${attachment.id}"
+				.attachment="${attachment}"
+			>
+			</d2l-labs-attachment>
 		`;
 	}
 }


### PR DESCRIPTION
fix: I am so smart! SMRT!

This small indent fix will create a new patch release that includes the changes from https://github.com/BrightspaceHypermediaComponents/activities/pull/1402