### PR TITLE
fix: don't show the alert if the description is empty

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
@@ -100,7 +100,7 @@ class QuizEditorDetail extends ActivityEditorMixin(AsyncContainerMixin(SkeletonM
 		const descriptionLang = this.localize('description');
 
 		return html`
-		<d2l-alert has-close-button ?hidden=${this.skeleton || descriptionIsDisplayed}>
+		<d2l-alert has-close-button ?hidden=${this.skeleton || descriptionIsDisplayed || !description || description.length === 0}>
 			${this.localize('textIsDisplayedPart1')}
 			${this.localize('textIsDisplayedSingularPart2', 'field', descriptionLang)}
 		</d2l-alert>


### PR DESCRIPTION
Don't show the alert if the description is empty. Note that if the description contains whitespace characters that is NOT considered empty and the alert will show (if toggle is off). This is acceptable by Joseph since non-trivial to detect (since description is html and empty still contains html characters).