### PR TITLE
Backported work-to-do changes for 20.21.3

### DIFF
--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
@@ -215,7 +215,7 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 					</div>
 					<div class=${classMap(secondaryClasses)} slot="secondary">
 						${supportingInfoTemplate([this._date ? dateTemplate : null, this._orgName || this._orgCode, // eslint-disable-next-line indent
-							this._activityProperties.type === ActivityAllowList.userCourseOfferingActivity.type && this._type])}
+							this._activityProperties && this._activityProperties.type === ActivityAllowList.userCourseOfferingActivity.type && this._type])}
 						${startDateTemplate}
 					</div>
 				</d2l-list-item-content>

--- a/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
+++ b/components/d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js
@@ -179,8 +179,8 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 
 		const dateTemplate = html `<d2l-activity-date href="${this.href}" .token="${this.token}" format="MMM d" ?hidden=${this.skeleton}></d2l-activity-date>`;
 
-		const separatorTemplate = !this.skeleton && this._date && (this._orgName || this._orgCode)
-			? html `<d2l-icon class="d2l-icon-bullet" icon="tier1:bullet"></d2l-icon>`
+		const separatorTemplate = !this.skeleton
+			? html ` <d2l-icon class="d2l-icon-bullet" icon="tier1:bullet"></d2l-icon> `
 			: nothing;
 
 		const startDateTemplate = !this.skeleton && !this._started && !this.evaluationHref
@@ -189,6 +189,11 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 				<d2l-status-indicator state="none" text="${this._startDateFormatted}"></d2l-status-indicator>
 			</div>`
 			: nothing;
+
+		const supportingInfoTemplate = (items) => {
+			const filteredItems = items.filter(item => item);
+			return html `${filteredItems.map((item, idx) => [item, idx < filteredItems.length - 1 ? separatorTemplate : nothing]).flat()}`;
+		};
 
 		return this._renderListItem({
 			illustration: this.evaluationHref ? html`
@@ -208,10 +213,9 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 					<div class=${classMap(nameClasses)}>
 						${this._name}
 					</div>
-					<div class=${classMap(secondaryClasses)} slot="supporting-info">
-						${dateTemplate}
-						${separatorTemplate}
-						${this._orgName || this._orgCode}
+					<div class=${classMap(secondaryClasses)} slot="secondary">
+						${supportingInfoTemplate([this._date ? dateTemplate : null, this._orgName || this._orgCode, // eslint-disable-next-line indent
+							this._activityProperties.type === ActivityAllowList.userCourseOfferingActivity.type && this._type])}
 						${startDateTemplate}
 					</div>
 				</d2l-list-item-content>
@@ -239,6 +243,12 @@ class ActivityListItemBasic extends ListItemLinkMixin(SkeletonMixin(EntityMixinL
 			this._usage && this._usage.startDate()
 				? formatDate(new Date(this._usage.startDate()), { format: 'shortMonthDay' })
 				: '');
+	}
+
+	get _type() {
+		return this._activityProperties && !this.skeleton
+			? this.localize(this._activityProperties.type)
+			: '';
 	}
 
 	/** String associated with icon catalogue for provided activity type */

--- a/components/d2l-work-to-do/d2l-work-to-do.js
+++ b/components/d2l-work-to-do/d2l-work-to-do.js
@@ -372,7 +372,7 @@ class WorkToDoWidget extends EntityMixinLit(WorkToDoTelemetryMixin(LocalizeWorkT
 			return html`
 				${immersiveNav()}
 				<div class="d2l-work-to-do-fullscreen-container">
-					<h1 class="d2l-heading-1 d2l-work-to-do-fullscreen-title">${this.localize('myWorkToDo')}</h1>
+					<h1 class="d2l-heading-1 d2l-work-to-do-fullscreen-title">${this.localize('workToDo')}</h1>
 					<div class="d2l-overdue-collection-fullscreen">
 						${fullscreenCollectionTemplate(this._overdueActivities, true)}
 					</div>
@@ -397,7 +397,7 @@ class WorkToDoWidget extends EntityMixinLit(WorkToDoTelemetryMixin(LocalizeWorkT
 		const detailedSkeleton = html`
 			${immersiveNav()}
 			<div class="d2l-work-to-do-fullscreen-container">
-				<div class="d2l-heading-1 d2l-work-to-do-fullscreen-title">${this.localize('myWorkToDo')}</div>
+				<div class="d2l-heading-1 d2l-work-to-do-fullscreen-title">${this.localize('workToDo')}</div>
 				<div class="d2l-overdue-collection-fullscreen">
 					<d2l-work-to-do-activity-list-header skeleton fullscreen></d2l-work-to-do-activity-list-header>
 					<d2l-list separators="none">

--- a/components/d2l-work-to-do/env/index.js
+++ b/components/d2l-work-to-do/env/index.js
@@ -28,50 +28,50 @@ export const ActivityAllowList = {
 		class: Classes.activities.userAssignmentActivity,
 		icon: 'tier2:assignments',
 		rel: Rels.assignment,
-		type: 'Assignment'
+		type: 'assignment'
 	},
 	userChecklistActivity: {
 		class: Classes.activities.userChecklistActivity,
 		icon: 'tier2:checklist',
 		rel: Rels.Checklists.checklistItem,
-		type: 'Checklist'
+		type: 'checklist'
 	},
 	userContentActivity: {
 		class: Classes.activities.userContentActivity,
 		icon: 'tier2:content',
 		rel: Rels.content,
-		type: 'Content'
+		type: 'content'
 	},
 	userCourseOfferingActivity: {
 		class: Classes.activities.userCourseOfferingActivity,
 		icon: 'tier2:syllabus',
 		rel: [ Rels.userEnrollment, Rels.organization ],
 		linkRel: Rels.organizationHomepage,
-		type: 'Course'
+		type: 'course'
 	},
 	userDiscussionActivity: {
 		class: Classes.activities.userDiscussionActivity,
 		icon: 'tier2:discussions',
 		rel: Rels.Discussions.topic,
-		type: 'Discussion'
+		type: 'discussion'
 	},
 	userQuizActivity: {
 		class: Classes.activities.userQuizActivity,
 		icon: 'tier2:quizzing',
 		rel: Rels.quiz,
-		type: 'Quiz'
+		type: 'quiz'
 	},
 	userQuizAttemptActivity: {
 		class: Classes.activities.userQuizAttemptActivity,
 		icon: 'tier2:quizzing',
 		rel: Rels.quiz,
-		type: 'Quiz'
+		type: 'quiz'
 	},
 	userSurveyActivity: {
 		class: Classes.activities.userSurveyActivity,
 		icon: 'tier2:surveys',
 		rel: Rels.Surveys.survey,
-		type: 'Survey'
+		type: 'survey'
 	}
 };
 

--- a/components/d2l-work-to-do/lang/ar.js
+++ b/components/d2l-work-to-do/lang/ar.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-  myWorkToDo: "My Work To Do", // Widget title
+  workToDo: "Work To Do", // Widget title
   noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/ar.js
+++ b/components/d2l-work-to-do/lang/ar.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  activitiesAvailable: "اكتملت الأنشطة المستحقة أو التي تنتهي بعد أسبوعين! حدد عرض كل العمل للاطّلاع على الأنشطة المقبلة.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "ما من أنشطة متوفرة في الوقت الحالي!", // Displayed as header line in widget text when there are no activities
+  assignment: "الفرض",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "العودة إلى الصفحة الرئيسية", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "قائمة التحقق", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "تحقق من الصفحة في وقت لاحق لمعرفة ما إذا كان ثمة عمل يجب إنجازه.", // 'Empty state' - When there are no activities in full page view
+  content: "المحتوى", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "المقرر التعليمي", // Meta-data descriptor that informs which type of activity is being displayed on a line item
   dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  discussion: "المناقشة", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "عرض كل العمل", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "الانتقال إلى Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "تحميل المزيد", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "عرض المزيد من الأنشطة المعيّنة", // Additional description text to accompany the load more button for additional clarity for the user
   workToDo: "Work To Do", // Widget title
-  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+  noActivities: "ليس لديك أي أنشطة غير مكتملة تتوفر تواريخ استحقاقها أو انتهائها.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "ليس لديك أي أنشطة غير مكتملة مستحقة أو تنتهي قريبًا. تحقق من الصفحة في وقت لاحق أو حدد عرض كل العمل للاطّلاع على الأنشطة المقبلة.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "ليس لديك أي أنشطة غير مكتملة تتوفر تواريخ استحقاقها أو انتهائها. تحقق من الصفحة في وقت لاحق لمعرفة ما إذا كان ثمة عمل يجب إنجازه.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "ما من أنشطة هنا...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "أنشطة التي تجاوزت تاريخ الاستحقاق", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "الاختبار", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "تاريخ البدء {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "الاستطلاع", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "عمل قادم", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "عرض كل العمل", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {أسبوع واحد بدون أنشطة} other {{count} من الأسابيع بدون أنشطة}}!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
 }

