### PR TITLE
Quick Eval Widget Skeleton Fix

### DIFF
--- a/components/d2l-quick-eval-widget/d2l-quick-eval-widget-submission-icon.js
+++ b/components/d2l-quick-eval-widget/d2l-quick-eval-widget-submission-icon.js
@@ -19,7 +19,12 @@ class SubmissionIcon extends RtlMixin(LitElement) {
 			/**
 			 * Submission count to display as a superscript on the icon
 			 */
-			submissionCount: { type: String, attribute: 'submission-count', reflect: true }
+			submissionCount: { type: String, attribute: 'submission-count', reflect: true },
+			/**
+			 * Does not make the component fully skeleton compatible, but makes it more comparable to
+			 * d2l-icon which doesn't support it either (prevents visual weirdness of count bubble displaying behind skeleton)
+			 */
+			skeleton: { type: Boolean }
 		};
 	}
 
@@ -85,8 +90,8 @@ class SubmissionIcon extends RtlMixin(LitElement) {
 	render() {
 		return html`
 			<div class="d2l-quick-eval-widget-submission-icon-content">
-				<d2l-icon icon="${this.icon}"></d2l-icon>
-				<div class="d2l-quick-eval-widget-submission-icon-submission-count-container" ?hidden=${!this.submissionCount}>
+				<d2l-icon icon="${this.icon}" ></d2l-icon>
+				<div class="d2l-quick-eval-widget-submission-icon-submission-count-container" ?hidden=${!this.submissionCount || this.skeleton}>
 					<div class="d2l-quick-eval-widget-submission-icon-submission-count">${this.submissionCount}</div>
 				</div>
 			</div>

--- a/components/d2l-quick-eval-widget/d2l-quick-eval-widget.js
+++ b/components/d2l-quick-eval-widget/d2l-quick-eval-widget.js
@@ -12,13 +12,15 @@ import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
 const errorState = 'error';
-const loadedState = 'loaded';
+const listState = 'list';
 const noSubmissionState = 'noSubmission';
 
 export class QuickEvalWidget extends LocalizeQuickEvalWidget(SkeletonMixin(LitElement)) {
 	static get properties() {
 		return {
 			_activities: { type: Array },
+			_loading: { type: Boolean },
+			_loadedElements: { type: Array },
 			_state: { type: String },
 			activitiesHref: {
 				attribute: 'href',
@@ -89,6 +91,9 @@ export class QuickEvalWidget extends LocalizeQuickEvalWidget(SkeletonMixin(LitEl
 	constructor() {
 		super();
 		this._activities = [];
+		this._loading = true;
+		this._loadedElements = [];
+		this._state = listState;
 		this.count = 6;
 	}
 
@@ -96,15 +101,13 @@ export class QuickEvalWidget extends LocalizeQuickEvalWidget(SkeletonMixin(LitEl
 		super.updated();
 
 		if ((changedProperties.has('activitiesHref') || changedProperties.has('token')) && this.activitiesHref && this.token) {
-			this.skeleton = true;
 			try {
 				this._activities = await this.getActivities(this.activitiesHref, this.token);
-				this._state = this._activities.length > 0 ? loadedState : noSubmissionState;
+				this._state = this._activities.length > 0 ? listState : noSubmissionState;
+				this._loading = true;
 			} catch (e) {
 				console.error('quick-eval-widget: Unable to load activities from entity.');
 				this._state = errorState;
-			} finally {
-				this.skeleton = false;
 			}
 		}
 	}
@@ -140,6 +143,17 @@ export class QuickEvalWidget extends LocalizeQuickEvalWidget(SkeletonMixin(LitEl
 		}
 	}
 
+	_itemLoaded(event) {
+		if (this._loading) {
+			this._loadedElements.push(event.target);
+
+			if (this._loadedElements.length === this._activities.length) {
+				this._loading = false;
+				this._loadedElements = [];
+			}
+		}
+	}
+
 	get errorTemplate() {
 		return html`
 		<div class="d2l-quick-eval-widget-error">
@@ -162,13 +176,15 @@ export class QuickEvalWidget extends LocalizeQuickEvalWidget(SkeletonMixin(LitEl
 			</div>`;
 	}
 
-	get loadedTemplate() {
+	get listTemplate() {
 		const listItems = this._activities.map(activity => {
 			return html`<d2l-work-to-do-activity-list-item-basic
 					evaluate-href="${activity.evaluationHref}"
 					href="${activity.href}"
+					?skeleton=${this._loading || this.skeleton}
 					submission-count=${activity.submissionCount}
-					.token=${ifDefined(this.token)}></d2l-work-to-do-activity-list-item-basic>`;
+					.token=${ifDefined(this.token)}
+					@data-loaded=${this._itemLoaded}></d2l-work-to-do-activity-list-item-basic>`;
 		});
 		return html`
 			<d2l-list class="d2l-quick-eval-widget-list" separators="none">${listItems}</d2l-list>
@@ -184,20 +200,9 @@ export class QuickEvalWidget extends LocalizeQuickEvalWidget(SkeletonMixin(LitEl
 	}
 
 	render() {
-		// delete when d2l-list supports SkeletonMixin
-		if (this.skeleton) {
-			const loading = [];
-			for (let i = 0; i < this.count ; i++) {
-				loading.push(html`<ol class="d2l-skeletize"><li></li><li></li></ol>`);
-			}
-			return html`
-				${loading }
-				${this.viewAllLinkTemplate}`;
-		}
-
 		switch (this._state) {
-			case loadedState:
-				return this.loadedTemplate;
+			case listState:
+				return this.listTemplate;
 			case noSubmissionState:
 				return this.noSubmissionTemplate;
 			case errorState:

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
@@ -68,8 +68,8 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 				}
 				:host([skeleton]) .d2l-activity-qe-icon-container {
 					height: 2rem;
-					width: 2.5rem;
 					margin-left: 0.5rem;
+					width: 2.5rem;
 				}
 				.d2l-activity-name-container {
 					overflow: hidden;
@@ -173,7 +173,7 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 		const qeIconClasses = {
 			'd2l-activity-qe-icon-container': true,
 			'd2l-skeletize': true,
-		}
+		};
 
 		const nameClasses = {
 			'd2l-activity-name-container': true,
@@ -201,7 +201,7 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 			: nothing;
 
 		return this._renderListItem({
-			illustration: this.evaluationHref? html`
+			illustration: this.evaluationHref ? html`
 				<d2l-quick-eval-widget-submission-icon style="overflow: visible;"
 					class=${classMap(qeIconClasses)}
 					icon=${this._icon}

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
@@ -66,6 +66,11 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 					height: 1.3rem;
 					width: 1.2rem;
 				}
+				:host([skeleton]) .d2l-activity-qe-icon-container {
+					height: 2rem;
+					width: 2.5rem;
+					margin-left: 0.5rem;
+				}
 				.d2l-activity-name-container {
 					overflow: hidden;
 					text-overflow: ellipsis;
@@ -165,6 +170,11 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 			'd2l-skeletize': true,
 		};
 
+		const qeIconClasses = {
+			'd2l-activity-qe-icon-container': true,
+			'd2l-skeletize': true,
+		}
+
 		const nameClasses = {
 			'd2l-activity-name-container': true,
 			'd2l-skeletize': true,
@@ -191,17 +201,19 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 			: nothing;
 
 		return this._renderListItem({
-			illustration: this.evaluationHref ? html`
-					<d2l-quick-eval-widget-submission-icon style="overflow: visible;"
-						icon=${this._icon}
-						submission-count=${ifDefined(this.submissionCount > 0 ? (this.submissionCount > 99 ? '99+' : this.submissionCount) : undefined)} >
-					</d2l-quick-eval-widget-submission-icon>` :
+			illustration: this.evaluationHref? html`
+				<d2l-quick-eval-widget-submission-icon style="overflow: visible;"
+					class=${classMap(qeIconClasses)}
+					icon=${this._icon}
+					?skeleton=${this.skeleton}
+					submission-count=${ifDefined(this.submissionCount > 0 ? (this.submissionCount > 99 ? '99+' : this.submissionCount) : undefined)} >
+				</d2l-quick-eval-widget-submission-icon>` :
 				html`
-					<d2l-icon
-						class=${classMap(iconClasses)}
-						?skeleton=${this.skeleton}
-						icon=${this._icon}>
-					</d2l-icon>`,
+				<d2l-icon
+					class=${classMap(iconClasses)}
+					?skeleton=${this.skeleton}
+					icon=${this._icon}>
+				</d2l-icon>`,
 			content: html`
 				<d2l-list-item-content id="content">
 					<div class=${classMap(nameClasses)}>


### PR DESCRIPTION
Items in Quick-Eval widget will not render until fully loaded
Also changes the style of skeleton to be more detailed
![image](https://user-images.githubusercontent.com/50635849/108763493-6e4e6700-751f-11eb-96a0-fa455cdd0dc0.png)
