### PR TITLE
US123706 added selects, rio checkbox, button

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-manage-attempts-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-manage-attempts-editor.js
@@ -1,10 +1,12 @@
 import '@brightspace-ui/core/components/dialog/dialog.js';
+import './d2l-activity-quiz-retake-incorrect-only-editor.js';
+import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorDialogMixin } from '../mixins/d2l-activity-editor-dialog-mixin';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin';
-import { html } from 'lit-element/lit-element';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles';
 import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
+import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles';
 import { shared as store } from './state/quiz-store';
 
 class ActivityQuizManageAttemptsEditor extends ActivityEditorMixin(ActivityEditorDialogMixin(LocalizeActivityQuizEditorMixin(MobxLitElement))) {
@@ -12,6 +14,12 @@ class ActivityQuizManageAttemptsEditor extends ActivityEditorMixin(ActivityEdito
 	static get styles() {
 		return [
 			labelStyles,
+			selectStyles,
+			css`
+				.d2l-input-select {
+					margin-bottom: 1.5rem
+				}
+			`
 		];
 	}
 
@@ -25,16 +33,54 @@ class ActivityQuizManageAttemptsEditor extends ActivityEditorMixin(ActivityEdito
 		`;
 	}
 
+	_renderAttemptsCondition() {
+		// TODO: add Attempts Conditions once design has been refined
+		return html`
+			<d2l-button-subtle text=${this.localize('btnAddAttemptConditions')}></d2l-button-subtle>
+		`;
+	}
+	_renderAttemptsSelects() {
+		// TODO: replace consts with data fetched from attempts entity
+		const attemptsAllowed = ['Unlimited', 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+		const gradingTypes = ['Highest Attempt', 'Lowest Attempt', 'Average of All Attempts', 'First Attempt', 'Last Attempt'];
+
+		return html`
+			<div class="d2l-label-text">${this.localize('attemptsAllowed')}</div>
+			<select class="d2l-input-select">
+				${attemptsAllowed.map((option) => html `<option value=${option}>${option}</option>`)}
+			</select>
+
+			<div class="d2l-label-text">${this.localize('overallGradeCalculation')}</div>
+			<select class="d2l-input-select">
+				${gradingTypes.map((option) => html `<option value=${option}>${option}</option>`)}
+			</select>
+		`;
+	}
+
 	_renderDialog() {
 		return html`
 			<d2l-dialog
 				id="quiz-manage-attempts-dialog"
 				?opened="${this.opened}"
 				@d2l-dialog-close="${this.handleClose}"
-				title-text="${this.localize('subHdrAttemptsTools')}">
+				title-text="${this.localize('subHdrAttemptsTools')}"
+				width=700>
+					${this._renderDialogContent()}
 					<d2l-button slot="footer" primary data-dialog-action="ok">${this.localize('manageAttemptsDialogConfirmationText')}</d2l-button>
 		 			<d2l-button slot="footer" data-dialog-action>${this.localize('manageAttemptsDialogCancelText')}</d2l-button>
 			</d2l-dialog>
+		`;
+	}
+
+	_renderDialogContent() {
+		// TODO: replace consts with data fetched from attempts entity
+		const showRio = true;
+		const showAttemptsConditions = true;
+
+		return html `
+			${this._renderAttemptsSelects()}
+			${showRio ? html`${this._renderRioOption()}` : null}
+			${showAttemptsConditions ? html `${this._renderAttemptsCondition()}` : null}
 		`;
 	}
 
@@ -47,6 +93,15 @@ class ActivityQuizManageAttemptsEditor extends ActivityEditorMixin(ActivityEdito
 				text="${this.localize('manageAttempts')}"
 				@click="${this.open}">
 			</d2l-button-subtle>
+		`;
+	}
+
+	_renderRioOption() {
+		return html `
+			<d2l-activity-quiz-retake-incorrect-only-editor
+				href="${this.href}"
+				.token="${this.token}">
+			</d2l-activity-quiz-retake-incorrect-only-editor>
 		`;
 	}
 }

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-manage-attempts-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-manage-attempts-editor.js
@@ -17,7 +17,7 @@ class ActivityQuizManageAttemptsEditor extends ActivityEditorMixin(ActivityEdito
 			selectStyles,
 			css`
 				.d2l-input-select {
-					margin-bottom: 1.5rem
+					margin-bottom: 1.5rem;
 				}
 			`
 		];

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-retake-incorrect-only-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-retake-incorrect-only-editor.js
@@ -1,0 +1,77 @@
+import { css, html } from 'lit-element/lit-element.js';
+import { ActivityEditorDialogMixin } from '../mixins/d2l-activity-editor-dialog-mixin.js';
+import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
+import { checkboxStyles } from '../styles/checkbox-styles.js';
+import { labelStyles } from '@brightspace-ui/core/components/typography/styles';
+import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang-mixin';
+import { MobxLitElement } from '@adobe/lit-mobx';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
+import { shared as store } from './state/quiz-store';
+
+class ActivityQuizRetakeIncorrectOnlyEditor
+	extends ActivityEditorMixin(RtlMixin(LocalizeActivityQuizEditorMixin(ActivityEditorDialogMixin(MobxLitElement)))) {
+
+	static get styles() {
+		return [
+			checkboxStyles,
+			labelStyles,
+			css`
+				.d2l-input-checkbox-help-container {
+					align-items: center;
+					display: flex;
+				}
+				.d2l-input-checkbox-help {
+					margin-bottom: 0.9rem;
+				}
+			`
+		];
+	}
+
+	constructor() {
+		super(store);
+	}
+
+	render() {
+		const entity = store.get(this.href);
+		if (!entity) {
+			return html``;
+		}
+
+		return html`
+			<div class="d2l-label-text">${this.localize('retakeIncorrectQuestionsOnly')}</div>
+			<div class="d2l-input-checkbox-help-container">
+				<d2l-input-checkbox>${this.localize('rioCheckboxLabel')}</d2l-input-checkbox>
+				<div class="d2l-input-checkbox-help">
+					<d2l-button-icon
+						text="${this.localize('rioAccessibileHelpText')}"
+						icon="tier1:help"
+						@click="${this.open}">
+					</d2l-button-icon>
+				</div>
+			</div>
+			${this._renderDialog()}
+		`;
+	}
+
+	_renderDialog() {
+		return html`
+			<d2l-dialog
+				?opened="${this.opened}"
+				@d2l-dialog-close="${this.handleClose}"
+				title-text="${this.localize('rioDialogTitle')}">
+					${this.localize('rioDialogParagraph')}
+					<d2l-button
+						data-dialog-action="done"
+						slot="footer"
+						primary>
+						${this.localize('rioDialogConfirmationText')}
+					</d2l-button>
+			</d2l-dialog>
+		`;
+	}
+}
+
+customElements.define(
+	'd2l-activity-quiz-retake-incorrect-only-editor',
+	ActivityQuizRetakeIncorrectOnlyEditor
+);

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
@@ -60,5 +60,15 @@ export default {
 	"subHdrAttemptsTools": "Attempts", // Title for attempts tools
 	"manageAttempts": "Manage Attempts", // Label for button to launch attempts dialog
 	"textIsDisplayedPart1": "Fields cannot be toggled off in the new quiz creation experience.", // First sentence of alert warning that text fields will be visible
-	"textIsDisplayedSingularPart2": "The {field} field appears to learners when the quiz is saved." // Second sentence of alert warning that text fields will be visible, when there is only one field
+	"textIsDisplayedSingularPart2": "The {field} field appears to learners when the quiz is saved.", // Second sentence of alert warning that text fields will be visible, when there is only one field
+	"attemptsAllowed": "Attempts Allowed", // Title for Attempts Allowed select in Attempts dialog
+	"overallGradeCalculation": "Overall Grade Calculation", // Title for Overall Grade Calculation select in Attempts dialog
+	"retakeIncorrectQuestionsOnly": "Retake Incorrect Questions Only", // Title for RIO checkbox in Attempts dialog
+	"rioCheckboxLabel": "On new attempts, only allow answers for previously incorrect questions", // Label for RIO checkbox in Attempts dialog
+	"btnAddAttemptConditions": "Add Attempt Conditions", // Label for Add Attempt Conditions button in Attempts dialog
+	"rioAccessibileHelpText": "Get help on - Retake Incorrect Only", // accessible help text for RIO question mark button
+	"rioDialogTitle": "Information: Retake Incorrect Questions Only", // Title for RIO help dialog
+	"rioDialogParagraph": "When this setting is selected, learners who attempt a quiz more than once can only answer questions that were incorrect on the previous attempt. If you are using Automatic grading, Written Response questions will be marked as 0 and included in future attempts until they are graded manually.", // content for RIO dialog
+	"rioDialogConfirmationText": "OK", // copy that appears on the RIO help dialog confirmation button
+
 };


### PR DESCRIPTION
UI components added: 
- Attempts Allowed select
- Overall Grade Calculation select
- RIO checkbox
- RIO help info dialog
- Add Attempts Conditions button

Values for selects are hardcoded for now, Eventually these will be read from Attempts Entity

[US123706](https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F478977336380&fdp=true?fdp=true): [ui] Attempts: Conditions entities

https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F478977336380&fdp=true?fdp=true