--- a/components/d2l-work-to-do/lang/ar.js
+++ b/components/d2l-work-to-do/lang/ar.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/ar.js
+++ b/components/d2l-work-to-do/lang/ar.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "الانتقال إلى Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "تحميل المزيد", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "عرض المزيد من الأنشطة المعيّنة", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Work To Do", // Widget title
+  workToDo: "العمل الذي يجب إنجازه", // Widget title
   noActivities: "ليس لديك أي أنشطة غير مكتملة تتوفر تواريخ استحقاقها أو انتهائها.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "ليس لديك أي أنشطة غير مكتملة مستحقة أو تنتهي قريبًا. تحقق من الصفحة في وقت لاحق أو حدد عرض كل العمل للاطّلاع على الأنشطة المقبلة.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "ليس لديك أي أنشطة غير مكتملة تتوفر تواريخ استحقاقها أو انتهائها. تحقق من الصفحة في وقت لاحق لمعرفة ما إذا كان ثمة عمل يجب إنجازه.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/ar.js
+++ b/components/d2l-work-to-do/lang/ar.js
@@ -1,0 +1,28 @@
+export const val = {
+	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+	myWorkToDo: "My Work To Do", // Widget title
+	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/components/d2l-work-to-do/lang/cy-gb.js
+++ b/components/d2l-work-to-do/lang/cy-gb.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  activitiesAvailable: "Mae gweithgareddau sy'n ddyledus neu'n dod i ben mewn pythefnos wedi’u cwblhau! Gwiriwch Gweld Pob Darn o Waith i weld beth sy'n dod yn nes ymlaen.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "Dim Byd Am y Tro!", // Displayed as header line in widget text when there are no activities
+  assignment: "Aseiniad",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Yn ôl i’r Hafan", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Rhestr wirio", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Dewch yn ôl yn nes ymlaen i weld os oes gennych waith i'w wneud.", // 'Empty state' - When there are no activities in full page view
+  content: "Cynnwys", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Cwrs", // Meta-data descriptor that informs which type of activity is being displayed on a line item
   dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Work To Do", // Widget title
-  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+  discussion: "Trafodaeth", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Gweld pob darn o waith", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Ewch i Darganfod", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Llwytho Mwy", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Dangos rhagor o weithgareddau penodedig", // Additional description text to accompany the load more button for additional clarity for the user
+  workToDo: "Fy Ngwaith i’w Wneud", // Widget title
+  noActivities: "Nid oes gennych unrhyw weithgareddau anghyflawn gyda dyddiadau dyledus neu ddyddiadau gorffen ar gael.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "Nid oes gennych unrhyw weithgareddau anghyflawn dyledus neu sy'n dod i ben yn fuan. Dewch yn ôl yn nes ymlaen neu Gweld Pob Darn o Waith i weld beth sy'n dod nesaf.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "Nid oes gennych unrhyw weithgareddau anghyflawn gyda dyddiadau dyledus neu ddyddiadau gorffen ar gael. Dewch yn ôl yn nes ymlaen i weld os oes gennych waith i'w wneud.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "Does dim byd yma...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Yn hwyr", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Cwis", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Yn dechrau ar {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Arolwg", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Gwaith Ar Ddod", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Gweld Pob Darn o Waith", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "Mae {count, plural, =1 {1 wythnos} other{{count} wythnos}} wedi’u cwblhau!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
 }

--- a/components/d2l-work-to-do/lang/cy-gb.js
+++ b/components/d2l-work-to-do/lang/cy-gb.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-  myWorkToDo: "My Work To Do", // Widget title
+  workToDo: "Work To Do", // Widget title
   noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/cy-gb.js
+++ b/components/d2l-work-to-do/lang/cy-gb.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/cy-gb.js
+++ b/components/d2l-work-to-do/lang/cy-gb.js
@@ -1,0 +1,28 @@
+export const val = {
+	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+	myWorkToDo: "My Work To Do", // Widget title
+	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/components/d2l-work-to-do/lang/cy.js
+++ b/components/d2l-work-to-do/lang/cy.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-  myWorkToDo: "My Work To Do", // Widget title
+  workToDo: "Work To Do", // Widget title
   noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/cy.js
+++ b/components/d2l-work-to-do/lang/cy.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/cy.js
+++ b/components/d2l-work-to-do/lang/cy.js
@@ -1,0 +1,28 @@
+export const val = {
+	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+	myWorkToDo: "My Work To Do", // Widget title
+	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/components/d2l-work-to-do/lang/cy.js
+++ b/components/d2l-work-to-do/lang/cy.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  activitiesAvailable: "Mae gweithgareddau sy'n ddyledus neu'n dod i ben mewn pythefnos wedi’u cwblhau! Gwiriwch Gweld Pob Darn o Waith i weld beth sy'n dod yn nes ymlaen.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "Dim Byd Am y Tro!", // Displayed as header line in widget text when there are no activities
+  assignment: "Aseiniad",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Yn ôl i’r Hafan", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Rhestr wirio", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Dewch yn ôl yn nes ymlaen i weld os oes gennych waith i'w wneud.", // 'Empty state' - When there are no activities in full page view
+  content: "Cynnwys", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Cwrs", // Meta-data descriptor that informs which type of activity is being displayed on a line item
   dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  discussion: "Trafodaeth", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Gweld pob darn o waith", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Ewch i Darganfod", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Llwytho Mwy", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Dangos rhagor o weithgareddau penodedig", // Additional description text to accompany the load more button for additional clarity for the user
   workToDo: "Work To Do", // Widget title
-  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+  noActivities: "Nid oes gennych unrhyw weithgareddau anghyflawn gyda dyddiadau dyledus neu ddyddiadau gorffen ar gael.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "Nid oes gennych unrhyw weithgareddau anghyflawn dyledus neu sy'n dod i ben yn fuan. Dewch yn ôl yn nes ymlaen neu Gweld Pob Darn o Waith i weld beth sy'n dod nesaf.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "Nid oes gennych unrhyw weithgareddau anghyflawn gyda dyddiadau dyledus neu ddyddiadau gorffen ar gael. Dewch yn ôl yn nes ymlaen i weld os oes gennych waith i'w wneud.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "Does dim byd yma...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Yn hwyr", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Cwis", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Yn dechrau ar {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Arolwg", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Gwaith Ar Ddod", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Gweld Pob Darn o Waith", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "Mae {count, plural, =1 {1 wythnos} other{{count} wythnos}} wedi’u cwblhau!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
 }

--- a/components/d2l-work-to-do/lang/cy.js
+++ b/components/d2l-work-to-do/lang/cy.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Ewch i Darganfod", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Llwytho Mwy", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Dangos rhagor o weithgareddau penodedig", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Work To Do", // Widget title
+  workToDo: "Fy Ngwaith i’w Wneud", // Widget title
   noActivities: "Nid oes gennych unrhyw weithgareddau anghyflawn gyda dyddiadau dyledus neu ddyddiadau gorffen ar gael.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "Nid oes gennych unrhyw weithgareddau anghyflawn dyledus neu sy'n dod i ben yn fuan. Dewch yn ôl yn nes ymlaen neu Gweld Pob Darn o Waith i weld beth sy'n dod nesaf.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "Nid oes gennych unrhyw weithgareddau anghyflawn gyda dyddiadau dyledus neu ddyddiadau gorffen ar gael. Dewch yn ôl yn nes ymlaen i weld os oes gennych waith i'w wneud.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/da.js
+++ b/components/d2l-work-to-do/lang/da.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-  myWorkToDo: "My Work To Do", // Widget title
+  workToDo: "Work To Do", // Widget title
   noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/da.js
+++ b/components/d2l-work-to-do/lang/da.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Gå til Registrer", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Indlæs flere", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Vis flere tildelte aktiviteter", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Work To Do", // Widget title
+  workToDo: "Mine opgaver, der skal udføres", // Widget title
   noActivities: "Du har ingen ikke-gennemførte aktiviteter, hvor forfalds- eller slutdatoer er tilgængelige.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "Du har ingen ikke-gennemførte aktiviteter, der forfalder eller slutter snart. Kom tilbage senere eller Se alle opgaver for at se, hvad der er på vej.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "Du har ingen ikke-gennemførte aktiviteter, hvor forfalds- eller slutdatoer er tilgængelige. Kom tilbage senere for at se, om du har opgaver, der skal udføres.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/da.js
+++ b/components/d2l-work-to-do/lang/da.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/da.js
+++ b/components/d2l-work-to-do/lang/da.js
@@ -1,0 +1,28 @@
+export const val = {
+	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+	myWorkToDo: "My Work To Do", // Widget title
+	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/components/d2l-work-to-do/lang/da.js
+++ b/components/d2l-work-to-do/lang/da.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  activitiesAvailable: "Aktiviteter, der er forfaldne eller slutter om to uger, er fuldført! Kontrollér Se alle opgaver for at se, hvad der er på vej.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "Alt er ryddet nu!", // Displayed as header line in widget text when there are no activities
+  assignment: "Opgave",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Tilbage til startsiden", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Tjekliste", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Kom tilbage senere for at se, om du har opgaver, der skal udføres.", // 'Empty state' - When there are no activities in full page view
+  content: "Indhold", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Kursus", // Meta-data descriptor that informs which type of activity is being displayed on a line item
   dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  discussion: "Diskussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Se alle opgaver", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Gå til Registrer", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Indlæs flere", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Vis flere tildelte aktiviteter", // Additional description text to accompany the load more button for additional clarity for the user
   workToDo: "Work To Do", // Widget title
-  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+  noActivities: "Du har ingen ikke-gennemførte aktiviteter, hvor forfalds- eller slutdatoer er tilgængelige.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "Du har ingen ikke-gennemførte aktiviteter, der forfalder eller slutter snart. Kom tilbage senere eller Se alle opgaver for at se, hvad der er på vej.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "Du har ingen ikke-gennemførte aktiviteter, hvor forfalds- eller slutdatoer er tilgængelige. Kom tilbage senere for at se, om du har opgaver, der skal udføres.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "Der er intet her...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Forfalden", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Eksamination", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starter d. {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Undersøgelse", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Forestående opgaver", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Se alle opgaver", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 uge} other {{count} uger}} ryd!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
 }

--- a/components/d2l-work-to-do/lang/de.js
+++ b/components/d2l-work-to-do/lang/de.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-  myWorkToDo: "My Work To Do", // Widget title
+  workToDo: "Work To Do", // Widget title
   noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/de.js
+++ b/components/d2l-work-to-do/lang/de.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/de.js
+++ b/components/d2l-work-to-do/lang/de.js
@@ -1,0 +1,28 @@
+export const val = {
+	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+	myWorkToDo: "My Work To Do", // Widget title
+	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/components/d2l-work-to-do/lang/de.js
+++ b/components/d2l-work-to-do/lang/de.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  activitiesAvailable: "In den nächsten zwei Wochen fällige oder endende Aktivitäten sind abgeschlossen! Aktivieren Sie „Alle Arbeiten anzeigen“, um zu sehen, was danach kommt.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "Soweit alles klar!", // Displayed as header line in widget text when there are no activities
+  assignment: "Übung",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Zurück zur Startseite", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checkliste", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Sehen Sie später erneut nach, ob Sie unerledigte Arbeit haben.", // 'Empty state' - When there are no activities in full page view
+  content: "Inhalt", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Kurs", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} – {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Diskussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Alle Arbeiten anzeigen", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Zu Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Mehr laden", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Weitere zugewiesene Aktivitäten anzeigen", // Additional description text to accompany the load more button for additional clarity for the user
   workToDo: "Work To Do", // Widget title
-  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+  noActivities: "Sie haben keine unerledigten Aktivitäten mit verfügbarem Fälligkeits- oder Enddatum.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "Es sind keine unvollständigen Aktivitäten vorhanden, die in Kürze fällig sind oder enden. Kommen Sie später zurück oder sehen Sie sich alle Arbeiten an, um zu sehen, was als Nächstes kommt.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "Sie haben keine unerledigten Aktivitäten mit verfügbarem Fälligkeits- oder Enddatum. Sehen Sie später erneut nach, ob Sie unerledigte Arbeit haben.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "Hier gibt es nichts...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Überfällig", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Test", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Beginnt am {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Umfrage", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Anstehende Arbeit", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Alle Arbeiten anzeigen.", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 Woche} other {{count} Wochen}} ohne Termine!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
 }

--- a/components/d2l-work-to-do/lang/de.js
+++ b/components/d2l-work-to-do/lang/de.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Zu Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Mehr laden", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Weitere zugewiesene Aktivitäten anzeigen", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Work To Do", // Widget title
+  workToDo: "Meine ausstehenden Aufgaben", // Widget title
   noActivities: "Sie haben keine unerledigten Aktivitäten mit verfügbarem Fälligkeits- oder Enddatum.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "Es sind keine unvollständigen Aktivitäten vorhanden, die in Kürze fällig sind oder enden. Kommen Sie später zurück oder sehen Sie sich alle Arbeiten an, um zu sehen, was als Nächstes kommt.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "Sie haben keine unerledigten Aktivitäten mit verfügbarem Fälligkeits- oder Enddatum. Sehen Sie später erneut nach, ob Sie unerledigte Arbeit haben.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/en.js
+++ b/components/d2l-work-to-do/lang/en.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-  myWorkToDo: "My Work To Do", // Widget title
+  workToDo: "Work To Do", // Widget title
   noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/en.js
+++ b/components/d2l-work-to-do/lang/en.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/es-es.js
+++ b/components/d2l-work-to-do/lang/es-es.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-  myWorkToDo: "My Work To Do", // Widget title
+  workToDo: "Work To Do", // Widget title
   noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/es-es.js
+++ b/components/d2l-work-to-do/lang/es-es.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/es-es.js
+++ b/components/d2l-work-to-do/lang/es-es.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  activitiesAvailable: "Se completaron las actividades pendientes o que finalizan en dos semanas. Revise la sección Ver todos los trabajos para saber lo que viene después.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "¡Todo claro hasta ahora!", // Displayed as header line in widget text when there are no activities
+  assignment: "Asignación",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Volver a Inicio", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Lista de verificación", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Vuelva más tarde para ver si tiene trabajo que hacer.", // 'Empty state' - When there are no activities in full page view
+  content: "Contenido", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Curso", // Meta-data descriptor that informs which type of activity is being displayed on a line item
   dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Work To Do", // Widget title
-  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+  discussion: "Debate", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Ver todos los trabajos", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Ir a Descubrir", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Cargar más", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Mostrar más actividades asignadas", // Additional description text to accompany the load more button for additional clarity for the user
+  workToDo: "Trabajo pendiente", // Widget title
+  noActivities: "No tiene actividades sin completar pendientes o con fechas finales disponibles.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "No hay actividades sin completar pendientes o que finalicen pronto. Vuelva más tarde o revise la sección Todos los trabajos para ver próximas tareas.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "No tiene actividades sin completar pendientes o con fechas finales disponibles. Vuelva más tarde para ver si tiene trabajo que hacer.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "No hay nada aquí…", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Vencida", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Cuestionario", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Inicia el {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Encuesta", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Próximos trabajos", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Ver todos los trabajos", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 semana} other {{count} semanas}} despejada(s)." // 'Empty state' - Header when widget has no activities to display within the next x weeks
 }

--- a/components/d2l-work-to-do/lang/es-es.js
+++ b/components/d2l-work-to-do/lang/es-es.js
@@ -1,0 +1,28 @@
+export const val = {
+	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+	myWorkToDo: "My Work To Do", // Widget title
+	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/components/d2l-work-to-do/lang/es.js
+++ b/components/d2l-work-to-do/lang/es.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-  myWorkToDo: "My Work To Do", // Widget title
+  workToDo: "Work To Do", // Widget title
   noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/es.js
+++ b/components/d2l-work-to-do/lang/es.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Ir a Descubrir", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Cargar más", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Mostrar más actividades asignadas", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Work To Do", // Widget title
+  workToDo: "Trabajo pendiente", // Widget title
   noActivities: "No tiene actividades sin completar pendientes o con fechas finales disponibles.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "No hay actividades sin completar pendientes o que finalicen pronto. Vuelva más tarde o revise la sección Todos los trabajos para ver próximas tareas.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "No tiene actividades sin completar pendientes o con fechas finales disponibles. Vuelva más tarde para ver si tiene trabajo que hacer.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/es.js
+++ b/components/d2l-work-to-do/lang/es.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  activitiesAvailable: "Se completaron las actividades pendientes o que finalizan en dos semanas. Revise la sección Ver todos los trabajos para saber lo que viene después.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "¡Todo claro hasta ahora!", // Displayed as header line in widget text when there are no activities
+  assignment: "Asignación",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Volver a Inicio", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Lista de verificación", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Vuelva más tarde para ver si tiene trabajo que hacer.", // 'Empty state' - When there are no activities in full page view
+  content: "Contenido", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Curso", // Meta-data descriptor that informs which type of activity is being displayed on a line item
   dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  discussion: "Debate", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Ver todos los trabajos", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Ir a Descubrir", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Cargar más", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Mostrar más actividades asignadas", // Additional description text to accompany the load more button for additional clarity for the user
   workToDo: "Work To Do", // Widget title
-  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+  noActivities: "No tiene actividades sin completar pendientes o con fechas finales disponibles.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "No hay actividades sin completar pendientes o que finalicen pronto. Vuelva más tarde o revise la sección Todos los trabajos para ver próximas tareas.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "No tiene actividades sin completar pendientes o con fechas finales disponibles. Vuelva más tarde para ver si tiene trabajo que hacer.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "No hay nada aquí…", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Vencida", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Cuestionario", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Inicia el {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Encuesta", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Próximos trabajos", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Ver todos los trabajos", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 semana} other {{count} semanas}} despejada(s)." // 'Empty state' - Header when widget has no activities to display within the next x weeks
 }

