### PR TITLE
Preview should only be visible when user has entered a URL

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-editor-link.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-editor-link.js
@@ -3,6 +3,7 @@ import 'd2l-tooltip/d2l-tooltip';
 import '@brightspace-ui/core/components/button/button-subtle.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../../mixins/d2l-activity-editor-mixin.js';
+import { AsyncContainerMixin } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
 import { ContentEditorConstants } from '../constants';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { ErrorHandlingMixin } from '../../error-handling-mixin.js';
@@ -48,6 +49,7 @@ class ContentEditorLink extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 		super();
 		this._debounceJobs = {};
 		this.skeleton = true;
+		this.saveOrder = 3000;
 	}
 
 	render() {
@@ -103,8 +105,12 @@ class ContentEditorLink extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 	}
 
 	validate() {
+		const link = this.shadowRoot.getElementById('content-link').value;
+		const isExternalResource = this.shadowRoot.getElementById('open-new-tab').checked;
+		const invalidWeblinkError = getWeblinkError(link, isExternalResource, true);
+
 		this.clearError('_linkError');
-		this._saveLink(null);
+		this.setError('_linkError', invalidWeblinkError, 'link-tooltip');
 	}
 
 	_renderLinkTooltip() {
@@ -125,11 +131,10 @@ class ContentEditorLink extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 		`;
 	}
 
-	_saveLink(inputEvent = null) {
-		const isSubmitting = inputEvent === null;
+	_saveLink() {
 		const link = this.shadowRoot.getElementById('content-link').value;
 		const isExternalResource = this.shadowRoot.getElementById('open-new-tab').checked;
-		const invalidWeblinkError = getWeblinkError(link, isExternalResource, isSubmitting);
+		const invalidWeblinkError = getWeblinkError(link, isExternalResource);
 
 		this._debounceJobs.link = Debouncer.debounce(
 			this._debounceJobs.link,

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-editor-link.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-editor-link.js
@@ -3,7 +3,6 @@ import 'd2l-tooltip/d2l-tooltip';
 import '@brightspace-ui/core/components/button/button-subtle.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../../mixins/d2l-activity-editor-mixin.js';
-import { AsyncContainerMixin } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
 import { ContentEditorConstants } from '../constants';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { ErrorHandlingMixin } from '../../error-handling-mixin.js';
@@ -49,7 +48,7 @@ class ContentEditorLink extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 		super();
 		this._debounceJobs = {};
 		this.skeleton = true;
-		this.saveOrder = 3000;
+		this.saveOrder = 2000;
 	}
 
 	render() {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-editor-link.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-editor-link.js
@@ -109,7 +109,7 @@ class ContentEditorLink extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 		const invalidWeblinkError = getWeblinkError(link, isExternalResource, true);
 
 		this.clearError('_linkError');
-		this.setError('_linkError', invalidWeblinkError, 'link-tooltip');
+		this.setError('_linkError', invalidWeblinkError);
 	}
 
 	_renderLinkTooltip() {
@@ -140,7 +140,7 @@ class ContentEditorLink extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 			timeOut.after(ContentEditorConstants.DEBOUNCE_TIMEOUT),
 			() => {
 				if (invalidWeblinkError) {
-					this.setError('_linkError', invalidWeblinkError, 'link-tooltip');
+					this.setError('_linkError', invalidWeblinkError);
 				}
 				else {
 					this.clearError('_linkError');

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-editor-link.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-editor-link.js
@@ -104,7 +104,7 @@ class ContentEditorLink extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 
 	validate() {
 		this.clearError('_linkError');
-		this._saveLink();
+		this._saveLink(null);
 	}
 
 	_renderLinkTooltip() {
@@ -125,10 +125,11 @@ class ContentEditorLink extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 		`;
 	}
 
-	_saveLink() {
+	_saveLink(inputEvent = null) {
+		const isSubmitting = inputEvent === null;
 		const link = this.shadowRoot.getElementById('content-link').value;
 		const isExternalResource = this.shadowRoot.getElementById('open-new-tab').checked;
-		const invalidWeblinkError = getWeblinkError(link, isExternalResource);
+		const invalidWeblinkError = getWeblinkError(link, isExternalResource, isSubmitting);
 
 		this._debounceJobs.link = Debouncer.debounce(
 			this._debounceJobs.link,

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-url-preview.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-url-preview.js
@@ -39,6 +39,7 @@ class ContentWebLinkUrlPreview extends SkeletonMixin(LocalizeActivityEditorMixin
 
 	render() {
 		const attachment = {};
+
 		if (!this.entity || !this.entity.link) {
 			return html``;
 		}

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-url-preview.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-url-preview.js
@@ -39,7 +39,6 @@ class ContentWebLinkUrlPreview extends SkeletonMixin(LocalizeActivityEditorMixin
 
 	render() {
 		const attachment = {};
-
 		if (!this.entity || !this.entity.link) {
 			return html``;
 		}

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/helpers/url-validation-helper.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/helpers/url-validation-helper.js
@@ -1,6 +1,7 @@
-export const getWeblinkError = (link, isExternalResource) => {
+export const getWeblinkError = (link, isExternalResource, isSubmitting = false) => {
 	if (link.length === 0) {
-		return 'content.emptyLinkField';
+		// This error should only show when the user tries to submit, not on keystroke
+		return isSubmitting ? 'content.emptyLinkField' : null;
 	}
 
 	const expression = /^(?:https?:\/\/)?(?:[a-zA-Z0-9][a-zA-Z0-9-]*\.)+[a-zA-Z0-9][a-zA-Z0-9-]*(?::\d+)?(?:$|[/?#].*$)/;


### PR DESCRIPTION
If the user enters a url and then deletes it, the preview should disappear.

The way this is all configured, is that preview will update when the url is valid. However, an empty link: `""` is technically an "invalid" url. This is condition is weird, however in that we don't want to show this error to the user right away, and I assume they will also know if they delete the url, it is invalid. So I removed the error when the user deletes the link. The error _will_ still show when they try to submit.

This allows `""` to be considered valid as long as the user is not submitting the form, and the preview will disappear.

![previewfix2](https://user-images.githubusercontent.com/14796305/106632553-7f6d0f00-6543-11eb-8904-d34225e1f7cc.gif)

