### PR TITLE
fix: Make w2d langterm context comments unique

### DIFF
--- a/components/d2l-work-to-do/lang/en.js
+++ b/components/d2l-work-to-do/lang/en.js
@@ -1,14 +1,14 @@
 export const val = {
 	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
 	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity (e.g. assignment) is being displayed on a line item
 	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity (e.g. checklist) is being displayed on a line item
 	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	Content : "Content", // Meta-data descriptor that informs which type of activity (e.g. content) is being displayed on a line item
+	Course : "Course", // Meta-data descriptor that informs which type of activity (e.g. course) is being displayed on a line item
 	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity (e.g. discussion) is being displayed on a line item
 	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
 	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
 	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
@@ -19,9 +19,9 @@ export const val = {
 	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
 	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
 	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity (e.g. quiz) is being displayed on a line item
 	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	Survey : "Survey", // Meta-data descriptor that informs which type of activity (e.g. survey) is being displayed on a line item
 	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
 	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
 	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks


### PR DESCRIPTION
Bug with serge confuses it if you have the same context comment, even if the key is different.