--- a/components/d2l-work-to-do/lang/es.js
+++ b/components/d2l-work-to-do/lang/es.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/fr-ca.js
+++ b/components/d2l-work-to-do/lang/fr-ca.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-  myWorkToDo: "My Work To Do", // Widget title
+  workToDo: "Work To Do", // Widget title
   noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/fr-ca.js
+++ b/components/d2l-work-to-do/lang/fr-ca.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/fr-ca.js
+++ b/components/d2l-work-to-do/lang/fr-ca.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Allez à Découvrir", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "En voir plus", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Afficher plus d’activités attribuées", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Work To Do", // Widget title
+  workToDo: "Travaux à faire", // Widget title
   noActivities: "Vous n’avez pas d’activités non terminées avec les dates d’échéance ou de fin disponibles.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "Vous n’avez aucune activité non terminée qui vient à échéance ou qui se termine bientôt. Revenez plus tard ou consultez Afficher tous les travaux pour voir ce qui vient ensuite.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "Vous n’avez pas d’activités non terminées avec les dates d’échéance ou de fin disponibles. Revenez plus tard pour voir si vous avez du travail.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/fr-ca.js
+++ b/components/d2l-work-to-do/lang/fr-ca.js
@@ -1,0 +1,28 @@
+export const val = {
+	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+	myWorkToDo: "My Work To Do", // Widget title
+	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+	quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+};

