### PR TITLE
Move w2d to dynamic locale imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,8 +6,8 @@
   },
   "parser": "@babel/eslint-parser",
   "parserOptions": {
-      "sourceType": "module",
-			"requireConfigFile": false
+    "sourceType": "module",
+    "requireConfigFile": false
   },
   "rules": {
     "no-var": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,9 +4,10 @@
     "es6": true,
     "jest": true
   },
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "parserOptions": {
-      "sourceType": "module"
+      "sourceType": "module",
+			"requireConfigFile": false
   },
   "rules": {
     "no-var": "error",

--- a/components/d2l-work-to-do/mixins/d2l-work-to-do-localization-mixin.js
+++ b/components/d2l-work-to-do/mixins/d2l-work-to-do-localization-mixin.js
@@ -1,86 +1,12 @@
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
-import { getLocalizeOverrideResources } from '@brightspace-ui/core/helpers/getLocalizeResources.js';
+import { LocalizeDynamicMixin } from '@brightspace-ui/core/mixins/localize-dynamic-mixin.js';
 
-export const LocalizeWorkToDoMixin = superclass => class extends LocalizeMixin(superclass) {
+export const LocalizeWorkToDoMixin = superclass => class extends LocalizeDynamicMixin(superclass) {
 
-	static async getLocalizeResources(langs) {
-
-		function resolveOverridesFunc() {
-			return 'd2l-activities\\workToDo';
-		}
-
-		let translations;
-		for await (const lang of langs) {
-			switch (lang) {
-				case 'ar':
-					translations = await import('../lang/ar.js');
-					break;
-				case 'cy-gb':
-					translations = await import('../lang/cy-gb.js');
-					break;
-				case 'cy':
-					translations = await import('../lang/cy.js');
-					break;
-				case 'da':
-					translations = await import('../lang/da.js');
-					break;
-				case 'de':
-					translations = await import('../lang/de.js');
-					break;
-				case 'en':
-					translations = await import('../lang/en.js');
-					break;
-				case 'es-es':
-					translations = await import('../lang/es-es.js');
-					break;
-				case 'es':
-					translations = await import('../lang/es.js');
-					break;
-				case 'fr-ca':
-					translations = await import('../lang/fr-ca.js');
-					break;
-				case 'fr':
-					translations = await import('../lang/fr.js');
-					break;
-				case 'ja':
-					translations = await import('../lang/ja.js');
-					break;
-				case 'ko':
-					translations = await import('../lang/ko.js');
-					break;
-				case 'nl':
-					translations = await import('../lang/nl.js');
-					break;
-				case 'pt':
-					translations = await import('../lang/pt.js');
-					break;
-				case 'sv':
-					translations = await import('../lang/sv.js');
-					break;
-				case 'tr':
-					translations = await import('../lang/tr.js');
-					break;
-				case 'zh-tw':
-					translations = await import('../lang/zh-tw.js');
-					break;
-				case 'zh':
-					translations = await import('../lang/zh.js');
-					break;
-			}
-			if (translations && translations.val) {
-				return await getLocalizeOverrideResources(
-					lang,
-					translations.val,
-					resolveOverridesFunc
-				);
-			}
-		}
-
-		translations = await import('../lang/en.js');
-		return await getLocalizeOverrideResources(
-			'en',
-			translations.val,
-			resolveOverridesFunc
-		);
+	static get config() {
+		return {
+			importFunc: lang => import(`../lang/${lang}.js`),
+			osloCollection: 'd2l-activities\\workToDo',
+			exportName: 'val',
+		};
 	}
 };

--- a/components/d2l-work-to-do/mixins/d2l-work-to-do-localization-mixin.js
+++ b/components/d2l-work-to-do/mixins/d2l-work-to-do-localization-mixin.js
@@ -5,7 +5,6 @@ export const LocalizeWorkToDoMixin = superclass => class extends LocalizeDynamic
 	static get config() {
 		return {
 			importFunc: lang => import(`../lang/${lang}.js`),
-			supportedLangs: ['ar', 'cy-gb', 'cy', 'da', 'de', 'en', 'en-us', 'es-es', 'es', 'fr-ca', 'fr', 'ja', 'ko', 'nl', 'pt', 'sv', 'tr', 'zh-tw', 'zh'],
 			osloCollection: 'd2l-activities\\workToDo',
 			exportName: 'val',
 		};

--- a/components/d2l-work-to-do/mixins/d2l-work-to-do-localization-mixin.js
+++ b/components/d2l-work-to-do/mixins/d2l-work-to-do-localization-mixin.js
@@ -2,11 +2,10 @@ import { LocalizeDynamicMixin } from '@brightspace-ui/core/mixins/localize-dynam
 
 export const LocalizeWorkToDoMixin = superclass => class extends LocalizeDynamicMixin(superclass) {
 
-	static get config() {
+	static get localizeConfig() {
 		return {
-			importFunc: lang => import(`../lang/${lang}.js`),
+			importFunc: async lang => (await import(`../lang/${lang}.js`)).val,
 			osloCollection: 'd2l-activities\\workToDo',
-			exportName: 'val',
 		};
 	}
 };

--- a/components/d2l-work-to-do/mixins/d2l-work-to-do-localization-mixin.js
+++ b/components/d2l-work-to-do/mixins/d2l-work-to-do-localization-mixin.js
@@ -5,6 +5,7 @@ export const LocalizeWorkToDoMixin = superclass => class extends LocalizeDynamic
 	static get config() {
 		return {
 			importFunc: lang => import(`../lang/${lang}.js`),
+			supportedLangs: ['ar', 'cy-gb', 'cy', 'da', 'de', 'en', 'en-us', 'es-es', 'es', 'fr-ca', 'fr', 'ja', 'ko', 'nl', 'pt', 'sv', 'tr', 'zh-tw', 'zh'],
 			osloCollection: 'd2l-activities\\workToDo',
 			exportName: 'val',
 		};

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "chai-a11y-axe": "^1.2.2",
     "chai-as-promised": "^7.1.1",
     "eslint": "^7.9.0",
-    "eslint-config-brightspace": "^0.12.0",
+    "eslint-config-brightspace": "^0.13.0",
     "eslint-plugin-html": "^6.0.0",
     "eslint-plugin-lit": "^1.2.0",
     "eslint-plugin-sort-class-members": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@babel/core": "^7.8.3",
+    "@babel/eslint-parser": "^7.12.17",
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.8.3",
     "@brightspace-ui/stylelint-config": "^0.0.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@polymer/test-fixture": "^4.0.2",
     "@webcomponents/webcomponentsjs": "^2.2.1",
     "axe-core": "^4.0.2",
-    "babel-eslint": "^10.0.1",
     "babel-jest": "^26.0.1",
     "chai": "^4.2.0",
     "chai-a11y-axe": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@brightspace-ui-labs/accordion": "^2.0.2",
     "@brightspace-ui-labs/edit-in-place": "^1.0.11",
     "@brightspace-ui-labs/list-item-accumulator": "^1",
-    "@brightspace-ui/core": "^1.115.1",
+    "@brightspace-ui/core": "^1.116.0",
     "@brightspace-ui/htmleditor": "^1",
     "@brightspace-ui/intl": "^3.0.1",
     "@d2l/d2l-attachment": "Brightspace/attachment#semver:^1",


### PR DESCRIPTION
Uses the new `localize-dynamic-mixin` for true dynamic imports. Also enables OSLO.

~Dependent upon https://github.com/BrightspaceUI/core/pull/1146~