### PR TITLE
Fix unparsable w2d language keys

### DIFF
--- a/components/d2l-work-to-do/env/index.js
+++ b/components/d2l-work-to-do/env/index.js
@@ -28,50 +28,50 @@ export const ActivityAllowList = {
 		class: Classes.activities.userAssignmentActivity,
 		icon: 'tier2:assignments',
 		rel: Rels.assignment,
-		type: 'Assignment'
+		type: 'assignment'
 	},
 	userChecklistActivity: {
 		class: Classes.activities.userChecklistActivity,
 		icon: 'tier2:checklist',
 		rel: Rels.Checklists.checklistItem,
-		type: 'Checklist'
+		type: 'checklist'
 	},
 	userContentActivity: {
 		class: Classes.activities.userContentActivity,
 		icon: 'tier2:content',
 		rel: Rels.content,
-		type: 'Content'
+		type: 'content'
 	},
 	userCourseOfferingActivity: {
 		class: Classes.activities.userCourseOfferingActivity,
 		icon: 'tier2:syllabus',
 		rel: [ Rels.userEnrollment, Rels.organization ],
 		linkRel: Rels.organizationHomepage,
-		type: 'Course'
+		type: 'course'
 	},
 	userDiscussionActivity: {
 		class: Classes.activities.userDiscussionActivity,
 		icon: 'tier2:discussions',
 		rel: Rels.Discussions.topic,
-		type: 'Discussion'
+		type: 'discussion'
 	},
 	userQuizActivity: {
 		class: Classes.activities.userQuizActivity,
 		icon: 'tier2:quizzing',
 		rel: Rels.quiz,
-		type: 'Quiz'
+		type: 'quiz'
 	},
 	userQuizAttemptActivity: {
 		class: Classes.activities.userQuizAttemptActivity,
 		icon: 'tier2:quizzing',
 		rel: Rels.quiz,
-		type: 'Quiz'
+		type: 'quiz'
 	},
 	userSurveyActivity: {
 		class: Classes.activities.userSurveyActivity,
 		icon: 'tier2:surveys',
 		rel: Rels.Surveys.survey,
-		type: 'Survey'
+		type: 'survey'
 	}
 };
 

--- a/components/d2l-work-to-do/lang/ar.js
+++ b/components/d2l-work-to-do/lang/ar.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/cy-gb.js
+++ b/components/d2l-work-to-do/lang/cy-gb.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/cy.js
+++ b/components/d2l-work-to-do/lang/cy.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/da.js
+++ b/components/d2l-work-to-do/lang/da.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/de.js
+++ b/components/d2l-work-to-do/lang/de.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/en.js
+++ b/components/d2l-work-to-do/lang/en.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity (e.g. assignment) is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity (e.g. checklist) is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity (e.g. content) is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity (e.g. course) is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity (e.g. discussion) is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity (e.g. quiz) is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity (e.g. survey) is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/es-es.js
+++ b/components/d2l-work-to-do/lang/es-es.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/es.js
+++ b/components/d2l-work-to-do/lang/es.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/fr-ca.js
+++ b/components/d2l-work-to-do/lang/fr-ca.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/fr.js
+++ b/components/d2l-work-to-do/lang/fr.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/ja.js
+++ b/components/d2l-work-to-do/lang/ja.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/ko.js
+++ b/components/d2l-work-to-do/lang/ko.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/nl.js
+++ b/components/d2l-work-to-do/lang/nl.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/pt.js
+++ b/components/d2l-work-to-do/lang/pt.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/sv.js
+++ b/components/d2l-work-to-do/lang/sv.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/tr.js
+++ b/components/d2l-work-to-do/lang/tr.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/zh-tw.js
+++ b/components/d2l-work-to-do/lang/zh-tw.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/zh.js
+++ b/components/d2l-work-to-do/lang/zh.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}


### PR DESCRIPTION
Serge bug is _actually_ with the key names. View without whitespace changes to see the actual changes.

`myKey`, `MyKey`, `mykey` ✅ 

`Mykey` ❌ 