--- a/components/d2l-work-to-do/lang/fr-ca.js
+++ b/components/d2l-work-to-do/lang/fr-ca.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  activitiesAvailable: "Les activités qui viennent à échéance ou se terminent dans deux semaines ont été effectuées! Consultez Afficher tous les travaux pour voir ce qui vient ensuite.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "Rien de plus pour l’instant!", // Displayed as header line in widget text when there are no activities
+  assignment: "Travail",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Retour à l’accueil", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Liste des rappels", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Revenez plus tard pour voir si vous avez du travail.", // 'Empty state' - When there are no activities in full page view
+  content: "Contenu", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Cours", // Meta-data descriptor that informs which type of activity is being displayed on a line item
   dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
   discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  fullViewLink: "Afficher tous les travaux", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Allez à Découvrir", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "En voir plus", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Afficher plus d’activités attribuées", // Additional description text to accompany the load more button for additional clarity for the user
   workToDo: "Work To Do", // Widget title
-  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+  noActivities: "Vous n’avez pas d’activités non terminées avec les dates d’échéance ou de fin disponibles.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "Vous n’avez aucune activité non terminée qui vient à échéance ou qui se termine bientôt. Revenez plus tard ou consultez Afficher tous les travaux pour voir ce qui vient ensuite.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "Vous n’avez pas d’activités non terminées avec les dates d’échéance ou de fin disponibles. Revenez plus tard pour voir si vous avez du travail.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "Il n’y a rien ici…", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "En retard", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Questionnaire", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Débute le {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Sondage", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Travaux à venir", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Afficher tous les travaux", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "Rien de plus pour {count, plural, =1 {1 week} other {{count} weeks}}!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
 }

