### PR TITLE
Return

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz-timing.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz-timing.js
@@ -78,6 +78,7 @@ export class QuizTiming {
 		// In this case, we should attempt to reload the MobX object, so that the UI state is in sync again.
 		if (!entity) {
 			this.fetch();
+			return;
 		}
 		this._entity = entity;
 	}


### PR DESCRIPTION
if `entity` is undefined, and we call `fetch`, `this._entity` is updated with the correct entity. We shouldn't be re-setting it to `undefined`.