### PR TITLE
Us123398/fix ip validation

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restriction-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restriction-editor.js
@@ -36,14 +36,6 @@ class ActivityQuizIpRestrictionEditor
 					display: none;
 				}
 
-				#ip-restriction-editor-label {
-					margin-bottom: 10px;
-				}
-
-				d2l-button {
-					margin: 1rem 0;
-				}
-
 				d2l-alert {
 					margin: 1rem 0;
 				}
@@ -69,13 +61,6 @@ class ActivityQuizIpRestrictionEditor
 		`;
 	}
 
-	_renderActionButtons() {
-		return html`
-			<d2l-button primary @click=${this._saveRestrictions}>${this.localize('btnIpRestrictionsDialogAdd')}</d2l-button>
-			<d2l-button data-dialog-action>${this.localize('btnIpRestrictionsDialogBtnCancel')}</d2l-button>
-		`;
-	}
-
 	_renderDialog() {
 		return html`
 			<d2l-dialog
@@ -86,18 +71,23 @@ class ActivityQuizIpRestrictionEditor
 				${this._renderErrors()}
 				${this._renderHelpDialog()}
 				${this._renderIpRestrictionsContainer()}
-				${this._renderActionButtons()}
 
 			</d2l-dialog>
 		`;
 	}
 
 	_renderDialogOpener() {
+		const entity = ipStore.get(this.ipRestrictionsHref);
+		if (!entity) {
+			return;
+		}
+
 		return html`
-			<div id="ip-restriction-editor-label" class="d2l-label-text">
+			<div class="d2l-label-text">
 				${this.localize('ipRestrictionLabel')}
 			</div>
 			<d2l-button-subtle
+				?disabled=${!entity.canEditIpRestrictions}
 				text="${this.localize('btnOpenIpRestrictionDialog')}"
 				h-align="text"
 				@click="${this.open}">
@@ -143,7 +133,8 @@ class ActivityQuizIpRestrictionEditor
 			<d2l-activity-quiz-ip-restrictions-container
 				href="${this.ipRestrictionsHref}"
 				.token="${this.token}"
-				@restrictions-resize-dialog="${this._resizeDialog}">
+				@restrictions-resize-dialog="${this._resizeDialog}"
+				@close-ip-dialog="${this.handleClose}">
 			</d2l-activity-quiz-ip-restrictions-container>
 		`;
 	}
@@ -151,19 +142,6 @@ class ActivityQuizIpRestrictionEditor
 	_resizeDialog() {
 		const dialog = this.shadowRoot.querySelector('d2l-dialog');
 		dialog.resize();
-	}
-
-	async _saveRestrictions() {
-		const entity = ipStore.get(this.ipRestrictionsHref);
-		if (!entity) {
-			return;
-		}
-
-		await entity.saveRestrictions();
-
-		if (!entity.errors || !entity.errors.length) {
-			this.handleClose();
-		}
 	}
 }
 

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restrictions-container.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restrictions-container.js
@@ -18,7 +18,7 @@ class ActivityQuizIpRestrictionsContainer extends ActivityEditorMixin(ActivityEd
 	static get styles() {
 		return css`
 				:host {
-					border-bottom: solid 1px var(--d2l-color-gypsum);
+
 					display: block;
 				}
 				:host([hidden]) {
@@ -26,6 +26,15 @@ class ActivityQuizIpRestrictionsContainer extends ActivityEditorMixin(ActivityEd
 				}
 				d2l-button-subtle {
 					margin: 0.5rem 0;
+				}
+				d2l-thead {
+					font-weight: 700;
+				}
+				d2l-button {
+					margin: 1rem 0;
+				}
+				#d2l-actions-container {
+					border-top: solid 1px var(--d2l-color-gypsum);
 				}
 			`;
 	}
@@ -47,6 +56,7 @@ class ActivityQuizIpRestrictionsContainer extends ActivityEditorMixin(ActivityEd
 
 		return html`
 			${this._renderIpRestrictionTable()}
+			${this._renderAddRowButton()}
 			${this._renderActionButtons()}
     	`;
 	}
@@ -60,7 +70,7 @@ class ActivityQuizIpRestrictionsContainer extends ActivityEditorMixin(ActivityEd
 		entity.addRestriction();
 	}
 
-	_deleteIpRestriction(_, index) {
+	async _deleteIpRestriction(_, index) {
 		const entity = store.get(this.href);
 		if (!entity) {
 			return;
@@ -71,6 +81,9 @@ class ActivityQuizIpRestrictionsContainer extends ActivityEditorMixin(ActivityEd
 		}
 
 		entity.deleteIpRestriction(index);
+
+		await this.updateComplete;
+		this._validate();
 	}
 
 	_generateHandler(handler, rowindex) {
@@ -90,10 +103,19 @@ class ActivityQuizIpRestrictionsContainer extends ActivityEditorMixin(ActivityEd
 
 	_renderActionButtons() {
 		return html`
