### PR TITLE
W2D: fix red count element appearing when showing skeleton

### DIFF
--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-header.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-header.js
@@ -8,6 +8,7 @@ import { classMap } from 'lit-html/directives/class-map.js';
 import { formatDate } from '@brightspace-ui/intl/lib/dateTime';
 import { LocalizeWorkToDoMixin } from './mixins/d2l-work-to-do-localization-mixin';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin';
+import { nothing } from 'lit-html';
 
 const ro = window.ResizeObserver && new ResizeObserver(entries => {
 	entries.forEach(entry => {
@@ -149,12 +150,14 @@ class ActivityListHeader extends SkeletonMixin(LocalizeWorkToDoMixin(LitElement)
 					${this._message}
 				</h3>`;
 
-		const counterTemplate = html`
+		const counterTemplate = !this.skeleton
+			? html`
 			<div class=${classMap(counterContainerClasses)}>
 				<div class=${classMap(counterClasses)}>
 					${this._counterString}
 				</div>
-			</div>`;
+			</div>`
+			: nothing ;
 
 		return html`
 			<div class=${classMap(containerClasses)}>


### PR DESCRIPTION
https://rally1.rallydev.com/#/357251704080ud/workviews?detail=%2Fdefect%2F490418219912&view=b064b584-6337-43c1-b9a9-28047568284d

When the page is in skeleton view, we show an empty string for the activity count, but it styles the same round red circle around the empty string, which we should just be hiding entirely.