### PR TITLE
W2D: remove background gradient

### DIFF
--- a/components/d2l-work-to-do/d2l-work-to-do.js
+++ b/components/d2l-work-to-do/d2l-work-to-do.js
@@ -104,7 +104,6 @@ class WorkToDoWidget extends EntityMixinLit(WorkToDoTelemetryMixin(LocalizeWorkT
 					padding: 1.8rem 0;
 				}
 				.d2l-work-to-do-fullscreen-container {
-					background-image: linear-gradient(to bottom, #f9fbff, #ffffff);
 					padding: 0 2rem;
 				}
 				.d2l-activity-collection d2l-list d2l-work-to-do-activity-list-item-basic:first-of-type {


### PR DESCRIPTION
This turned out to be optional, so we're removing it - the background of the page clashes with the list items themselves when you mouse over them.

https://rally1.rallydev.com/#/357251704080ud/workviews?detail=%2Fuserstory%2F492516077212&view=b064b584-6337-43c1-b9a9-28047568284d