### PR TITLE
feat: Updated lang term as per design

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
@@ -86,7 +86,7 @@ export default {
 	"ipRestrictionDialogDescription": "Only learners coming from IP addresses that meet the defined restrictions can write the quiz.", // guidelines for IP restrictions dialog
 	"btnIpRestrictionsDialogAdd": "Add", // text for IP restrictions dialog "Add" button
 	"btnIpRestrictionsDialogBtnCancel": "Cancel", // text for IP restrictions dialog "Cancel" button
-	"ipRestrictionsDialogAddNewRange": "Add new IP range", // text for IP restrictions dialog "Add new IP range" button
+	"ipRestrictionsDialogAddNewRange": "IP range", // text for IP restrictions dialog "Add new IP range" button
 	"ipRestrictionsTableStartRangeHdr": "IP Range Start", // text for IP restrictions table header start
 	"ipRestrictionsTableEndRangeHdr": "IP Range End", // text for IP restrictions table header end
 	"ipRestrictionsTableDeleteRangeHdr": "Delete", // text for IP restrictions table header delete

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
@@ -86,7 +86,7 @@ export default {
 	"ipRestrictionDialogDescription": "Only learners coming from IP addresses that meet the defined restrictions can write the quiz.", // guidelines for IP restrictions dialog
 	"btnIpRestrictionsDialogAdd": "Add", // text for IP restrictions dialog "Add" button
 	"btnIpRestrictionsDialogBtnCancel": "Cancel", // text for IP restrictions dialog "Cancel" button
-	"ipRestrictionsDialogAddNewRange": "IP range", // text for IP restrictions dialog "Add new IP range" button
+	"ipRestrictionsDialogAddNewRange": "IP Range", // text for IP restrictions dialog "Add new IP range" button
 	"ipRestrictionsTableStartRangeHdr": "IP Range Start", // text for IP restrictions table header start
 	"ipRestrictionsTableEndRangeHdr": "IP Range End", // text for IP restrictions table header end
 	"ipRestrictionsTableDeleteRangeHdr": "Delete", // text for IP restrictions table header delete


### PR DESCRIPTION
Updated lang term as per Patrick for consistency across tools. The copy on the subtle button will now read:

![image](https://user-images.githubusercontent.com/46040098/108405208-a8450380-71d5-11eb-8256-9ff5522ec030.png)


