### PR TITLE
US123360 - Change to improve quiz timing entity optimistic loading jank

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz-timing.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz-timing.js
@@ -76,6 +76,10 @@ export class QuizTiming {
 
 	async updateProperty(updateFunc) {
 		const entity = await updateFunc();
+		// The siren-sdk function called to perform an action first checks that the entity has permission to do so.
+		// If the entity lacks permission, the function returns `undefined`, otherwise it returns a reconstructed siren-sdk timing entity.
+		// If `undefined` is returned, it likely means the UI is out of sync with the entity state, and disallowed actions can be performed.
+		// In this case, we should attempt to reload the MobX object, so that the UI state is in sync again.
 		if (!entity) {
 			this.fetch();
 		}

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz-timing.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz-timing.js
@@ -47,36 +47,39 @@ export class QuizTiming {
 		this.maxEnforcedGraceLimit = entity.maxEnforcedGraceLimit();
 	}
 
-	async setExceededTimeLimitBehaviour(data) {
+	setExceededTimeLimitBehaviour(data) {
 		this.isAutomaticZero = this._entity.isAutomaticZero(data);
-		await this._entity.setExceededTimeLimitBehaviour(data);
-		this.fetch();
+		this.updateProperty(() => this._entity.setExceededTimeLimitBehaviour(data));
+
 	}
 
-	async setExtendedDeadline(data) {
-		await this._entity.setExtendedDeadline(data);
-		this.fetch();
+	setExtendedDeadline(data) {
+		this.updateProperty(() => this._entity.setExtendedDeadline(data));
 	}
 
-	async setGracePeriod(data) {
-		await this._entity.setGracePeriod(data);
-		this.fetch();
+	setGracePeriod(data) {
+		this.updateProperty(() => this._entity.setGracePeriod(data));
 	}
 
-	async setShowClock(data) {
-		await this._entity.setShowClock(data);
-		this.fetch();
+	setShowClock(data) {
+		this.updateProperty(() => this._entity.setShowClock(data));
 	}
 
-	async setTimeLimit(data) {
-		await this._entity.setTimeLimit(data);
-		this.fetch();
+	setTimeLimit(data) {
+		this.updateProperty(() => this._entity.setTimeLimit(data));
 	}
 
-	async setTimingType(data) {
+	setTimingType(data) {
 		this.isTimingEnforced = this._entity.isTimingEnforced(data);
-		await this._entity.setTimingType(data);
-		this.fetch();
+		this.updateProperty(() => this._entity.setTimingType(data));
+	}
+
+	async updateProperty(updateFunc) {
+		const entity = await updateFunc();
+		if (!entity) {
+			this.fetch();
+		}
+		this._entity = entity;
 	}
 
 	_makeQuizData() {


### PR DESCRIPTION
Only refetch entity if no entity is returned. If entity is returned, update the timing entity, but don't reload it to avoid janky UI updates.

https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F464625055264%2Ftasks

See: https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/276