### PR TITLE
DE42620: Flush debouncer when saving

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -68,7 +68,7 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 						.ariaLabel="content-description"
 						.key="content-description"
 						.value="${descriptionRichText}"
-						@d2l-activity-html-editor-change="${this._onRichtextChange}"
+						@d2l-activity-text-editor-change="${this._onRichtextChange}"
 						.richtextEditorConfig="${{}}"
 					>
 					</d2l-activity-text-editor>
@@ -106,6 +106,7 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 			return;
 		}
 
+		this._saveOnChange('description');
 		await moduleEntity.save();
 	}
 
@@ -132,6 +133,10 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 			return;
 		}
 		moduleEntity.setDescription(richText);
+	}
+
+	_saveOnChange(jobName) {
+		this._debounceJobs[jobName] && this._debounceJobs[jobName].flush();
 	}
 }
 customElements.define('d2l-activity-content-module-detail', ContentModuleDetail);


### PR DESCRIPTION
[DE42620](https://rally1.rallydev.com/#/289692574792/custom/355050439968?detail=%2Fdefect%2F502153333324&fdp=true): Lessons FACE > Changes made in the new HTML editor are not always saved

The new html editor dispatches events on `blur` instead of on `change`. Typing into the new html editor then immediately clicking `Save` or `Save and close` created a race condition between setting the description (triggered by the `blur` event - this is also behind a 0.5 second debouncer) and the asynchronous api call which saves the description.

This PR makes sure the description is set first (if in the debouncer) before saving.