### PR TITLE
W2D: Change header divs to headers where appropriate

### DIFF
--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-header.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-header.js
@@ -139,10 +139,15 @@ class ActivityListHeader extends SkeletonMixin(LocalizeWorkToDoMixin(LitElement)
 			'd2l-heading-3': this.fullscreen,
 		};
 
-		const messageTemplate = html`
-			<div class=${classMap(messageClasses)}>
-				${this._message}
-			</div>`;
+		const messageTemplate = this.fullscreen
+			? html`
+				<h2 class=${classMap(messageClasses)}>
+					${this._message}
+				</h2>`
+			: html`
+				<h3 class=${classMap(messageClasses)}>
+					${this._message}
+				</h3>`;
 
 		const counterTemplate = html`
 			<div class=${classMap(counterContainerClasses)}>

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
@@ -217,7 +217,7 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 
 		const dateTemplate = this.includeDate
 			? html `
-				<div class=${classMap(dateClasses)}>
+				<h3 class=${classMap(dateClasses)}>
 					<d2l-activity-date
 						class="d2l-heading-4"
 						href=${this.href}
@@ -226,7 +226,7 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 						format="dddd, MMMM d"
 						date-only>
 					</d2l-activity-date>
-				</div>`
+				</h3>`
 			: nothing;
 
 		const separatorTemplate = !this.skeleton && this._type && (this._orgName || this._orgCode)

--- a/components/d2l-work-to-do/d2l-work-to-do.js
+++ b/components/d2l-work-to-do/d2l-work-to-do.js
@@ -374,7 +374,7 @@ class WorkToDoWidget extends EntityMixinLit(WorkToDoTelemetryMixin(LocalizeWorkT
 			return html`
 				${immersiveNav()}
 				<div class="d2l-work-to-do-fullscreen-container">
-					<div class="d2l-heading-1 d2l-work-to-do-fullscreen-title">${this.localize('myWorkToDo')}</div>
+					<h1 class="d2l-heading-1 d2l-work-to-do-fullscreen-title">${this.localize('myWorkToDo')}</h1>
 					<div class="d2l-overdue-collection-fullscreen">
 						${fullscreenCollectionTemplate(this._overdueActivities, true)}
 					</div>


### PR DESCRIPTION
context: some of our headers were divs with `d2l-heading-X` classes applied to them, instead of actual `h1`/`h2`/`h3` elements, which meant that they looked like headers but didn't behave like them when being read out by a screen reader. This fix should remedy that without any changes to how they look visually.

https://rally1.rallydev.com/#/357251704080ud/workviews?Name=01.%20Update%20Widget%2FFull%20Page%20Headers%20to%20be%20accessible&Priority=Normal&Project=%2Fproject%2F357251704080&Requirement=%2Fhierarchicalrequirement%2F463435916636&detail=%2Fdefect%2F492428081372&iteration=u&parentRef=%2Fhierarchicalrequirement%2F463435916636&rankTo=BOTTOM&view=b064b584-6337-43c1-b9a9-28047568284d