--- a/components/d2l-work-to-do/lang/fr.js
+++ b/components/d2l-work-to-do/lang/fr.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-  myWorkToDo: "My Work To Do", // Widget title
+  workToDo: "Work To Do", // Widget title
   noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/fr.js
+++ b/components/d2l-work-to-do/lang/fr.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  activitiesAvailable: "Les activités à remettre ou se terminant dans deux semaines sont terminées ! Cochez Afficher tout le travail pour voir les activités à venir.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "Il n’y a rien pour le moment !", // Displayed as header line in widget text when there are no activities
+  assignment: "Devoir",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Retourner à la page d’accueil", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Liste de contrôle", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Revenez plus tard pour vérifier si vous avez du travail à faire.", // 'Empty state' - When there are no activities in full page view
+  content: "Contenu", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Cours", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startDay} {startMonth} - {endDay} {endMonth}", // Indicates that the below list of activities are due/end within the listed date range
   discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  fullViewLink: "Afficher tout le travail", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Accéder à Découvrir", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Charger plus", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Afficher plus d’activités attribuées", // Additional description text to accompany the load more button for additional clarity for the user
   workToDo: "Work To Do", // Widget title
-  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+  noActivities: "Vous n’avez aucune activité incomplète avec des dates d’échéance ou de fin disponibles.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "Vous n’avez aucune activité incomplète ou se terminant bientôt. Revenez plus tard ou cliquez sur Afficher tout le travail pour voir les activités à venir.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "Vous n’avez aucune activité incomplète avec des dates d’échéance ou de fin disponibles. Revenez plus tard pour vérifier si vous avez du travail à faire.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "Il n’y a rien ici...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "En retard", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Questionnaire", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Débute le {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Sondage", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Travail à venir", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Afficher tout le travail", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 semaine terminée} other {{count} semaines terminées}}" // 'Empty state' - Header when widget has no activities to display within the next x weeks
 }

--- a/components/d2l-work-to-do/lang/fr.js
+++ b/components/d2l-work-to-do/lang/fr.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Accéder à Découvrir", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Charger plus", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Afficher plus d’activités attribuées", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Work To Do", // Widget title
+  workToDo: "Travail à faire", // Widget title
   noActivities: "Vous n’avez aucune activité incomplète avec des dates d’échéance ou de fin disponibles.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "Vous n’avez aucune activité incomplète ou se terminant bientôt. Revenez plus tard ou cliquez sur Afficher tout le travail pour voir les activités à venir.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "Vous n’avez aucune activité incomplète avec des dates d’échéance ou de fin disponibles. Revenez plus tard pour vérifier si vous avez du travail à faire.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/fr.js
+++ b/components/d2l-work-to-do/lang/fr.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/ja.js
+++ b/components/d2l-work-to-do/lang/ja.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-  myWorkToDo: "My Work To Do", // Widget title
+  workToDo: "Work To Do", // Widget title
   noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/ja.js
+++ b/components/d2l-work-to-do/lang/ja.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "［Discover］に移動", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "さらに読み込む", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "割り当てられたその他のアクティビティを表示します", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Work To Do", // Widget title
+  workToDo: "取り組むこと", // Widget title
   noActivities: "期限または終了日が設定された未完了のアクティビティはありません。", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "期限または終了日が近い未完了のアクティビティはありません。後でまた確認するか、［すべての学習の表示］をクリックして次のアクティビティを確認してください。",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "期限または終了日が設定された未完了のアクティビティはありません。後でまた、アクティビティがあるか確認してください。", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/ja.js
+++ b/components/d2l-work-to-do/lang/ja.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  activitiesAvailable: "2 週間以内に期限を迎えるまたは終了するアクティビティは完了しました。［すべての学習の表示］をチェックして、次のアクティビティを確認してください", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "今はすべて完了！", // Displayed as header line in widget text when there are no activities
+  assignment: "課題",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "ホームに戻る", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "チェックリスト", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "後でまた、アクティビティがあるか確認してください。", // 'Empty state' - When there are no activities in full page view
+  content: "コンテンツ", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "コース", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth}/{startDay} ～ {endMonth}/{endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "ディスカッション", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "すべての学習の表示", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "［Discover］に移動", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "さらに読み込む", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "割り当てられたその他のアクティビティを表示します", // Additional description text to accompany the load more button for additional clarity for the user
   workToDo: "Work To Do", // Widget title
-  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+  noActivities: "期限または終了日が設定された未完了のアクティビティはありません。", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "期限または終了日が近い未完了のアクティビティはありません。後でまた確認するか、［すべての学習の表示］をクリックして次のアクティビティを確認してください。",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "期限または終了日が設定された未完了のアクティビティはありません。後でまた、アクティビティがあるか確認してください。", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "何もありません ...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "期限切れ", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "クイズ", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "開始日 {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "調査", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "今後の学習", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "すべての学習の表示", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "この先 {count, plural, =1 {1 週間} other {{count} 週間}}何もありません。" // 'Empty state' - Header when widget has no activities to display within the next x weeks
 }

--- a/components/d2l-work-to-do/lang/ja.js
+++ b/components/d2l-work-to-do/lang/ja.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/ko.js
+++ b/components/d2l-work-to-do/lang/ko.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "검색으로 이동합니다", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "더 많이 로드", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "할당된 활동을 더 많이 표시합니다", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Work To Do", // Widget title
+  workToDo: "할 일", // Widget title
   noActivities: "기한 또는 종료일이 있는 미완료 활동이 없습니다.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "기한이 만료되거나 곧 종료되는 활동이 없습니다. 나중에 다시 돌아오거나 모든 작업 보기 를 통해 다음 내용을 확인할 수 있습니다.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "기한 또는 종료일이 있는 미완료 활동이 없습니다. 나중에 돌아와 해야 할 일이 있는지 확인합니다.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/ko.js
+++ b/components/d2l-work-to-do/lang/ko.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-  myWorkToDo: "My Work To Do", // Widget title
+  workToDo: "Work To Do", // Widget title
   noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/ko.js
+++ b/components/d2l-work-to-do/lang/ko.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  activitiesAvailable: "2주 내에 완료되거나 끝나는 활동이 완료되었습니다! 모든 작업 보기 를 선택하여 나중에 어떤 작업을 할 수 있는지 확인합니다.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "지금 모두 지우기!", // Displayed as header line in widget text when there are no activities
+  assignment: "과제",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "홈으로 돌아가기", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "체크리스트", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "나중에 돌아와 해야 할 일이 있는지 확인합니다.", // 'Empty state' - When there are no activities in full page view
+  content: "콘텐츠", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "강의", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay}-{endMonth}{endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "토론", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "모든 작업 보기", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "검색으로 이동합니다", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "더 많이 로드", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "할당된 활동을 더 많이 표시합니다", // Additional description text to accompany the load more button for additional clarity for the user
   workToDo: "Work To Do", // Widget title
-  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+  noActivities: "기한 또는 종료일이 있는 미완료 활동이 없습니다.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "기한이 만료되거나 곧 종료되는 활동이 없습니다. 나중에 다시 돌아오거나 모든 작업 보기 를 통해 다음 내용을 확인할 수 있습니다.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "기한 또는 종료일이 있는 미완료 활동이 없습니다. 나중에 돌아와 해야 할 일이 있는지 확인합니다.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "여기에 아무 것도 없습니다...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "기한 경과", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "퀴즈", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "{startDate}에 시작", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "설문조사", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "예정된 작업", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "모든 작업 보기", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1주} other {{count}주}} 완료!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
 }

