### PR TITLE
W2D: Activities without start dates should still work

### DIFF
--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
@@ -41,7 +41,7 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 				type: Number
 			},
 			/** whether or not the activity has a startDate in the past */
-			isStarted: {
+			isStartedProperty: {
 				attribute: 'is-started',
 				type: Boolean
 			}
@@ -183,7 +183,7 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 			? html `<d2l-icon class="d2l-icon-bullet" icon="tier1:bullet"></d2l-icon>`
 			: nothing;
 
-		const startDateTemplate = !this.skeleton && !this.isStarted
+		const startDateTemplate = !this.skeleton && !this._started
 			? html `
 			<div class="d2l-status-container">
 				<d2l-status-indicator state="none" text="${this._startDateFormatted}"></d2l-status-indicator>
@@ -224,6 +224,13 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 		return this._usage && !this.skeleton
 			? this._usage.dueDate() || this._usage.endDate()
 			: '';
+	}
+
+	/** Indicates if activity start date is in the past */
+	get _started() {
+		return this._usage && this._usage.startDate()
+			? this.isStartedProperty
+			: true;
 	}
 
 	/** Start Date formatted like (Short month) (Day) e.g. "Aug 15" */
@@ -305,7 +312,7 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 						&& this._activity.getLinkByRel(this._activityProperties.linkRel)
 					) || this._activity.getLinkByRel('alternate');
 
-					this.actionHref = (this.isStarted && (this.evaluateAllHref || (link && link.href))) || null;
+					this.actionHref = (this._started && (this.evaluateAllHref || (link && link.href))) || null;
 				}
 
 				break;

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-detailed.js
@@ -30,7 +30,7 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 			/** entity associated with ActivityUsageEntity's organization */
 			_organization: { type: Object },
 			/** whether or not the activity has a startDate in the past */
-			isStarted: {
+			isStartedProperty: {
 				attribute: 'is-started',
 				type: Boolean
 			}
@@ -238,7 +238,7 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 			? html `<d2l-icon class="d2l-icon-bullet" icon="tier1:bullet"></d2l-icon>`
 			: nothing;
 
-		const startDateTemplate = !this.skeleton && !this.isStarted
+		const startDateTemplate = !this.skeleton && !this._started
 			? html `
 			<div class="d2l-status-container">
 				<d2l-status-indicator state="none" text="${this._startDateFormatted}"></d2l-status-indicator>
@@ -338,6 +338,13 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 			: '';
 	}
 
+	/** Indicates if activity start date is in the past */
+	get _started() {
+		return this._usage && this._usage.startDate()
+			? this.isStartedProperty
+			: true;
+	}
+
 	/** Start Date formatted like (Short month) (Day) e.g. "Aug 15" */
 	get _startDateFormatted() {
 		return this.localize('StartsWithDate', 'startDate',
@@ -378,7 +385,7 @@ class ActivityListItemDetailed extends ListItemLinkMixin(SkeletonMixin(EntityMix
 						&& this._activity.getLinkByRel(this._activityProperties.linkRel)
 					) || this._activity.getLinkByRel('alternate');
 
-					this.actionHref = (this.isStarted && (link && link.href)) || null;
+					this.actionHref = (this._started && (link && link.href)) || null;
 				}
 
 				break;

--- a/components/d2l-work-to-do/d2l-work-to-do.js
+++ b/components/d2l-work-to-do/d2l-work-to-do.js
@@ -206,7 +206,7 @@ class WorkToDoWidget extends EntityMixinLit(WorkToDoTelemetryMixin(LocalizeWorkT
 			if (!activities || activities.length === 0 || displayLimit === 0) {
 				return nothing;
 			}
-			console.log('');
+
 			const items = repeat(
 				activities.slice(0, displayLimit),
 				item => item.links,

--- a/components/d2l-work-to-do/d2l-work-to-do.js
+++ b/components/d2l-work-to-do/d2l-work-to-do.js
@@ -206,7 +206,7 @@ class WorkToDoWidget extends EntityMixinLit(WorkToDoTelemetryMixin(LocalizeWorkT
 			if (!activities || activities.length === 0 || displayLimit === 0) {
 				return nothing;
 			}
-
+			console.log('');
 			const items = repeat(
 				activities.slice(0, displayLimit),
 				item => item.links,


### PR DESCRIPTION
Slack thread: https://d2l.slack.com/archives/G0150CJ3SB1/p1613151652045800

tl;dr if an activity has no start date, it should act as if it _has_ started - my prior code assumed the opposite, this should fix that.