### PR TITLE
Added quick fixes for focus and footer

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restriction-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restriction-editor.js
@@ -69,7 +69,12 @@ class ActivityQuizIpRestrictionEditor
 	}
 
 	_focusInput() {
-		this.shadowRoot.querySelector('d2l-activity-quiz-ip-restrictions-container').shadowRoot.querySelector('d2l-input-text').focus();
+		const ipRestrictionsContainer = this.shadowRoot.querySelector('d2l-activity-quiz-ip-restrictions-container');
+		if (!ipRestrictionsContainer) return;
+		const input = ipRestrictionsContainer.shadowRoot.querySelector('d2l-input-text');
+		if (!input) return;
+
+		input.focus();
 	}
 
 	_renderActionButtons() {
@@ -186,6 +191,9 @@ class ActivityQuizIpRestrictionEditor
 
 	_validate() {
 		const ipRestrictionsContainer = this.shadowRoot.querySelector('d2l-activity-quiz-ip-restrictions-container');
+
+		if (!ipRestrictionsContainer) return;
+
 		const inputs = ipRestrictionsContainer.shadowRoot.querySelectorAll('.d2l-ip-input');
 
 		let hasValidationError = false;

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restriction-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restriction-editor.js
@@ -48,12 +48,6 @@ class ActivityQuizIpRestrictionEditor
 		super(store);
 	}
 
-	connectedCallback() {
-		super.connectedCallback();
-
-		this.addEventListener('d2l-dialog-open', this._focusInput);
-	}
-
 	render() {
 		const entity = store.get(this.href);
 		if (!entity) {
@@ -66,15 +60,6 @@ class ActivityQuizIpRestrictionEditor
 			${this._renderDialog()}
 			${this._renderDialogOpener()}
 		`;
-	}
-
-	_focusInput() {
-		const ipRestrictionsContainer = this.shadowRoot.querySelector('d2l-activity-quiz-ip-restrictions-container');
-		if (!ipRestrictionsContainer) return;
-		const input = ipRestrictionsContainer.shadowRoot.querySelector('d2l-input-text');
-		if (!input) return;
-
-		input.focus();
 	}
 
 	_renderActionButtons() {

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restriction-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restriction-editor.js
@@ -65,8 +65,8 @@ class ActivityQuizIpRestrictionEditor
 	_renderActionButtons() {
 		return html`
 			<div slot="footer" id="d2l-actions-container">
-				<d2l-button slot="footer" primary @click=${this._saveRestrictions}>${this.localize('btnIpRestrictionsDialogAdd')}</d2l-button>
-				<d2l-button slot="footer" @click=${this.handleClose}>${this.localize('btnIpRestrictionsDialogBtnCancel')}</d2l-button>
+				<d2l-button primary @click=${this._saveRestrictions}>${this.localize('btnIpRestrictionsDialogAdd')}</d2l-button>
+				<d2l-button @click=${this.handleClose}>${this.localize('btnIpRestrictionsDialogBtnCancel')}</d2l-button>
 			</div>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restrictions-container.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restrictions-container.js
@@ -11,30 +11,25 @@ import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin';
 import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { sharedIpRestrictions as store } from './state/quiz-store.js';
-import { validateIp } from './helpers/ip-validation-helper.js';
 
 class ActivityQuizIpRestrictionsContainer extends ActivityEditorMixin(ActivityEditorContainerMixin(LocalizeActivityQuizEditorMixin(MobxLitElement))) {
 
 	static get styles() {
 		return css`
 				:host {
-
 					display: block;
 				}
 				:host([hidden]) {
 					display: none;
 				}
 				d2l-button-subtle {
-					margin: 0.5rem 0;
+					margin-top: 0.5rem;
 				}
 				d2l-thead {
 					font-weight: 700;
 				}
 				d2l-button {
 					margin: 1rem 0;
-				}
-				#d2l-actions-container {
-					border-top: solid 1px var(--d2l-color-gypsum);
 				}
 			`;
 	}
@@ -52,12 +47,9 @@ class ActivityQuizIpRestrictionsContainer extends ActivityEditorMixin(ActivityEd
 			return html``;
 		}
 
-		this._validationErrorMsg = this.localize('ipRestrictionsValidationError');
-
 		return html`
 			${this._renderIpRestrictionTable()}
 			${this._renderAddRowButton()}
-			${this._renderActionButtons()}
     	`;
 	}
 
@@ -99,15 +91,6 @@ class ActivityQuizIpRestrictionsContainer extends ActivityEditorMixin(ActivityEd
 		}
 
 		entity.setIpRestriction(index, name, value);
-	}
-
-	_renderActionButtons() {
-		return html`
-			<div id="d2l-actions-container">
-				<d2l-button primary @click=${this._saveRestrictions}>${this.localize('btnIpRestrictionsDialogAdd')}</d2l-button>
-				<d2l-button @click=${this._sendCloseEvent}>${this.localize('btnIpRestrictionsDialogBtnCancel')}</d2l-button>
-			</div>
-		`;
 	}
 
 	_renderAddRowButton() {
@@ -192,68 +175,9 @@ class ActivityQuizIpRestrictionsContainer extends ActivityEditorMixin(ActivityEd
 		});
 	}
 
-	async _saveRestrictions() {
-		const entity = store.get(this.href);
-		if (!entity) {
-			return;
-		}
-
-		const hasValidationError = this._validate();
-
-		if (hasValidationError) {
-			return;
-		}
-
-		await entity.saveRestrictions();
-
-		if (!entity.errors || !entity.errors.length) {
-			this._sendCloseEvent();
-		}
-	}
-
-	_sendCloseEvent() {
-		this.dispatchEvent(new CustomEvent('close-ip-dialog', { bubbles: true, composed: true }));
-	}
-
 	_sendResizeEvent() {
 		this.dispatchEvent(new CustomEvent('restrictions-resize-dialog', { bubbles: true, composed: true }));
 	}
-
-	_validate() {
-		const inputs = this.shadowRoot.querySelectorAll('.d2l-ip-input');
-		let hasValidationError = false;
-
-		for (const input of inputs) {
-			if (!this._validateRestriction(input)) {
-				hasValidationError = true;
-			}
-		}
-
-		const entity = store.get(this.href);
-
-		if (hasValidationError) {
-			const errorMsg = this.localize('ipRestrictionsValidationError');
-			entity.setErrors([errorMsg]);
-		} else {
-			entity.setErrors([]);
-			this._sendResizeEvent();
-		}
-
-		return hasValidationError;
-	}
-
-	_validateRestriction(restriction) {
-		if (!restriction) {
-			return true;
-		}
-
-		const isValid = !restriction.formValue || validateIp(restriction.formValue);
-
-		restriction.setAttribute('aria-invalid', !isValid);
-
-		return isValid;
-	}
-
 }
 
 customElements.define(


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F465115111280

Fixes requested by Joseph:

1. Moved action buttons to slot="footer" so that they would behave consistently with the attempts dialog i.e. the action buttons stick in place even when new elements force scroll bar. This meant lifting the actions buttons up to `d2l-activity-quiz-ip-restrictions-editor` so that I could set the slot attribute correctly. 
2. (Edit: this change has been removed as Joseph didn't like the janky behaviour but if anyone has any thoughts on this I'm still interested so leaving here) Added an event listener for `d2l-dialog-open` to focus on the first instance of `d2l-input-text`. Prior to this change it focused on the "help" button on open as the core dialog component [forces focus](https://github.com/BrightspaceUI/core/blob/master/components/dialog/dialog-mixin.js#L314) on the first focusable element when the dialog opens. Not sure if there's a better way of handling this. It's kinda janky as for a split second you can see the help button in focus and then it changes. I wanted to use a lifecycle method like `firstUpdated` or `connectedCallback` to handle setting this but as core overrides any value on dialog open this doesn't seem possible. 