### PR TITLE
Fixed dialog close logic

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restriction-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restriction-editor.js
@@ -161,7 +161,7 @@ class ActivityQuizIpRestrictionEditor
 
 		await entity.saveRestrictions();
 
-		if (!entity.errors && !entity.errors.length) {
+		if (!entity.errors || !entity.errors.length) {
 			this.handleClose();
 		}
 	}


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F465115111280

I was testing the IP dialog and realized this condition wasn't correct. `entity.errors` defaults to an empty array which I thought was a falsy value. Turns out it's truthy and so in the case that there was an empty array of errors the dialog would never close. 

With this change the dialog should close if `entity.errors` is a falsy value or if it's an empty array.