### PR TITLE
Using placeholder to format evaluation href

### DIFF
--- a/components/d2l-quick-eval-widget/d2l-quick-eval-widget-controller.js
+++ b/components/d2l-quick-eval-widget/d2l-quick-eval-widget-controller.js
@@ -27,9 +27,12 @@ export async function fetchEvaluateAllHref(activityUsageEntity, token) {
 
 	const evaluationStatusEntity = await fetch(evalStatusLink, token);
 
-	const url = new URL(evaluationStatusEntity.getSubEntityByRel('https://assessments.api.brightspace.com/rels/assess-all-application').properties.path);
-	url.searchParams.append('cft', 'qe');
-	return url;
+	const path = evaluationStatusEntity.getSubEntityByRel('https://assessments.api.brightspace.com/rels/assess-all-application').properties.path;
+	const placeHolderHost = 'http://fake.commm';
+	const newUrl = new URL(path, placeHolderHost);
+	newUrl.searchParams.append('cft', 'qe');
+
+	return newUrl.pathname + newUrl.search;
 }
 
 export async function setToggleState(href, toggleState) {


### PR DESCRIPTION
Using the same weird workaround from [this function in quick-eval](https://github.com/BrightspaceHypermediaComponents/activities/blob/6269ee819b7d718abcd626037ff851a209d4f394/components/d2l-quick-eval/behaviors/d2l-quick-eval-siren-helper-behavior.js#L175) to add a search param to a relative url. Fixes it throwing an error because the `URL` constructor expects a base for relative paths.