### PR TITLE
fix: refactor handling of d2l-request-provider for html-editor-enable…

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor.js
@@ -85,7 +85,9 @@ class AssignmentEditor extends AsyncContainerMixin(RtlMixin(LocalizeActivityAssi
 				@d2l-request-provider="${this._onRequestProvider}"
 				width-type="${this.widthType}"
 				error-term="${this.localize('assignmentSaveError')}"
-				?isnew="${this.isNew}">
+				?isnew="${this.isNew}"
+				?html-editor-enabled="${this.htmlEditorEnabled}"
+				?html-new-editor-enabled="${this.htmlNewEditorEnabled}">
 
 				${this._editorTemplate}
 
@@ -126,18 +128,6 @@ class AssignmentEditor extends AsyncContainerMixin(RtlMixin(LocalizeActivityAssi
 	}
 
 	_onRequestProvider(e) {
-		if (e.detail.key === 'd2l-provider-html-editor-enabled') {
-			e.detail.provider = this.htmlEditorEnabled;
-			e.stopPropagation();
-			return;
-		}
-
-		if (e.detail.key === 'd2l-provider-html-new-editor-enabled') {
-			e.detail.provider = this.htmlNewEditorEnabled;
-			e.stopPropagation();
-			return;
-		}
-
 		// Provides unfurl API endpoint for d2l-labs-attachment component
 		// https://github.com/Brightspace/attachment/blob/e44cab1f0cecc55dd93acf59212fabc6872c0bd3/components/attachment.js#L110
 		if (e.detail.key === 'd2l-provider-unfurl-api-endpoint') {

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -21,6 +21,8 @@ class ActivityEditor extends ActivityEditorContainerMixin(ActivityEditorTelemetr
 		return {
 			widthType: { type: String, attribute: 'width-type' },
 			errorTerm: { type: String, attribute: 'error-term' },
+			htmlEditorEnabled: { type: Boolean, attribute: 'html-editor-enabled' },
+			htmlNewEditorEnabled: { type: Boolean, attribute: 'html-new-editor-enabled' },
 			_backdropShown: { type: Boolean },
 			_saveToastVisible: { type: Boolean }
 		};
@@ -70,11 +72,13 @@ class ActivityEditor extends ActivityEditorContainerMixin(ActivityEditorTelemetr
 	connectedCallback() {
 		super.connectedCallback();
 		this.addEventListener('d2l-activity-editor-save-complete', this._onSaveComplete);
+		this.addEventListener('d2l-request-provider', this._onRequestProvider);
 	}
 
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		this.removeEventListener('d2l-activity-editor-save-complete', this._onSaveComplete);
+		this.removeEventListener('d2l-request-provider', this._onRequestProvider);
 	}
 
 	render() {
@@ -85,7 +89,10 @@ class ActivityEditor extends ActivityEditorContainerMixin(ActivityEditorTelemetr
 
 		return html`
 			<div id="editor-container">
-				<d2l-template-primary-secondary background-shading="secondary" width-type="${this.widthType}">
+				<d2l-template-primary-secondary
+					background-shading="secondary"
+					width-type="${this.widthType}">
+
 					<slot name="header" slot="header"></slot>
 					<div slot="primary" class="d2l-primary-panel">
 						<d2l-alert type="error" ?hidden=${!this.isError}>${this.errorTerm}</d2l-alert>
@@ -170,6 +177,20 @@ class ActivityEditor extends ActivityEditorContainerMixin(ActivityEditorTelemetr
 
 	_toggleBackdrop(show) {
 		this._backdropShown = show;
+	}
+
+	_onRequestProvider(e) {
+		if (e.detail.key === 'd2l-provider-html-editor-enabled') {
+			e.detail.provider = this.htmlEditorEnabled;
+			e.stopPropagation();
+			return;
+		}
+
+		if (e.detail.key === 'd2l-provider-html-new-editor-enabled') {
+			e.detail.provider = this.htmlNewEditorEnabled;
+			e.stopPropagation();
+			return;
+		}
 	}
 }
 customElements.define('d2l-activity-editor', ActivityEditor);

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -164,6 +164,20 @@ class ActivityEditor extends ActivityEditorContainerMixin(ActivityEditorTelemetr
 		}
 	}
 
+	_onRequestProvider(e) {
+		if (e.detail.key === 'd2l-provider-html-editor-enabled') {
+			e.detail.provider = this.htmlEditorEnabled;
+			e.stopPropagation();
+			return;
+		}
+
+		if (e.detail.key === 'd2l-provider-html-new-editor-enabled') {
+			e.detail.provider = this.htmlNewEditorEnabled;
+			e.stopPropagation();
+			return;
+		}
+	}
+
 	_onSaveComplete(e) {
 		if (e.detail.saveInPlace) {
 			this._saveToastVisible = true;
@@ -177,20 +191,6 @@ class ActivityEditor extends ActivityEditorContainerMixin(ActivityEditorTelemetr
 
 	_toggleBackdrop(show) {
 		this._backdropShown = show;
-	}
-
-	_onRequestProvider(e) {
-		if (e.detail.key === 'd2l-provider-html-editor-enabled') {
-			e.detail.provider = this.htmlEditorEnabled;
-			e.stopPropagation();
-			return;
-		}
-
-		if (e.detail.key === 'd2l-provider-html-new-editor-enabled') {
-			e.detail.provider = this.htmlNewEditorEnabled;
-			e.stopPropagation();
-			return;
-		}
 	}
 }
 customElements.define('d2l-activity-editor', ActivityEditor);

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -50,8 +50,9 @@ class QuizEditor extends AsyncContainerMixin(RtlMixin(LocalizeActivityQuizEditor
 				.token=${this.token}
 				width-type="${this.widthType}"
 				error-term="${this.localize('quizSaveError')}"
-				@d2l-request-provider="${this._onRequestProvider}"
-				?isnew="${this.isNew}">
+				?isnew="${this.isNew}"
+				?html-editor-enabled="${this.htmlEditorEnabled}"
+				?html-new-editor-enabled="${this.htmlNewEditorEnabled}">
 
 				${this._editorTemplate}
 
@@ -83,20 +84,5 @@ class QuizEditor extends AsyncContainerMixin(RtlMixin(LocalizeActivityQuizEditor
 			</div>
 		`;
 	}
-
-	_onRequestProvider(e) {
-		if (e.detail.key === 'd2l-provider-html-editor-enabled') {
-			e.detail.provider = this.htmlEditorEnabled;
-			e.stopPropagation();
-			return;
-		}
-
-		if (e.detail.key === 'd2l-provider-html-new-editor-enabled') {
-			e.detail.provider = this.htmlNewEditorEnabled;
-			e.stopPropagation();
-			return;
-		}
-	}
-
 }
 customElements.define('d2l-activity-quiz-editor', QuizEditor);


### PR DESCRIPTION
…d and html-new-editor-enabled, used by all activity editor types.

@mdgbayly this is something you suggested in a previous PR, am just getting to it, as I was about to add another attribute for an LD flag. Figured I should refactor this first.