### PR TITLE
Set work-to-do-activity-list-item-basic to always use submission-icon in quick-eval widget

### DIFF
--- a/components/d2l-quick-eval-widget/d2l-quick-eval-widget-controller.js
+++ b/components/d2l-quick-eval-widget/d2l-quick-eval-widget-controller.js
@@ -18,7 +18,8 @@ export async function fetchSubmissionCount(activityUsageEntity, token) {
 
 	const evaluationStatusEntity = await fetch(evalStatusLink, token);
 
-	return evaluationStatusEntity.properties.newsubmissions + evaluationStatusEntity.properties.resubmissions;
+	const newSubmissions = evaluationStatusEntity.properties.newsubmissions + evaluationStatusEntity.properties.resubmissions;
+	return newSubmissions || 0;
 }
 
 export async function fetchEvaluateAllHref(activityUsageEntity, token) {

--- a/components/d2l-quick-eval-widget/d2l-quick-eval-widget-submission-icon.js
+++ b/components/d2l-quick-eval-widget/d2l-quick-eval-widget-submission-icon.js
@@ -86,7 +86,7 @@ class SubmissionIcon extends RtlMixin(LitElement) {
 		return html`
 			<div class="d2l-quick-eval-widget-submission-icon-content">
 				<d2l-icon icon="${this.icon}"></d2l-icon>
-				<div class="d2l-quick-eval-widget-submission-icon-submission-count-container">
+				<div class="d2l-quick-eval-widget-submission-icon-submission-count-container" ?hidden=${!this.submissionCount}>
 					<div class="d2l-quick-eval-widget-submission-icon-submission-count">${this.submissionCount}</div>
 				</div>
 			</div>

--- a/components/d2l-quick-eval-widget/d2l-quick-eval-widget.js
+++ b/components/d2l-quick-eval-widget/d2l-quick-eval-widget.js
@@ -118,7 +118,7 @@ export class QuickEvalWidget extends LocalizeQuickEvalWidget(SkeletonMixin(LitEl
 			unassessedActivityCollection.entities
 				.slice(0, this.count)
 				.map(async activityUsage => {
-					let submissionCount = await fetchSubmissionCount(activityUsage, token);
+					const submissionCount = await fetchSubmissionCount(activityUsage, token);
 
 					const href = activityUsage.getLinkByRel('self').href;
 					const evaluateAllHref = await fetchEvaluateAllHref(activityUsage, token);

--- a/components/d2l-quick-eval-widget/d2l-quick-eval-widget.js
+++ b/components/d2l-quick-eval-widget/d2l-quick-eval-widget.js
@@ -120,11 +120,6 @@ export class QuickEvalWidget extends LocalizeQuickEvalWidget(SkeletonMixin(LitEl
 				.map(async activityUsage => {
 					let submissionCount = await fetchSubmissionCount(activityUsage, token);
 
-					// don't display submissionCounts of zero
-					if (submissionCount === 0) {
-						submissionCount = undefined;
-					}
-
 					const href = activityUsage.getLinkByRel('self').href;
 					const evaluateAllHref = await fetchEvaluateAllHref(activityUsage, token);
 

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
@@ -11,6 +11,7 @@ import { ActivityAllowList, HideOrgInfoClasses } from './env';
 import { classMap } from 'lit-html/directives/class-map';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { fetchEntity } from './state/fetch-entity';
+import { ifDefined } from 'lit-html/directives/if-defined';
 import { ListItemLinkMixin } from '@brightspace-ui/core/components/list/list-item-link-mixin';
 import { LocalizeWorkToDoMixin } from './mixins/d2l-work-to-do-localization-mixin';
 import { nothing } from 'lit-html';
@@ -185,11 +186,11 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 			: nothing;
 
 		return this._renderListItem({
-			illustration: this.submissionCount ? html`
+			illustration: this.evaluateAllHref ? html`
 					<d2l-quick-eval-widget-submission-icon style="overflow: visible;"
 						class="${classMap(iconClasses)}"
 						icon=${this._icon}
-						submission-count=${this.submissionCount > 99 ? '99+' : this.submissionCount}>
+						submission-count=${ifDefined(this.submissionCount > 0 ? (this.submissionCount > 99 ? '99+' : this.submissionCount) : undefined)} >
 					</d2l-quick-eval-widget-submission-icon>` :
 				html`
 					<d2l-icon

--- a/demo/d2l-quick-eval-widget/data/evaluation-status-quiz.json
+++ b/demo/d2l-quick-eval-widget/data/evaluation-status-quiz.json
@@ -4,8 +4,8 @@
     "evaluation-status"
   ],
   "properties": {
-    "newsubmissions": 8,
-    "resubmissions": 4
+    "newsubmissions": 0,
+    "resubmissions": 0
   },
   "entities": [
     {


### PR DESCRIPTION
Fixed a problem where items with no submissions were using the regular icon component instead of the submission icon component, causing misalignment in the list. 

Before:
![image](https://user-images.githubusercontent.com/50635849/107571855-77534600-6bb9-11eb-9ac0-2165228f8959.png)

After:
![image](https://user-images.githubusercontent.com/50635849/107571786-5d196800-6bb9-11eb-9760-12a987bed02e.png)