+			<div id="d2l-actions-container">
+				<d2l-button primary @click=${this._saveRestrictions}>${this.localize('btnIpRestrictionsDialogAdd')}</d2l-button>
+				<d2l-button @click=${this._sendCloseEvent}>${this.localize('btnIpRestrictionsDialogBtnCancel')}</d2l-button>
+			</div>
+		`;
+	}
+
+	_renderAddRowButton() {
+		return html`
 			<d2l-button-subtle
 				text=${this.localize('ipRestrictionsDialogAddNewRange')}
 				h-align="text"
-				icon="tier1:plus-default"
+				icon="tier1:plus-large"
 				@click="${this._addRow}">
 			</d2l-button-subtle>
 		`;
@@ -141,9 +163,9 @@ class ActivityQuizIpRestrictionsContainer extends ActivityEditorMixin(ActivityEd
 					<d2l-th>
 
 						<d2l-input-text
+							class="d2l-ip-input"
 							@input="${this._generateHandler(this._handleChange, index)}"
 							value="${start}"
-							@blur=${this._validateRestriction}
 							name="start">
 						</d2l-input-text>
 
@@ -151,9 +173,9 @@ class ActivityQuizIpRestrictionsContainer extends ActivityEditorMixin(ActivityEd
 					<d2l-th>
 
 						<d2l-input-text
+							class="d2l-ip-input"
 							@input="${this._generateHandler(this._handleChange, index)}"
 							value="${end}"
-							@blur=${this._validateRestriction}
 							name="end">
 						</d2l-input-text>
 
@@ -170,29 +192,68 @@ class ActivityQuizIpRestrictionsContainer extends ActivityEditorMixin(ActivityEd
 		});
 	}
 
+	async _saveRestrictions() {
+		const entity = store.get(this.href);
+		if (!entity) {
+			return;
+		}
+
+		const hasValidationError = this._validate();
+
+		if (hasValidationError) {
+			return;
+		}
+
+		await entity.saveRestrictions();
+
+		if (!entity.errors || !entity.errors.length) {
+			this._handleClose();
+		}
+	}
+
+	_sendCloseEvent() {
+		this.dispatchEvent(new CustomEvent('close-ip-dialog', { bubbles: true, composed: true }));
+	}
+
 	_sendResizeEvent() {
 		this.dispatchEvent(new CustomEvent('restrictions-resize-dialog', { bubbles: true, composed: true }));
 	}
 
-	_validateRestriction(e) {
-		if (!e || !e.target || !e.target.value) {
-			return;
+	_validate() {
+		const inputs = this.shadowRoot.querySelectorAll('.d2l-ip-input');
+		let hasValidationError = false;
+
+		for (const input of inputs) {
+			if (!this._validateRestriction(input)) {
+				hasValidationError = true;
+			}
 		}
 
 		const entity = store.get(this.href);
 
-		const isValid = validateIp(e.target.value);
-
-		e.target.setAttribute('aria-invalid', !isValid);
-
-		if (isValid) {
-			entity.setErrors([]);
-			this._sendResizeEvent();
-		} else {
+		if (hasValidationError) {
 			const errorMsg = this.localize('ipRestrictionsValidationError');
 			entity.setErrors([errorMsg]);
+		} else {
+			entity.setErrors([]);
+			this._sendResizeEvent();
 		}
+
+		return hasValidationError;
 	}
+
+	_validateRestriction(restriction) {
+		if (!restriction) {
+			return true;
+		}
+
+		const isValid = !restriction.formValue || validateIp(restriction.formValue);
+
+		restriction.setAttribute('aria-invalid', !isValid);
+
+		return isValid;
+	}
+
 }
 
 customElements.define(

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restrictions-container.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restrictions-container.js
@@ -207,7 +207,7 @@ class ActivityQuizIpRestrictionsContainer extends ActivityEditorMixin(ActivityEd
 		await entity.saveRestrictions();
 
 		if (!entity.errors || !entity.errors.length) {
-			this._handleClose();
+			this._sendCloseEvent();
 		}
 	}
 


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F465115111280

Addressing comments from @me-louie when testing. I refactored the validation logic to occur on save instead of on blur. Basically it prevents saving if there are validation errors and points out which boxes need corrected. When errors are corrected and the user presses save there is the same server side error handling as before. The reason for this change is that handling it on blur meant the error states became difficult to manage. It wasn't specified in the design when the validation should occur so hopefully this approach is ok. 

I added a few small fixes such as increasing the icon size to large and disabling the dialog opener if user lacks permissions as well. 

