### PR TITLE
Us123398/cross browser styling

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restriction-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restriction-editor.js
@@ -161,7 +161,7 @@ class ActivityQuizIpRestrictionEditor
 
 		await entity.saveRestrictions();
 
-		if (!entity.errors && !entity.errors.length) {
+		if (!entity.errors || !entity.errors.length) {
 			this.handleClose();
 		}
 	}

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restrictions-container.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restrictions-container.js
@@ -11,23 +11,26 @@ import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin';
 import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { sharedIpRestrictions as store } from './state/quiz-store.js';
+import { tableStyles } from '../styles/table-styles';
 import { validateIp } from './helpers/ip-validation-helper.js';
 
 class ActivityQuizIpRestrictionsContainer extends ActivityEditorMixin(ActivityEditorContainerMixin(LocalizeActivityQuizEditorMixin(MobxLitElement))) {
 
 	static get styles() {
-		return css`
-				:host {
-					border-bottom: solid 1px var(--d2l-color-gypsum);
-					display: block;
-				}
-				:host([hidden]) {
-					display: none;
-				}
-				d2l-button-subtle {
-					margin: 0.5rem 0;
-				}
-			`;
+		return [
+			tableStyles,
+			css`
+			:host {
+				border-bottom: solid 1px var(--d2l-color-gypsum);
+				display: block;
+			}
+			:host([hidden]) {
+				display: none;
+			}
+			d2l-button-subtle {
+				margin: 0.5rem 0;
+			}
+		`];
 	}
 
 	constructor() {

--- a/components/d2l-activity-editor/styles/table-styles.js
+++ b/components/d2l-activity-editor/styles/table-styles.js
@@ -1,0 +1,607 @@
+import { css } from 'lit-element';
+
+export const tableStyles = css`
+	.d2l-table {
+		@apply --d2l-table;
+	}
+
+	.d2l-table > thead,
+	d2l-thead {
+		@apply --d2l-table-head;
+	}
+
+	.d2l-table > tfoot,
+	d2l-tfoot {
+		@apply --d2l-table-foot;
+		background-color:var(--d2l-table-body-background-color);
+	}
+
+	.d2l-table > tbody,
+	d2l-tbody {
+		@apply --d2l-table-body;
+		background-color:var(--d2l-table-body-background-color);
+	}
+
+	.d2l-table > * > tr,
+	d2l-tr {
+		@apply --d2l-table-row;
+	}
+
+	d2l-table-wrapper[type="default"] .d2l-table > * > tr > td,
+	d2l-table-wrapper[type="default"] .d2l-table > * > tr > th,
+	d2l-table[type="default"] d2l-td,
+	d2l-table[type="default"] d2l-th {
+		@apply --d2l-table-cell;
+		border-top:var(--d2l-table-border);
+		border-right:var(--d2l-table-border);
+		font-weight: inherit;
+		text-align: left;
+	}
+
+	d2l-table-wrapper[type="light"] .d2l-table > * > tr > td,
+	d2l-table-wrapper[type="light"] .d2l-table > * > tr > th,
+	d2l-table[type="light"] d2l-td,
+	d2l-table[type="light"] d2l-th {
+		@apply --d2l-table-light-cell;
+		border-top: var(--d2l-table-light-border);
+		font-weight: inherit;
+		text-align: left;
+	}
+
+	d2l-table-wrapper[type="default"] .d2l-table-cell-first,
+	d2l-table[type="default"] .d2l-table-cell-first,
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table-cell-last,
+	[dir="rtl"] d2l-table[type="default"] .d2l-table-cell-last {
+		border-left: var(--d2l-table-border);
+	}
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table-cell-first:not(.d2l-table-cell-last),
+	[dir="rtl"] d2l-table[type="default"] .d2l-table-cell-first:not(.d2l-table-cell-last) {
+		border-left: 0;
+	}
+
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table > * > tr > td,
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table > * > tr > th,
+	[dir="rtl"] d2l-table[type="default"] d2l-td,
+	[dir="rtl"] d2l-table[type="default"] d2l-th,
+	[dir="rtl"] d2l-table-wrapper[type="light"] .d2l-table > * > tr > td,
+	[dir="rtl"] d2l-table-wrapper[type="light"] .d2l-table > * > tr > th,
+	[dir="rtl"] d2l-table[type="light"] d2l-td,
+	[dir="rtl"] d2l-table[type="light"] d2l-th {
+		text-align: right;
+	}
+
+	d2l-table-wrapper[type="default"] .d2l-table > thead > tr > th,
+	d2l-table-wrapper[type="default"] .d2l-table > * > tr[header] > th,
+	d2l-table[type="default"] d2l-thead > d2l-tr > d2l-th,
+	d2l-table[type="default"] d2l-tr[header] > d2l-th {
+		font-family: inherit;
+		@apply --d2l-table-header;
+		background-color:var(--d2l-table-header-background-color);
+	}
+
+	d2l-table-wrapper[type="light"] .d2l-table > thead > tr > th,
+	d2l-table-wrapper[type="light"] .d2l-table > * > tr[header] > th,
+	d2l-table[type="light"] d2l-thead > d2l-tr > d2l-th,
+	d2l-table[type="light"] d2l-tr[header] > d2l-th {
+		font-family: inherit;
+		@apply --d2l-table-light-header;
+		background-color:var(--d2l-table-light-header-background-color);
+	}
+
+	d2l-table-wrapper[type="light"] .d2l-table > thead > tr.d2l-table-row-first > th,
+	d2l-table-wrapper[type="light"] .d2l-table > * > tr[header].d2l-table-row-first  > th,
+	d2l-table[type="light"] d2l-thead > d2l-tr.d2l-table-row-first  > d2l-th,
+	d2l-table[type="light"] d2l-tr[header].d2l-table-row-first  > d2l-th {
+		border-top: none;
+	}
+
+	/* border radiuses */
+
+	d2l-table-wrapper[type="default"] .d2l-table-row-first > .d2l-table-cell-first,
+	d2l-table[type="default"] .d2l-table-row-first > .d2l-table-cell-first {
+		border-top-left-radius: var(--d2l-table-border-radius);
+	}
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table-row-first > .d2l-table-cell-first:not(.d2l-table-cell-last),
+	[dir="rtl"] d2l-table[type="default"] .d2l-table-row-first > .d2l-table-cell-first:not(.d2l-table-cell-last) {
+		border-top-left-radius: 0;
+	}
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table-row-first > .d2l-table-cell-first,
+	[dir="rtl"] d2l-table[type="default"] .d2l-table-row-first > .d2l-table-cell-first {
+		border-top-right-radius: var(--d2l-table-border-radius);
+	}
+
+	d2l-table-wrapper[type="default"] .d2l-table-row-first > .d2l-table-cell-last,
+	d2l-table[type="default"] .d2l-table-row-first > .d2l-table-cell-last {
+		border-top-right-radius: var(--d2l-table-border-radius);
+	}
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table-row-first > .d2l-table-cell-last:not(.d2l-table-cell-first),
+	[dir="rtl"] d2l-table[type="default"] .d2l-table-row-first > .d2l-table-cell-last:not(.d2l-table-cell-first) {
+		border-top-right-radius: 0;
+	}
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table-row-first > .d2l-table-cell-last,
+	[dir="rtl"] d2l-table[type="default"] .d2l-table-row-first > .d2l-table-cell-last {
+		border-top-left-radius: var(--d2l-table-border-radius);
+	}
+
+	d2l-table-wrapper[type="default"] .d2l-table-row-last > .d2l-table-cell-first,
+	d2l-table[type="default"] .d2l-table-row-last > .d2l-table-cell-first {
+		border-bottom-left-radius: var(--d2l-table-border-radius);
+	}
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table-row-last > .d2l-table-cell-first:not(.d2l-table-cell-last),
+	[dir="rtl"] d2l-table[type="default"] .d2l-table-row-last > .d2l-table-cell-first:not(.d2l-table-cell-last) {
+		border-bottom-left-radius: 0;
+	}
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table-row-last > .d2l-table-cell-first,
+	[dir="rtl"] d2l-table[type="default"] .d2l-table-row-last > .d2l-table-cell-first {
+		border-bottom-right-radius: var(--d2l-table-border-radius);
+	}
+
+	d2l-table-wrapper[type="default"] .d2l-table-row-last > .d2l-table-cell-last,
+	d2l-table[type="default"] .d2l-table-row-last > .d2l-table-cell-last {
+		border-bottom-right-radius: var(--d2l-table-border-radius);
+	}
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table-row-last > .d2l-table-cell-last:not(.d2l-table-cell-first),
+	[dir="rtl"] d2l-table[type="default"] .d2l-table-row-last > .d2l-table-cell-last:not(.d2l-table-cell-first) {
+		border-bottom-right-radius: 0;
+	}
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table-row-last > .d2l-table-cell-last,
+	[dir="rtl"] d2l-table[type="default"] .d2l-table-row-last > .d2l-table-cell-last {
+		border-bottom-left-radius: var(--d2l-table-border-radius);
+	}
+
+	d2l-table-wrapper[type="default"] .d2l-table-row-last > *,
+	d2l-table[type="default"] .d2l-table-row-last > * {
+		border-bottom: var(--d2l-table-border);
+	}
+
+	d2l-table-wrapper[type="light"] .d2l-table-row-last > *,
+	d2l-table[type="light"] .d2l-table-row-last > * {
+		border-bottom: var(--d2l-table-light-border);
+	}
+
+	/* active rows or un-selected hover rows */
+	d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active],
+	d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr:not([selected]):hover,
+	d2l-table[type="default"] d2l-tbody > d2l-tr[active],
+	d2l-table[type="default"][selectable] d2l-tbody > d2l-tr:not([selected]):hover,
+	d2l-table-wrapper[type="light"] .d2l-table > tbody > tr[active],
+	d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > tr:not([selected]):hover,
+	d2l-table[type="light"] d2l-tbody > d2l-tr[active],
+	d2l-table[type="light"][selectable] d2l-tbody > d2l-tr:not([selected]):hover {
+		background-color: var(--d2l-table-row-background-color-active);
+	}
+
+	/* selected rows */
+
+	d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[selected],
+	d2l-table[type="default"] d2l-tbody > d2l-tr[selected],
+	d2l-table-wrapper[type="light"] .d2l-table > tbody > tr[selected],
+	d2l-table[type="light"] d2l-tbody > d2l-tr[selected] {
+		background-color: var(--d2l-table-row-background-color-selected);
+	}
+
+	d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[selected] > .d2l-table-cell-last,
+	d2l-table[type="default"] d2l-tbody > d2l-tr[selected] > .d2l-table-cell-last,
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[selected] > .d2l-table-cell-first,
+	[dir="rtl"] d2l-table[type="default"] d2l-tbody > d2l-tr[selected] > .d2l-table-cell-first {
+		border-right-color: var(--d2l-table-row-border-color-selected);
+	}
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[selected] > .d2l-table-cell-last,
+	[dir="rtl"] d2l-table[type="default"] d2l-tbody > d2l-tr[selected] > .d2l-table-cell-last {
+		border-right-color: var(--d2l-table-border-color);
+	}
+	d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[selected] > .d2l-table-cell-first,
+	d2l-table[type="default"] d2l-tbody > d2l-tr[selected] > .d2l-table-cell-first,
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[selected] > .d2l-table-cell-last,
+	[dir="rtl"] d2l-table[type="default"] d2l-tbody > d2l-tr[selected] > .d2l-table-cell-last {
+		border-left-color: var(--d2l-table-row-border-color-selected);
+	}
+
+	d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[selected] > td,
+	d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[selected] > th,
+	d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[selected] + tr > td,
+	d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[selected] + tr > th,
+	d2l-table[type="default"] d2l-tbody > d2l-tr[selected] > d2l-td,
+	d2l-table[type="default"] d2l-tbody > d2l-tr[selected] > d2l-th,
+	d2l-table[type="default"] d2l-tbody > d2l-tr[selected] + d2l-tr > d2l-td,
+	d2l-table[type="default"] d2l-tbody > d2l-tr[selected] + d2l-tr > d2l-th,
+	d2l-table-wrapper[type="light"] .d2l-table > tbody > tr[selected] > td,
+	d2l-table-wrapper[type="light"] .d2l-table > tbody > tr[selected] > th,
+	d2l-table-wrapper[type="light"] .d2l-table > tbody > tr[selected] + tr > td,
+	d2l-table-wrapper[type="light"] .d2l-table > tbody > tr[selected] + tr > th,
+	d2l-table[type="light"] d2l-tbody > d2l-tr[selected] > d2l-td,
+	d2l-table[type="light"] d2l-tbody > d2l-tr[selected] > d2l-th,
+	d2l-table[type="light"] d2l-tbody > d2l-tr[selected] + d2l-tr > d2l-td,
+	d2l-table[type="light"] d2l-tbody > d2l-tr[selected] + d2l-tr > d2l-th {
+		border-top-color: var(--d2l-table-row-border-color-selected);
+	}
+
+	d2l-table-wrapper[type="default"] .d2l-table-row-last[selected] > td,
+	d2l-table-wrapper[type="default"] .d2l-table-row-last[selected] > th,
+	d2l-table[type="default"] .d2l-table-row-last[selected] > d2l-td,
+	d2l-table[type="default"] .d2l-table-row-last[selected] > d2l-th,
+	d2l-table-wrapper[type="light"] .d2l-table-row-last[selected] > td,
+	d2l-table-wrapper[type="light"] .d2l-table-row-last[selected] > th,
+	d2l-table[type="light"] .d2l-table-row-last[selected] > d2l-td,
+	d2l-table[type="light"] .d2l-table-row-last[selected] > d2l-th {
+		border-bottom-color:var(--d2l-table-row-border-color-selected);
+	}
+
+	/* active + selected rows */
+
+	d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active][selected],
+	d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover,
+	d2l-table[type="default"] d2l-tbody > d2l-tr[active][selected],
+	d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover,
+	d2l-table-wrapper[type="light"] .d2l-table > tbody > tr[active][selected],
+	d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > tr[selected]:hover,
+	d2l-table[type="light"] d2l-tbody > d2l-tr[active][selected],
+	d2l-table[type="light"][selectable] d2l-tbody > d2l-tr[selected]:hover {
+		background-color:var(--d2l-table-row-background-color-active-selected);
+	}
+
+	d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active][selected] > .d2l-table-cell-last,
+	d2l-table[type="default"] d2l-tbody > d2l-tr[active][selected] > .d2l-table-cell-last,
+	d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover > .d2l-table-cell-last,
+	d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover > .d2l-table-cell-last,
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active][selected] > .d2l-table-cell-first,
+	[dir="rtl"] d2l-table[type="default"] d2l-tbody > d2l-tr[active][selected] > .d2l-table-cell-first,
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover > .d2l-table-cell-first,
+	[dir="rtl"] d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover > .d2l-table-cell-first {
+		border-right-color: var(--d2l-table-row-border-color-active-selected);
+	}
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active][selected] > .d2l-table-cell-last,
+	[dir="rtl"] d2l-table[type="default"] d2l-tbody > d2l-tr[active][selected] > .d2l-table-cell-last,
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover > .d2l-table-cell-last,
+	[dir="rtl"] d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover > .d2l-table-cell-last {
+		border-right-color: var(--d2l-table-border-color);
+	}
+	d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active][selected] > .d2l-table-cell-first,
+	d2l-table[type="default"] d2l-tbody > d2l-tr[active][selected] > .d2l-table-cell-first,
+	d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover > .d2l-table-cell-first,
+	d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover > .d2l-table-cell-first,
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover > .d2l-table-cell-last,
+	[dir="rtl"] d2l-table[type="default"] d2l-tbody > d2l-tr[active][selected] > .d2l-table-cell-last,
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active][selected] > .d2l-table-cell-last,
+	[dir="rtl"] d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover > .d2l-table-cell-last {
+		border-left-color: var(--d2l-table-row-border-color-active-selected);
+	}
+
+	d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active][selected] > td,
+	d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active][selected] > th,
+	d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover > td,
+	d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover > th,
+	d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active][selected] + tr > td,
+	d2l-table-wrapper[type="default"] .d2l-table > tbody > tr[active][selected] + tr > th,
+	d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover + tr > td,
+	d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > tr[selected]:hover + tr > th,
+	d2l-table[type="default"] d2l-tbody > d2l-tr[active][selected] > d2l-td,
+	d2l-table[type="default"] d2l-tbody > d2l-tr[active][selected] > d2l-th,
+	d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover > d2l-td,
+	d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover > d2l-th,
+	d2l-table[type="default"] d2l-tbody > d2l-tr[active][selected] + d2l-tr > d2l-td,
+	d2l-table[type="default"] d2l-tbody > d2l-tr[active][selected] + d2l-tr > d2l-th,
+	d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover + d2l-tr > d2l-td,
+	d2l-table[type="default"][selectable] d2l-tbody > d2l-tr[selected]:hover + d2l-tr > d2l-th,
+	d2l-table-wrapper[type="light"] .d2l-table > tbody > tr[active][selected] > td,
+	d2l-table-wrapper[type="light"] .d2l-table > tbody > tr[active][selected] > th,
+	d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > tr[selected]:hover > td,
+	d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > tr[selected]:hover > th,
+	d2l-table-wrapper[type="light"] .d2l-table > tbody > tr[active][selected] + tr > td,
+	d2l-table-wrapper[type="light"] .d2l-table > tbody > tr[active][selected] + tr > th,
+	d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > tr[selected]:hover + tr > td,
+	d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > tr[selected]:hover + tr > th,
+	d2l-table[type="light"] d2l-tbody > d2l-tr[active][selected] > d2l-td,
+	d2l-table[type="light"] d2l-tbody > d2l-tr[active][selected] > d2l-th,
+	d2l-table[type="light"][selectable] d2l-tbody > d2l-tr[selected]:hover > d2l-td,
+	d2l-table[type="light"][selectable] d2l-tbody > d2l-tr[selected]:hover > d2l-th,
+	d2l-table[type="light"] d2l-tbody > d2l-tr[active][selected] + d2l-tr > d2l-td,
+	d2l-table[type="light"] d2l-tbody > d2l-tr[active][selected] + d2l-tr > d2l-th,
+	d2l-table[type="light"][selectable] d2l-tbody > d2l-tr[selected]:hover + d2l-tr > d2l-td,
+	d2l-table[type="light"][selectable] d2l-tbody > d2l-tr[selected]:hover + d2l-tr > d2l-th {
+		border-top-color:var(--d2l-table-row-border-color-active-selected);
+	}
+
+	d2l-table-wrapper[type="default"] .d2l-table-row-last[active][selected] > td,
+	d2l-table-wrapper[type="default"] .d2l-table-row-last[active][selected] > th,
+	d2l-table[type="default"] .d2l-table-row-last[active][selected] > d2l-td,
+	d2l-table[type="default"] .d2l-table-row-last[active][selected] > d2l-th,
+	d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > .d2l-table-row-last[selected]:hover > td,
+	d2l-table-wrapper[type="default"] .d2l-table[selectable] > tbody > .d2l-table-row-last[selected]:hover > th,
+	d2l-table[type="default"][selectable] d2l-tbody > .d2l-table-row-last[selected]:hover > d2l-td,
+	d2l-table[type="default"][selectable] d2l-tbody > .d2l-table-row-last[selected]:hover > d2l-th,
+	d2l-table-wrapper[type="light"] .d2l-table-row-last[active][selected] > td,
+	d2l-table-wrapper[type="light"] .d2l-table-row-last[active][selected] > th,
+	d2l-table[type="light"] .d2l-table-row-last[active][selected] > d2l-td,
+	d2l-table[type="light"] .d2l-table-row-last[active][selected] > d2l-th,
+	d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > .d2l-table-row-last[selected]:hover > td,
+	d2l-table-wrapper[type="light"] .d2l-table[selectable] > tbody > .d2l-table-row-last[selected]:hover > th,
+	d2l-table[type="light"][selectable] d2l-tbody > .d2l-table-row-last[selected]:hover > d2l-td,
+	d2l-table[type="light"][selectable] d2l-tbody > .d2l-table-row-last[selected]:hover > d2l-th {
+		border-bottom-color:var(--d2l-table-row-border-color-active-selected);
+	}
+
+	/* no-column-border */
+	d2l-table-wrapper[type="default"] .d2l-table[no-column-border] > tbody > tr > td:not(.d2l-table-cell-last),
+	d2l-table-wrapper[type="default"] .d2l-table[no-column-border] > tbody > tr > th:not(.d2l-table-cell-last),
+	d2l-table[type="default"][no-column-border] d2l-tbody > d2l-tr > d2l-td:not(.d2l-table-cell-last),
+	d2l-table[type="default"][no-column-border] d2l-tbody > d2l-tr > d2l-th:not(.d2l-table-cell-last) {
+		border-right: none;
+	}
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table[no-column-border] > tbody > tr > .d2l-table-cell-last,
+	[dir="rtl"] d2l-table[type="default"][no-column-border] d2l-tbody > d2l-tr > .d2l-table-cell-last {
+		border-right: none;
+	}
+	[dir="rtl"] d2l-table-wrapper[type="default"] .d2l-table[no-column-border] > tbody > tr > .d2l-table-cell-first,
+	[dir="rtl"] d2l-table[type="default"][no-column-border] d2l-tbody > d2l-tr > .d2l-table-cell-first {
+		border-right: var(--d2l-table-border);
+	}
+
+	/* sticky-headers */
+
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] table,
+	[dir="rtl"] d2l-table-wrapper[type="light"][sticky-headers] table {
+		padding-left: 20px;
+	}
+
+	d2l-table-wrapper[type="default"][sticky-headers] tr,
+	d2l-table-wrapper[type="light"][sticky-headers] tr {
+		background-color: inherit;
+	}
+
+	d2l-table-wrapper[type="default"][sticky-headers] tr[header] th,
+	d2l-table-wrapper[type="default"][sticky-headers] thead tr th,
+	d2l-table-wrapper[type="light"][sticky-headers] tr[header] th,
+	d2l-table-wrapper[type="light"][sticky-headers] thead tr th {
+		position: -webkit-sticky;
+		position: sticky;
+		top: 0;
+	}
+
+	d2l-table-wrapper[type="default"][sticky-headers] tr[header] th,
+	d2l-table-wrapper[type="default"][sticky-headers] thead tr th {
+		border-bottom: var(--d2l-table-border);
+	}
+
+	d2l-table-wrapper[type="light"][sticky-headers] tr[header] th,
+	d2l-table-wrapper[type="light"][sticky-headers] thead tr th {
+		border-bottom: var(--d2l-table-light-border);
+	}
+
+	d2l-table-wrapper[type="default"][sticky-headers] td[sticky].d2l-table-cell-first,
+	d2l-table-wrapper[type="default"][sticky-headers] th[sticky].d2l-table-cell-first,
+	d2l-table-wrapper[type="default"][sticky-headers] td[sticky]:first-child,
+	d2l-table-wrapper[type="default"][sticky-headers] th[sticky]:first-child,
+	d2l-table-wrapper[type="light"][sticky-headers] td[sticky].d2l-table-cell-first,
+	d2l-table-wrapper[type="light"][sticky-headers] th[sticky].d2l-table-cell-first,
+	d2l-table-wrapper[type="light"][sticky-headers] td[sticky]:first-child,
+	d2l-table-wrapper[type="light"][sticky-headers] th[sticky]:first-child {
+		left: -5px;
+	}
+
+	d2l-table-wrapper[type="default"][sticky-headers] tr[header] + tr[header] [sticky].d2l-table-cell-first,
+	d2l-table-wrapper[type="default"][sticky-headers] thead tr + tr [sticky]:first-child,
+	d2l-table-wrapper[type="light"][sticky-headers] tr[header] + tr[header] [sticky].d2l-table-cell-first,
+	d2l-table-wrapper[type="light"][sticky-headers] thead tr + tr [sticky]:first-child {
+		left: 0;
+	}
+
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] td[sticky].d2l-table-cell-first,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] th[sticky].d2l-table-cell-first,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] td[sticky]:first-child,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] th[sticky]:first-child,
+	[dir="rtl"] d2l-table-wrapper[type="light"][sticky-headers] td[sticky].d2l-table-cell-first,
+	[dir="rtl"] d2l-table-wrapper[type="light"][sticky-headers] th[sticky].d2l-table-cell-first,
+	[dir="rtl"] d2l-table-wrapper[type="light"][sticky-headers] td[sticky]:first-child,
+	[dir="rtl"] d2l-table-wrapper[type="light"][sticky-headers] th[sticky]:first-child {
+		right: -5px;
+	}
+
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] tr[header] + tr[header] [sticky].d2l-table-cell-first,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] thead tr + tr [sticky]:first-child,
+	[dir="rtl"] d2l-table-wrapper[type="light"][sticky-headers] tr[header] + tr[header] [sticky].d2l-table-cell-first,
+	[dir="rtl"] d2l-table-wrapper[type="light"][sticky-headers] thead tr + tr [sticky]:first-child {
+		right: 0;
+	}
+
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] tr[header]:not(.d2l-table-row-first) th,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] tr[header]:not(.d2l-table-row-first) td,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] thead tr:not(:first-child) th {
+		border-left: var(--d2l-table-border);
+	}
+
+	d2l-table-wrapper[type="default"][sticky-headers] tr[header]:not(.d2l-table-row-first) th,
+	d2l-table-wrapper[type="default"][sticky-headers] tr[header]:not(.d2l-table-row-first) td,
+	d2l-table-wrapper[type="default"][sticky-headers] thead tr:not(:first-child) th,
+	d2l-table-wrapper[type="light"][sticky-headers] tr[header]:not(.d2l-table-row-first) th,
+	d2l-table-wrapper[type="light"][sticky-headers] tr[header]:not(.d2l-table-row-first) td,
+	d2l-table-wrapper[type="light"][sticky-headers] thead tr:not(:first-child) th {
+		position: -webkit-sticky;
+		position: sticky;
+		top: -5px;
+		border-left: none;
+		border-top: none;
+	}
+
+	d2l-table-wrapper[type="default"][sticky-headers] tr[header]:not(.d2l-table-row-first) th,
+	d2l-table-wrapper[type="default"][sticky-headers] tr[header]:not(.d2l-table-row-first) td,
+	d2l-table-wrapper[type="default"][sticky-headers] thead tr:not(:first-child) th {
+		border-bottom: var(--d2l-table-border);
+	}
+
+	d2l-table-wrapper[type="light"][sticky-headers] tr[header]:not(.d2l-table-row-first) th,
+	d2l-table-wrapper[type="light"][sticky-headers] tr[header]:not(.d2l-table-row-first) td,
+	d2l-table-wrapper[type="light"][sticky-headers] thead tr:not(:first-child) th {
+		border-bottom: var(--d2l-table-light-border);
+	}
+
+	d2l-table-wrapper[type="default"][sticky-headers] tr[header] th,
+	d2l-table-wrapper[type="default"][sticky-headers] tr[header] td,
+	d2l-table-wrapper[type="default"][sticky-headers] thead tr th {
+		position: -webkit-sticky;
+		position: sticky;
+		top: -5px;
+	}
+
+	d2l-table-wrapper[type="light"][sticky-headers] tr[header] th,
+	d2l-table-wrapper[type="light"][sticky-headers] tr[header] td,
+	d2l-table-wrapper[type="light"][sticky-headers] thead tr th {
+		position: -webkit-sticky;
+		position: sticky;
+		top: -3.5px;
+	}
+
+	d2l-table-wrapper[type="default"][sticky-headers] tbody tr:not([header]) td,
+	d2l-table-wrapper[type="default"][sticky-headers] tbody tr:not([header]) th {
+		border-top: var(--d2l-table-border);
+		border-bottom: none;
+	}
+
+	d2l-table-wrapper[type="light"][sticky-headers] tbody tr:not([header]) td,
+	d2l-table-wrapper[type="light"][sticky-headers] tbody tr:not([header]) th {
+		border-top: var(--d2l-table-light-border);
+		border-bottom: none;
+	}
+
+	d2l-table-wrapper[type="default"][sticky-headers] tr[header] + tr:not([header]) td,
+	d2l-table-wrapper[type="default"][sticky-headers] tr[header] + tr:not([header]) th,
+	d2l-table-wrapper[type="default"][sticky-headers] tbody tr:not([header]):not([selected]):first-child td,
+	d2l-table-wrapper[type="default"][sticky-headers] tbody tr:not([header]):not([selected]):first-child th,
+	d2l-table-wrapper[type="light"][sticky-headers] tr[header] + tr:not([header]) td,
+	d2l-table-wrapper[type="light"][sticky-headers] tr[header] + tr:not([header]) th,
+	d2l-table-wrapper[type="light"][sticky-headers] tbody tr:not([header]):not([selected]):first-child td,
+	d2l-table-wrapper[type="light"][sticky-headers] tbody tr:not([header]):not([selected]):first-child th  {
+		border-top: none;
+		border-bottom: none;
+	}
+
+	d2l-table-wrapper[type="default"][sticky-headers] .d2l-table > thead > tr[header] + tr:not([header])[selected] > td,
+	d2l-table-wrapper[type="default"][sticky-headers] .d2l-table > tbody > tr[header] + tr:not([header])[selected] > td,
+	d2l-table-wrapper[type="default"][sticky-headers] tr[header] + tr:not([header])[selected] th,
+	d2l-table-wrapper[type="default"][sticky-headers] tbody tr[selected]:first-child td,
+	d2l-table-wrapper[type="default"][sticky-headers] tbody tr[selected]:first-child th {
+		border-top: var(--d2l-table-border);
+		border-top-color: var(--d2l-table-row-border-color-selected);
+	}
+
+	d2l-table-wrapper[type="light"][sticky-headers] .d2l-table > thead > tr[header] + tr:not([header])[selected] > td,
+	d2l-table-wrapper[type="light"][sticky-headers] .d2l-table > tbody > tr[header] + tr:not([header])[selected] > td,
+	d2l-table-wrapper[type="light"][sticky-headers] tr[header] + tr:not([header])[selected] th,
+	d2l-table-wrapper[type="light"][sticky-headers] tbody tr[selected]:first-child td,
+	d2l-table-wrapper[type="light"][sticky-headers] tbody tr[selected]:first-child th {
+		border-top: var(--d2l-table-light-border);
+		border-top-color: var(--d2l-table-row-border-color-selected);
+	}
+
+	d2l-table-wrapper[type="default"][sticky-headers] tr[header] th[sticky],
+	d2l-table-wrapper[type="default"][sticky-headers] tr[header] td[sticky],
+	d2l-table-wrapper[type="default"][sticky-headers] thead > tr > th[sticky],
+	d2l-table-wrapper[type="light"][sticky-headers] tr[header] th[sticky],
+	d2l-table-wrapper[type="light"][sticky-headers] tr[header] td[sticky],
+	d2l-table-wrapper[type="light"][sticky-headers] thead > tr > th[sticky] {
+		z-index: 3;
+		left: 0;
+	}
+
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] th[sticky],
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] td[sticky],
+	[dir="rtl"] d2l-table-wrapper[type="light"][sticky-headers] th[sticky],
+	[dir="rtl"] d2l-table-wrapper[type="light"][sticky-headers] td[sticky] {
+		right: 0;
+	}
+
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table-cell-last,
+	[dir="rtl"] d2l-table-wrapper[type="light"][sticky-headers] .d2l-table-cell-last {
+		border-left: none;
+	}
+
+	d2l-table-wrapper[type="default"][sticky-headers] tbody :not([header]) [sticky],
+	d2l-table-wrapper[type="light"][sticky-headers] tbody :not([header]) [sticky]{
+		position: -webkit-sticky;
+		position: sticky;
+		left: 0;
+		z-index: 1;
+		background-color: inherit;
+	}
+
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table > thead > tr > td,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table > tbody > tr > td,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table th {
+		border-left: var(--d2l-table-border);
+		border-right: none;
+	}
+
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table [selected] .d2l-table-cell-last,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table > thead > tr[selected] > td:last-child,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table > tbody > tr[selected] > td:last-child {
+		border-left: var(--d2l-table-border);
+		border-left-color: var(--d2l-table-row-border-color-selected);
+	}
+
+	d2l-table-wrapper[type="default"][sticky-headers] .d2l-table tr[selected] th,
+	d2l-table-wrapper[type="default"][sticky-headers] .d2l-table tr[selected] td {
+		border-top: var(--d2l-table-border);
+		border-top-color: var(--d2l-table-row-border-color-selected);
+	}
+
+	d2l-table-wrapper[type="light"][sticky-headers] .d2l-table tr[selected] th,
+	d2l-table-wrapper[type="light"][sticky-headers] .d2l-table tr[selected] td {
+		border-top: var(--d2l-table-light-border);
+		border-top-color: var(--d2l-table-row-border-color-selected);
+	}
+
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table .d2l-table-cell-first,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table > thead > tr > td:first-child,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table > tbody > tr > td:first-child,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table th:first-child {
+		border-right: var(--d2l-table-border);
+	}
+
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table [selected] .d2l-table-cell-first,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table > thead > tr[selected] > td:first-child,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table > tbody > tr[selected] > td:first-child,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table [selected] th:first-child {
+		border-right-color: var(--d2l-table-row-border-color-selected);
+	}
+
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table [selected] .d2l-table-cell-first,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table [selected] > thead > tr > td:first-child,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table [selected] > tbody > tr > td:first-child,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table [selected] + :not([selected]) .d2l-table-cell-last,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table [selected] + :not([selected]) td:last-child {
+		border-left: var(--d2l-table-border);
+	}
+
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table [header] + [header] > td,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table [header] + [header] > th,
+	[dir="rtl"] d2l-table-wrapper[type="default"][sticky-headers] .d2l-table thead tr:not(:first-child) th {
+		border-right: none;
+	}
+
+	d2l-table-wrapper[type="default"][sticky-headers] .d2l-table > tbody > tr.d2l-table-row-last > td,
+	d2l-table-wrapper[type="default"][sticky-headers] .d2l-table > tbody > tr.d2l-table-row-last > th {
+		border-bottom: var(--d2l-table-border)
+	}
+
+	d2l-table-wrapper[type="light"][sticky-headers] .d2l-table > tbody > tr.d2l-table-row-last > td,
+	d2l-table-wrapper[type="light"][sticky-headers] .d2l-table > tbody > tr.d2l-table-row-last > th {
+		border-bottom: var(--d2l-table-light-border)
+	}
+
+	d2l-table-wrapper[type="default"][sticky-headers] .d2l-table tr[selected].d2l-table-row-last td,
+	d2l-table-wrapper[type="default"][sticky-headers] .d2l-table tr[selected].d2l-table-row-last th,
+	d2l-table-wrapper[type="light"][sticky-headers] .d2l-table tr[selected].d2l-table-row-last td,
+	d2l-table-wrapper[type="light"][sticky-headers] .d2l-table tr[selected].d2l-table-row-last th {
+		border-bottom-color: var(--d2l-table-row-border-color-selected);
+	}
+
+	d2l-table-wrapper[type="default"][sticky-headers] .d2l-table > tbody > tr.d2l-table-row-first.d2l-table-row-last > td.d2l-table-cell-first.d2l-table-cell-last {
+		border-top: var(--d2l-table-border);
+		border-bottom: var(--d2l-table-border);
+	}
+
+	d2l-table-wrapper[type="light"][sticky-headers] .d2l-table > tbody > tr.d2l-table-row-first.d2l-table-row-last > td.d2l-table-cell-first.d2l-table-cell-last {
+		border-top: var(--d2l-table-light-border);
+		border-bottom: var(--d2l-table-light-border);
+	}
+`;


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F465115111280

As part of this story I made use of the Polymer [d2l-table component ](https://github.com/BrightspaceUI/table) by adding it to Lit Element components. Testing on Chrome based browsers the styling applied correctly however when I tested on firefox/safari styles were not being picked up at all.  

To get styling to work on Chrome I had added this style tag when rendering the table:

```
<custom-style>
    <style include="d2l-table-style">
    </style>
</custom-style>
```

The "fix" I added which works locally on firefox was to copy all of the styles from `d2l-table-style` and add them as part of LitElement CSS.

Is there a better solution for this? Am I missing a polyfill or something that's preventing other browsers from picking up this styling?