### PR TITLE
Clean up w2d styles and actionHref logic

### DIFF
--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
@@ -58,16 +58,9 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 					width: 1.2rem;
 				}
 				.d2l-activity-name-container {
-					color: var(--d2l-color-ferrite);
 					overflow: hidden;
 					text-overflow: ellipsis;
 					white-space: nowrap;
-				}
-				.d2l-hovering .d2l-activity-icon-container.d2l-has-action,
-				.d2l-focusing .d2l-activity-icon-container.d2l-has-action,
-				.d2l-hovering .d2l-activity-name-container.d2l-has-action,
-				.d2l-focusing .d2l-activity-name-container.d2l-has-action {
-					color: var(--d2l-color-celestine);
 				}
 				.d2l-icon-bullet {
 					color: var(--d2l-color-tungsten);
@@ -82,9 +75,6 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 				}
 				[slot="content"] {
 					padding: 0.1rem 0;
-				}
-				d2l-list-item-generic-layout {
-					background: transparent !important; /* !important is temporary until the actionHref attribute reflection is fixed */
 				}
 				#content {
 					width: 100%;
@@ -145,19 +135,13 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 
 		const iconClasses = {
 			'd2l-activity-icon-container': true,
-			'd2l-focusing': this._focusingLink,
-			'd2l-hovering': this._hoveringLink,
 			'd2l-skeletize': true,
-			'd2l-has-action': this.actionHref,
 		};
 
 		const nameClasses = {
 			'd2l-activity-name-container': true,
-			'd2l-focusing': this._focusingLink,
-			'd2l-hovering': this._hoveringLink,
 			'd2l-skeletize': true,
 			'd2l-skeletize-60': true,
-			'd2l-has-action': this.actionHref,
 		};
 
 		const secondaryClasses = {
@@ -198,32 +182,6 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 				</d2l-list-item-content>
 			`
 		});
-	}
-
-	set actionHref(href) {  // This is a hack - Garbage setter function since list-mixin initializes value
-		this.requestUpdate('actionHref', this.evaluateAllHref ? this.evaluateAllHref : href);
-	}
-
-	/** Link to activity instance for user navigation to complete/work on activity */
-	get actionHref() {
-		if (!this._started || this.skeleton) {
-			return '';
-		}
-
-		if (this.evaluateAllHref) {
-			return this.evaluateAllHref;
-		} else if (
-			this._activity
-			&& this._activityProperties
-			&& this._activityProperties.linkRel
-			&& this._activity.hasLinkByRel(this._activityProperties.linkRel)) {
-
-			return this._activity.getLinkByRel(this._activityProperties.linkRel).href;
-		} else if (this._activity && this._activity.hasLinkByRel('alternate')) {
-			return this._activity.getLinkByRel('alternate').href;
-		} else {
-			return '';
-		}
 	}
 
 	/** Due or end date of activity */
@@ -298,6 +256,14 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 
 				if (foundEntity) {
 					this._activity = foundEntity;
+
+					const link = (
+						this._activityProperties
+						&& this._activityProperties.linkRel
+						&& this._activity.getLinkByRel(this._activityProperties.linkRel)
+					) || this._activity.getLinkByRel('alternate');
+
+					this.actionHref = (this._started && (this.evaluateAllHref || (link && link.href))) || null;
 				}
 
 				break;

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
@@ -61,17 +61,10 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 					padding: 0.8rem 0.25rem 0 0;
 				}
 				.d2l-activity-name-container {
-					color: var(--d2l-color-ferrite);
 					margin: 0.6rem 0 0 0;
 					overflow: hidden;
 					text-overflow: ellipsis;
 					white-space: nowrap;
-				}
-				.d2l-hovering .d2l-activity-icon-container.d2l-has-action,
-				.d2l-focusing .d2l-activity-icon-container.d2l-has-action,
-				.d2l-hovering .d2l-activity-name-container.d2l-has-action,
-				.d2l-focusing .d2l-activity-name-container.d2l-has-action {
-					color: var(--d2l-color-celestine);
 				}
 				.d2l-icon-bullet {
 					color: var(--d2l-color-tungsten);
@@ -101,9 +94,6 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 				}
 				[slot="content"] {
 					padding: 0;
-				}
-				d2l-list-item-generic-layout {
-					background: transparent !important; /* !important is temporary until the actionHref attribute reflection is fixed */
 				}
 				#content {
 					width: 100%;
@@ -179,20 +169,14 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 
 		const iconClasses = {
 			'd2l-activity-icon-container': true,
-			'd2l-focusing': this._focusingLink,
-			'd2l-hovering': this._hoveringLink,
 			'd2l-skeletize': true,
-			'd2l-has-action': this.actionHref,
 		};
 
 		const nameClasses = {
 			'd2l-body-standard': true,
 			'd2l-activity-name-container': true,
-			'd2l-focusing': this._focusingLink,
-			'd2l-hovering': this._hoveringLink,
 			'd2l-skeletize': true,
 			'd2l-skeletize-30': true,
-			'd2l-has-action': this.actionHref,
 		};
 
 		const secondaryClasses = {
@@ -255,23 +239,6 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 			${dateTemplate}
 			${listItemTemplate}
 		`;
-	}
-
-	set actionHref(href) {  // Require setter function as list-mixin initializes value
-		const oldVal = this._actionHref;
-		this._actionHref = href;
-		this.requestUpdate('actionHref', oldVal);
-	}
-
-	/** Link to activity instance for user navigation to complete/work on activity */
-	get actionHref() {
-		if (!this._started || this.skeleton) {
-			return '';
-		}
-
-		return this._activity && this._activity.hasLinkByRel('alternate')
-			? this._activity.getLinkByRel('alternate').href
-			: '';
 	}
 
 	/** Due or end date of activity */
@@ -360,6 +327,8 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 						.then((sirenEntity) => {
 							if (sirenEntity) {
 								this._activity = sirenEntity;
+								const link = sirenEntity.getLinkByRel('alternate');
+								this.actionHref = (this._started && link && link.href) || null;
 							}
 						});
 				}

--- a/components/d2l-work-to-do/d2l-work-to-do.js
+++ b/components/d2l-work-to-do/d2l-work-to-do.js
@@ -113,6 +113,10 @@ class WorkToDoWidget extends EntityMixinLit(LocalizeWorkToDoMixin(LitElement)) {
 				.d2l-activity-collection-container-fullscreen d2l-list d2l-work-to-do-activity-list-item-detailed:last-of-type {
 					margin-bottom: 1.5rem;
 				}
+				d2l-work-to-do-activity-list-item-basic,
+				d2l-work-to-do-activity-list-item-detailed {
+					--d2l-list-item-content-text-color: var(--d2l-color-ferrite);
+				}
 			`
 		];
 	}


### PR DESCRIPTION
Somewhat dependent on https://github.com/BrightspaceUI/core/pull/1076

Refactors the way links and icons are styled, `actionHref` is set, and restores the link background color on hover.