### PR TITLE
use full editor instead of inline

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -19,7 +19,6 @@ class ActivityHtmlNewEditor extends LocalizeActivityEditorMixin(LitElement) {
 				label="${this.ariaLabel}"
 				label-hidden
 				?disabled="${this.disabled}"
-				type="inline"
 				height="10rem"
 				@d2l-htmleditor-blur="${this._onContentChange}">
 			</d2l-htmleditor>


### PR DESCRIPTION
"full" is the default type, so leaving out the type gives us the full editor.