### PR TITLE
US124894: Adding new html editor

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
@@ -17,6 +17,8 @@ class ContentEditor extends LocalizeActivityEditorMixin(RtlMixin(ActivityEditorM
 
 	static get properties() {
 		return {
+			htmlEditorEnabled: { type: Boolean },
+			htmlNewEditorEnabled: { type: Boolean },
 			widthType: { type: String, attribute: 'width-type' },
 			isNew: { type: Boolean },
 			cancelHref: { type: String },
@@ -69,6 +71,8 @@ class ContentEditor extends LocalizeActivityEditorMixin(RtlMixin(ActivityEditorM
 				width-type="${this.widthType}"
 				error-term="${this.localize('content.saveError')}"
 				?isnew="${this.isNew}"
+				?html-editor-enabled="${this.htmlEditorEnabled}"
+				?html-new-editor-enabled="${this.htmlNewEditorEnabled}">
 			>
 				${this._editorTemplate}
 			</d2l-activity-editor>

--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -1,5 +1,5 @@
 import '../shared-components/d2l-activity-content-editor-title.js';
-import '../../d2l-activity-html-editor';
+import '../../d2l-activity-text-editor.js';
 import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { activityContentEditorStyles } from '../shared-components/d2l-activity-content-editor-styles.js';
@@ -64,14 +64,14 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 					${this.localize('content.description')}
 				</div>
 				<div class="d2l-skeletize">
-					<d2l-activity-html-editor
-						.ariaLabel="content-description"
-						.key="content-description"
-						.value="${descriptionRichText}"
-						@d2l-activity-html-editor-change="${this._onRichtextChange}"
-						.richtextEditorConfig="${{}}"
-					>
-					</d2l-activity-html-editor>
+				<d2l-activity-text-editor
+					.ariaLabel="content-description"
+					.key="content-description"
+					.value="${descriptionRichText}"
+					@d2l-activity-html-editor-change="${this._onRichtextChange}"
+					.richtextEditorConfig="${{}}"
+				>
+				</d2l-activity-text-editor>
 				</div>
 			</div>
 		`;

--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -64,14 +64,14 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 					${this.localize('content.description')}
 				</div>
 				<div class="d2l-skeletize">
-				<d2l-activity-text-editor
-					.ariaLabel="content-description"
-					.key="content-description"
-					.value="${descriptionRichText}"
-					@d2l-activity-html-editor-change="${this._onRichtextChange}"
-					.richtextEditorConfig="${{}}"
-				>
-				</d2l-activity-text-editor>
+					<d2l-activity-text-editor
+						.ariaLabel="content-description"
+						.key="content-description"
+						.value="${descriptionRichText}"
+						@d2l-activity-html-editor-change="${this._onRichtextChange}"
+						.richtextEditorConfig="${{}}"
+					>
+					</d2l-activity-text-editor>
 				</div>
 			</div>
 		`;


### PR DESCRIPTION
This PR replaces the previous html editor with the new html editor.

![image](https://user-images.githubusercontent.com/52549862/108751189-87e3b480-7507-11eb-84bb-c16878196845.png)

The new html editor relies on two attributes: `htmlEditorEnabled` and `htmlNewEditorEnabled`. If both are `true`, users can see the new html editor. If `htmlEditorEnabled` is true and `htmlNewEditorEnabled` is false, the users will see the previous editor. If both are false, the user will see a textbox.

The corresponding lms PR which adds the `htmlEditorEnabled` and `htmlNewEditorEnabled` attributes [can be found here](https://github.com/Brightspace/lms/pull/6849).

**Note**: These two attributes are set by config variables. To see the new editor, set `d2l.Preferences.TurnOffWYSIWYG=false`
and `d2l.Tools.WYSIWYG.NewEditor=true`. Setting the LD flag `F15913-html-editor-alignment` to `false` will also turn off the new editor.