--- a/components/d2l-work-to-do/lang/ko.js
+++ b/components/d2l-work-to-do/lang/ko.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/nl.js
+++ b/components/d2l-work-to-do/lang/nl.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-  myWorkToDo: "My Work To Do", // Widget title
+  workToDo: "Work To Do", // Widget title
   noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/nl.js
+++ b/components/d2l-work-to-do/lang/nl.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  activitiesAvailable: "Activiteiten de komende twee weken moeten worden uitgevoerd of beëindigd, zijn voltooid! Bekijk Al het werk weergeven om te zien wat er op komst is.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "Alles is nu klaar!", // Displayed as header line in widget text when there are no activities
+  assignment: "Opdracht",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Terug naar startpagina", // Displayed in the immersive navbar to escape out of fullscreen view
   checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Kom later terug om te zien of er werk is.", // 'Empty state' - When there are no activities in full page view
+  content: "Inhoud", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Cursus", // Meta-data descriptor that informs which type of activity is being displayed on a line item
   dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  discussion: "Discussie", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Al het werk weergeven", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Ga naar Ontdekken", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Meer laden", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Meer toegewezen activiteiten weergeven", // Additional description text to accompany the load more button for additional clarity for the user
   workToDo: "Work To Do", // Widget title
-  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+  noActivities: "U hebt geen onvolledige activiteiten met vervaldatums of einddatums beschikbaar.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "U hebt geen onvolledige activiteiten die binnenkort vervallen of eindigen. Kom later terug of bekijk Al het werk weergeven om te zien wat er op komst is.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "U hebt geen onvolledige activiteiten met vervaldatums of einddatums beschikbaar. Kom later terug om te zien of er werk is.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "Er is hier niets...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Achterstallig", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Test", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Begint op {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Enquête", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Komend werk", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Al het werk weergeven", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} klaar!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
 }

--- a/components/d2l-work-to-do/lang/nl.js
+++ b/components/d2l-work-to-do/lang/nl.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Ga naar Ontdekken", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Meer laden", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Meer toegewezen activiteiten weergeven", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Work To Do", // Widget title
+  workToDo: "Mijn Work To Do", // Widget title
   noActivities: "U hebt geen onvolledige activiteiten met vervaldatums of einddatums beschikbaar.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "U hebt geen onvolledige activiteiten die binnenkort vervallen of eindigen. Kom later terug of bekijk Al het werk weergeven om te zien wat er op komst is.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "U hebt geen onvolledige activiteiten met vervaldatums of einddatums beschikbaar. Kom later terug om te zien of er werk is.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/nl.js
+++ b/components/d2l-work-to-do/lang/nl.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/pt.js
+++ b/components/d2l-work-to-do/lang/pt.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-  myWorkToDo: "My Work To Do", // Widget title
+  workToDo: "Work To Do", // Widget title
   noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/pt.js
+++ b/components/d2l-work-to-do/lang/pt.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  activitiesAvailable: "As atividades com vencimento ou encerramento em duas semanas estão concluídas! Marque Exibir todos os trabalhos para ver o que está por vir.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "Tudo certo por enquanto!", // Displayed as header line in widget text when there are no activities
+  assignment: "Atividade",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Voltar ao Início", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Lista de verificação", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Volte mais tarde para verificar se você tem trabalho pendente.", // 'Empty state' - When there are no activities in full page view
+  content: "Conteúdo", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Curso", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} – {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussão", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Exibir todos os trabalhos", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Ir para o Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Carregar mais", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Exibir mais atividades atribuídas", // Additional description text to accompany the load more button for additional clarity for the user
   workToDo: "Work To Do", // Widget title
-  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+  noActivities: "Você não tem atividades incompletas com prazos ou datas finais disponíveis.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "Você não tem atividades incompletas que vencem ou encerram em breve. Volte mais tarde ou selecione Exibir todos os trabalhos para ver o que está por vir.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "Você não tem atividades incompletas com prazos ou datas finais disponíveis. Volte mais tarde para verificar se você tem trabalho pendente.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "Não há nada aqui…", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Atraso", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Questionário", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Início: {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Pesquisa", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Próximos trabalhos", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Exibir todos os trabalhos", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 semana} other {{count} semanas}} sem trabalhos a fazer!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
 }

--- a/components/d2l-work-to-do/lang/pt.js
+++ b/components/d2l-work-to-do/lang/pt.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Ir para o Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Carregar mais", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Exibir mais atividades atribuídas", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Work To Do", // Widget title
+  workToDo: "Trabalho pendente", // Widget title
   noActivities: "Você não tem atividades incompletas com prazos ou datas finais disponíveis.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "Você não tem atividades incompletas que vencem ou encerram em breve. Volte mais tarde ou selecione Exibir todos os trabalhos para ver o que está por vir.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "Você não tem atividades incompletas com prazos ou datas finais disponíveis. Volte mais tarde para verificar se você tem trabalho pendente.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/pt.js
+++ b/components/d2l-work-to-do/lang/pt.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/sv.js
+++ b/components/d2l-work-to-do/lang/sv.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-  myWorkToDo: "My Work To Do", // Widget title
+  workToDo: "Work To Do", // Widget title
   noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/sv.js
+++ b/components/d2l-work-to-do/lang/sv.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  activitiesAvailable: "Aktiviteter som förfaller eller slutar inom två veckor är slutförda! Markera Visa alla jobb om du vill se vad som kommer längre fram.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "Allt klart nu!", // Displayed as header line in widget text when there are no activities
+  assignment: "Uppgift",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Tillbaka till hemsida", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklista", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Kom tillbaka senare för att se om du har jobb att göra.", // 'Empty state' - When there are no activities in full page view
+  content: "Innehåll", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Kurs", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay}–{endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Diskussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Visa alla jobb", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Gå till Upptäck", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Läs in fler", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Visa fler tilldelade aktiviteter", // Additional description text to accompany the load more button for additional clarity for the user
   workToDo: "Work To Do", // Widget title
-  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+  noActivities: "Du har inga ofullständiga aktiviteter med tillgängliga förfallodatum eller slutdatum.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "Du har inga ofullständiga aktiviteter som förfaller eller slutar snart. Kom tillbaka senare eller Visa alla jobb för att se vad som kommer härnäst.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "Du har inga ofullständiga aktiviteter med tillgängliga förfallodatum eller slutdatum. Kom tillbaka senare för att se om du har arbete att göra.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "Det finns inget här …", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Försenad", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Förhör", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Börjar {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Enkät", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Kommande jobb", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Se allt", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 vecka} other {{count} veckor}} rensat!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
 }

--- a/components/d2l-work-to-do/lang/sv.js
+++ b/components/d2l-work-to-do/lang/sv.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/sv.js
+++ b/components/d2l-work-to-do/lang/sv.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Gå till Upptäck", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Läs in fler", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Visa fler tilldelade aktiviteter", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Work To Do", // Widget title
+  workToDo: "Mina jobb att göra", // Widget title
   noActivities: "Du har inga ofullständiga aktiviteter med tillgängliga förfallodatum eller slutdatum.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "Du har inga ofullständiga aktiviteter som förfaller eller slutar snart. Kom tillbaka senare eller Visa alla jobb för att se vad som kommer härnäst.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "Du har inga ofullständiga aktiviteter med tillgängliga förfallodatum eller slutdatum. Kom tillbaka senare för att se om du har arbete att göra.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/tr.js
