### PR TITLE
Validate IPs on delete

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restriction-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restriction-editor.js
@@ -144,7 +144,8 @@ class ActivityQuizIpRestrictionEditor
 			<d2l-activity-quiz-ip-restrictions-container
 				href="${this.ipRestrictionsHref}"
 				.token="${this.token}"
-				@restrictions-resize-dialog="${this._resizeDialog}">
+				@restrictions-resize-dialog="${this._resizeDialog}"
+				@ip-restriction-deleted="${this._validate}">
 			</d2l-activity-quiz-ip-restrictions-container>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restrictions-container.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restrictions-container.js
@@ -75,7 +75,7 @@ class ActivityQuizIpRestrictionsContainer extends ActivityEditorMixin(ActivityEd
 		entity.deleteIpRestriction(index);
 
 		await this.updateComplete;
-		this._validate();
+		this._sendDeleteEvent();
 	}
 
 	_generateHandler(handler, rowindex) {
@@ -173,6 +173,10 @@ class ActivityQuizIpRestrictionsContainer extends ActivityEditorMixin(ActivityEd
 				</d2l-tr>
 			`;
 		});
+	}
+
+	_sendDeleteEvent() {
+		this.dispatchEvent(new CustomEvent('ip-restriction-deleted', { bubbles: true, composed: true }));
 	}
 
 	_sendResizeEvent() {


### PR DESCRIPTION
I did some refactoring earlier and realized that `this._validate` had now been moved to parent component so it is no longer being triggered on delete. To handle this I added logic to emit a "deleted" event and run the validate logic from the parent component.