+++ b/components/d2l-work-to-do/lang/tr.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-  myWorkToDo: "My Work To Do", // Widget title
+  workToDo: "Work To Do", // Widget title
   noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/tr.js
+++ b/components/d2l-work-to-do/lang/tr.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  activitiesAvailable: "Teslim tarihi veya sona erme tarihi iki hafta içinde olan etkinlikler tamamlandı! Daha sonraki etkinlikleri görmek için Tüm İşleri Görüntüle seçeneğini işaretleyin.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "Şimdilik Her Şey Tamamlandı!", // Displayed as header line in widget text when there are no activities
+  assignment: "Ödev",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Ana Sayfaya Geri Dön", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Kontrol Listesi", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Üzerinde çalışacağınız bir iş olup olmadığını görmek için daha sonra tekrar ziyaret edin.", // 'Empty state' - When there are no activities in full page view
+  content: "İçerik", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Ders", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startDay} {startMonth} - {endDay} {endMonth}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Tartışma", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "Tüm çalışmaları görüntüle", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Keşfet'e Git", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Daha Fazla Yükle", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Daha fazla atanmış etkinlik görüntüle", // Additional description text to accompany the load more button for additional clarity for the user
   workToDo: "Work To Do", // Widget title
-  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+  noActivities: "Teslim veya sona erme tarihi bulunan tamamlanmamış etkinliğiniz yok.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "Teslim veya sona erme tarihi yaklaşmakta olan tamamlanmamış etkinliğiniz yok. Daha sonraki etkinlikleri görmek için daha sonra tekrar ziyaret edin veya Tüm İşleri Görüntüleyin.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "Teslim veya sona erme tarihi bulunan tamamlanmamış etkinliğiniz yok. Üzerinde çalışacağınız bir iş olup olmadığını görmek için daha sonra tekrar ziyaret edin.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "Hiçbir şey yok...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Süresi Dolmuş", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Sınav", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Başlama Tarihi: {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Anket", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Yaklaşan İş", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "Tüm İşleri Görüntüle", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 hafta} other {{count} hafta}} tamamlandı!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
 }

--- a/components/d2l-work-to-do/lang/tr.js
+++ b/components/d2l-work-to-do/lang/tr.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Keşfet'e Git", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Daha Fazla Yükle", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Daha fazla atanmış etkinlik görüntüle", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Work To Do", // Widget title
+  workToDo: "Yapılacak İşlerim", // Widget title
   noActivities: "Teslim veya sona erme tarihi bulunan tamamlanmamış etkinliğiniz yok.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "Teslim veya sona erme tarihi yaklaşmakta olan tamamlanmamış etkinliğiniz yok. Daha sonraki etkinlikleri görmek için daha sonra tekrar ziyaret edin veya Tüm İşleri Görüntüleyin.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "Teslim veya sona erme tarihi bulunan tamamlanmamış etkinliğiniz yok. Üzerinde çalışacağınız bir iş olup olmadığını görmek için daha sonra tekrar ziyaret edin.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/tr.js
+++ b/components/d2l-work-to-do/lang/tr.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/zh-tw.js
+++ b/components/d2l-work-to-do/lang/zh-tw.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-  myWorkToDo: "My Work To Do", // Widget title
+  workToDo: "Work To Do", // Widget title
   noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/zh-tw.js
+++ b/components/d2l-work-to-do/lang/zh-tw.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  activitiesAvailable: "兩週內截止的活動都已完成！請查看「檢視所有作業」，來瞭解接下來的活動。", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "目前已全數清空！", // Displayed as header line in widget text when there are no activities
+  assignment: "作業",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "返回首頁", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "檢查表", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "請稍後再回來看看是否有工作要進行。", // 'Empty state' - When there are no activities in full page view
+  content: "內容", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "課程", // Meta-data descriptor that informs which type of activity is being displayed on a line item
   dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  discussion: "討論", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "檢視所有作業", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "前往「探索」", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "載入更多", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "顯示更多已指派的活動", // Additional description text to accompany the load more button for additional clarity for the user
   workToDo: "Work To Do", // Widget title
-  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+  noActivities: "您沒有具有截止日期或結束日期的未完成活動。", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "您沒有即將截止的未完成活動。請稍後再回來，或透過「檢視所有工作」來瞭解接下來的活動。",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "您沒有具有截止日期或結束日期的未完成活動。請稍後再回來看看是否有工作要進行。", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "這裡沒有任何內容...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "逾期", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "測驗", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "開始於 {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "問卷調查", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "近期作業", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "檢視所有作業", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 週} other {{count} 週}}內均已清空！" // 'Empty state' - Header when widget has no activities to display within the next x weeks
 }

--- a/components/d2l-work-to-do/lang/zh-tw.js
+++ b/components/d2l-work-to-do/lang/zh-tw.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/zh-tw.js
+++ b/components/d2l-work-to-do/lang/zh-tw.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "前往「探索」", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "載入更多", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "顯示更多已指派的活動", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Work To Do", // Widget title
+  workToDo: "我的待做作業", // Widget title
   noActivities: "您沒有具有截止日期或結束日期的未完成活動。", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "您沒有即將截止的未完成活動。請稍後再回來，或透過「檢視所有工作」來瞭解接下來的活動。",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "您沒有具有截止日期或結束日期的未完成活動。請稍後再回來看看是否有工作要進行。", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/zh.js
+++ b/components/d2l-work-to-do/lang/zh.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-  myWorkToDo: "My Work To Do", // Widget title
+  workToDo: "Work To Do", // Widget title
   noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/zh.js
+++ b/components/d2l-work-to-do/lang/zh.js
@@ -13,7 +13,7 @@ export const val = {
   goToDiscover: "转至“发现”", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
   loadMore: "加载更多", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
   loadMoreDescription: "显示更多已分配的活动", // Additional description text to accompany the load more button for additional clarity for the user
-  workToDo: "Work To Do", // Widget title
+  workToDo: "待办事项", // Widget title
   noActivities: "您没有具有到期或结束日期的未完成活动。", // 'Empty state' - When widget has no activities in full page view
   noActivitiesFutureActivities: "您没有到期或即将结束的未完成活动。稍后回来或查看所有工作以查看即将发布的工作。",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
   noActivitiesNoFutureActivities: "您没有具有到期或结束日期的未完成活动。稍后回来查看您是否有工作要完成。", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future

--- a/components/d2l-work-to-do/lang/zh.js
+++ b/components/d2l-work-to-do/lang/zh.js
@@ -1,28 +1,28 @@
 export const val = {
-	activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-	allClear : "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-	Assignment : "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	backToD2L : "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-	Checklist : "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	comeBackNoFutureActivities : "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-	Content : "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	Course : "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	dateHeader : "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-	Discussion : "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-	goToDiscover : "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-	loadMore : "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-	loadMoreDescription : "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
-	myWorkToDo: "My Work To Do", // Widget title
-	noActivities : "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-	noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-	noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-	nothingHere : "There\'s nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-	overdue : "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-	Quiz : "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	StartsWithDate : "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-	Survey : "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-	upcoming : "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-	viewAllWork : "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-	xWeeksClear : "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
-};
+  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
+  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
+  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
+  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  myWorkToDo: "My Work To Do", // Widget title
+  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+}

--- a/components/d2l-work-to-do/lang/zh.js
+++ b/components/d2l-work-to-do/lang/zh.js
@@ -1,28 +1,28 @@
 export const val = {
-  activitiesAvailable: "Activities that are due or ending in two weeks are complete! Check View All Work to see what's coming later.", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
-  allClear: "All Clear For Now!", // Displayed as header line in widget text when there are no activities
-  assignment: "Assignment",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  backToD2L: "Back to Home", // Displayed in the immersive navbar to escape out of fullscreen view
-  checklist: "Checklist", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  comeBackNoFutureActivities: "Come back later to see if you have work to do.", // 'Empty state' - When there are no activities in full page view
-  content: "Content", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  course: "Course", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  activitiesAvailable: "两周内到期或结束的活动已完成！选中“查看所有工作”以查看即将发布的工作。", // 'Empty View' - When widget has no activities to display within the next two weeks, but there are more activities further into the future that can be shown on the full screen view
+  allClear: "现在已经全部清楚！", // Displayed as header line in widget text when there are no activities
+  assignment: "作业",  // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  backToD2L: "返回主页", // Displayed in the immersive navbar to escape out of fullscreen view
+  checklist: "清单", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  comeBackNoFutureActivities: "稍后回来查看您是否有工作要完成。", // 'Empty state' - When there are no activities in full page view
+  content: "内容", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  course: "课程", // Meta-data descriptor that informs which type of activity is being displayed on a line item
   dateHeader: "{startMonth} {startDay} - {endMonth} {endDay}", // Indicates that the below list of activities are due/end within the listed date range
-  discussion: "Discussion", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  fullViewLink: "View all work", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
-  goToDiscover: "Go To Discover", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
-  loadMore: "Load More", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
-  loadMoreDescription: "Display more assigned activities", // Additional description text to accompany the load more button for additional clarity for the user
+  discussion: "讨论", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  fullViewLink: "查看所有作业", // Link text displayed in "Activities View", where the user can navigate to the full page view to see all work
+  goToDiscover: "转至“发现”", // Button text displayed in 'Empty View' when user can navigate to discover homepage from the widget
+  loadMore: "加载更多", // Button text displayed in 'Fullscreen View' that allows the user to access the next page of activities which will append to the bottom of the list currently shown
+  loadMoreDescription: "显示更多已分配的活动", // Additional description text to accompany the load more button for additional clarity for the user
   workToDo: "Work To Do", // Widget title
-  noActivities: "You have no incomplete activities with due or end dates available.", // 'Empty state' - When widget has no activities in full page view
-  noActivitiesFutureActivities: "You have no incomplete activities due or ending soon. Come back later or View All Work to see what's coming next.",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
-  noActivitiesNoFutureActivities: "You have no incomplete activities with due or end dates available. Come back later to see if you have work to do.", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
-  nothingHere: "There's nothing here...", // Displayed as header line in widget text when there are no activities within the provided time period
-  overdue: "Overdue", // Indicates that the below list of activities are overdue (have a due date that is in the past)
-  quiz: "Quiz", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  StartsWithDate: "Starts {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
-  survey: "Survey", // Meta-data descriptor that informs which type of activity is being displayed on a line item
-  upcoming: "Upcoming Work", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
-  viewAllWork: "View All Work", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
-  xWeeksClear: "{count, plural, =1 {1 week} other {{count} weeks}} clear!" // 'Empty state' - Header when widget has no activities to display within the next x weeks
+  noActivities: "您没有具有到期或结束日期的未完成活动。", // 'Empty state' - When widget has no activities in full page view
+  noActivitiesFutureActivities: "您没有到期或即将结束的未完成活动。稍后回来或查看所有工作以查看即将发布的工作。",  // 'Empty View' - When widget has no activities to display within the next few weeks & there are activities in the future
+  noActivitiesNoFutureActivities: "您没有具有到期或结束日期的未完成活动。稍后回来查看您是否有工作要完成。", // 'Empty View' - When widget has no activities to display within the next few weeks & there are no more activities in the future
+  nothingHere: "没有任何工作...", // Displayed as header line in widget text when there are no activities within the provided time period
+  overdue: "过期", // Indicates that the below list of activities are overdue (have a due date that is in the past)
+  quiz: "测验", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  StartsWithDate: "开始日期 {startDate}", // show Start Date on status indicator when an activity starts in the future - formatted like "Starts Aug 15"
+  survey: "调查", // Meta-data descriptor that informs which type of activity is being displayed on a line item
+  upcoming: "即将分配的作业", // Indicates that the below list of activites are upcoming (have a due due or end date that is in the future)
+  viewAllWork: "查看所有作业", // Button text displayed in 'Empty View' when user can navigate to full page view to see all work
+  xWeeksClear: "{count, plural, =1 {1 周} other {{count} 周}} 清楚！" // 'Empty state' - Header when widget has no activities to display within the next x weeks
 }

--- a/components/d2l-work-to-do/mixins/d2l-work-to-do-localization-mixin.js
+++ b/components/d2l-work-to-do/mixins/d2l-work-to-do-localization-mixin.js
@@ -1,8 +1,14 @@
 import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { getLocalizeOverrideResources } from '@brightspace-ui/core/helpers/getLocalizeResources.js';
 
 export const LocalizeWorkToDoMixin = superclass => class extends LocalizeMixin(superclass) {
 
 	static async getLocalizeResources(langs) {
+
+		function resolveOverridesFunc() {
+			return 'd2l-activities\\workToDo';
+		}
+
 		let translations;
 		for await (const lang of langs) {
 			switch (lang) {
@@ -62,17 +68,19 @@ export const LocalizeWorkToDoMixin = superclass => class extends LocalizeMixin(s
 					break;
 			}
 			if (translations && translations.val) {
-				return {
-					language: lang,
-					resources: translations.val
-				};
+				return await getLocalizeOverrideResources(
+					lang,
+					translations.val,
+					resolveOverridesFunc
+				);
 			}
 		}
 
 		translations = await import('../lang/en.js');
-		return {
-			language: 'en',
-			resources: translations.val
-		};
+		return await getLocalizeOverrideResources(
+			'en',
+			translations.val,
+			resolveOverridesFunc
+		);
 	}
 };

--- a/components/d2l-work-to-do/mixins/d2l-work-to-do-localization-mixin.js
+++ b/components/d2l-work-to-do/mixins/d2l-work-to-do-localization-mixin.js
@@ -6,11 +6,32 @@ export const LocalizeWorkToDoMixin = superclass => class extends LocalizeMixin(s
 		let translations;
 		for await (const lang of langs) {
 			switch (lang) {
+				case 'ar':
+					translations = await import('../lang/ar.js');
+					break;
+				case 'cy-gb':
+					translations = await import('../lang/cy-gb.js');
+					break;
+				case 'cy':
+					translations = await import('../lang/cy.js');
+					break;
+				case 'da':
+					translations = await import('../lang/da.js');
+					break;
+				case 'de':
+					translations = await import('../lang/de.js');
+					break;
 				case 'en':
 					translations = await import('../lang/en.js');
 					break;
+				case 'es-es':
+					translations = await import('../lang/es-es.js');
+					break;
 				case 'es':
 					translations = await import('../lang/es.js');
+					break;
+				case 'fr-ca':
+					translations = await import('../lang/fr-ca.js');
 					break;
 				case 'fr':
 					translations = await import('../lang/fr.js');


### PR DESCRIPTION
Some items still to come:

- [x] Serge config (previously merged)
- [x] Missing languages
- [x] Updated langterm keys
- [x] "My Work To Do" -> "Work To Do"
- [x] Add "Course" subtitle to widget view
- [x] Old OSLO implementation
- [x] Translations
- [x] Fixed "Work To Do" title langterms