### PR TITLE
US123692 - Add error handling to working copy dialog mixin

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-manage-timing-container.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-manage-timing-container.js
@@ -1,4 +1,5 @@
 import './d2l-activity-quiz-manage-timing-editor.js';
+import '@brightspace-ui/core/components/alert/alert.js';
 import '@brightspace-ui/core/components/dialog/dialog.js';
 import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorWorkingCopyDialogMixin } from '../mixins/d2l-activity-editor-working-copy-dialog-mixin';
@@ -15,12 +16,21 @@ class ActivityQuizManageTimingContainer extends ActivityEditorWorkingCopyDialogM
 				#manage-timing-dialog-timing-editor {
 					height: 430px;
 				}
+				d2l-alert {
+					margin-bottom: 1rem;
+				}
 			`,
 		];
 	}
 
 	constructor() {
 		super(store);
+	}
+
+	firstUpdated() {
+		super.firstUpdated();
+		this.serverErrorTerm = this.localize('quizTimingServerError');
+		this.validationErrorTerm = this.localize('quizTimingValidationError');
 	}
 
 	render() {
@@ -41,9 +51,10 @@ class ActivityQuizManageTimingContainer extends ActivityEditorWorkingCopyDialogM
 				?async="${showSpinnerWhenLoading}"
 				width="${width}"
 				title-text=${this.localize('subHdrTimingTools') }>
+					<d2l-alert type="error" ?hidden=${!this.isError || !this.errorTerm}>${this.errorTerm}</d2l-alert>
 					<div id="manage-timing-dialog-timing-editor">${this._renderQuizTimingEditor()}</div>
-					<d2l-button slot="footer" primary @click="${this.checkinDialog}">${this.localize('manageTimingDialogConfirmationText')}</d2l-button>
-					<d2l-button slot="footer" data-dialog-action>${this.localize('manageTimingDialogCancelText')}</d2l-button>
+					<d2l-button slot="footer" primary @click="${this.checkinDialog}" ?disabled="${this.isSaving}">${this.localize('manageTimingDialogConfirmationText')}</d2l-button>
+					<d2l-button slot="footer" data-dialog-action ?disabled="${this.isSaving}">${this.localize('manageTimingDialogCancelText')}</d2l-button>
 			</d2l-dialog>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
@@ -109,5 +109,7 @@ export default {
 	"minLabel": "Min:", // label for Min input on Attempts Conditions range editor on Attempts Dialog
 	"maxLabel": "Max:", // label for Max input on Attempts Conditions range editor on Attempts Dialog
 	"andRangeText": "and", // copy on Attempts Condition range editor on Attempts Dialog
-	"percentageRangeText": "%" // copy on Attempts Condition range editor on Attempts Dialog
+	"percentageRangeText": "%", // copy on Attempts Condition range editor on Attempts Dialog
+	"quizTimingValidationError": "Timing cannot be changed, please correct the outlined fields", // Appears in error alert when validation fails in Manage Timing dialog
+	"quizTimingServerError": "Something went wrong. Please try again." // Timing save server error alert message
 };

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz.js
@@ -31,6 +31,7 @@ export class Quiz {
 			this._saving = null;
 		}
 
+		if (!sirenEntity) return;
 		const href = sirenEntity.self();
 		const entity = new Quiz(href, this.token);
 		entity.load(sirenEntity);

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz.js
@@ -25,7 +25,7 @@ export class Quiz {
 		let sirenEntity;
 		try {
 			sirenEntity = await this._saving;
-		} catch(e) {
+		} catch (e) {
 			return;
 		} finally {
 			this._saving = null;

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz.js
@@ -22,15 +22,19 @@ export class Quiz {
 		}
 
 		this._saving = this._entity.checkin();
-		const sirenEntity = await this._saving;
-		if (!sirenEntity) return;
+		let sirenEntity;
+		try {
+			sirenEntity = await this._saving;
+		} catch(e) {
+			return;
+		} finally {
+			this._saving = null;
+		}
 
 		const href = sirenEntity.self();
 		const entity = new Quiz(href, this.token);
 		entity.load(sirenEntity);
 		quizStore.put(href, entity);
-
-		this._saving = null;
 	}
 
 	checkout(quizStore, forcedCheckout) {

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-working-copy-dialog-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-working-copy-dialog-mixin.js
@@ -100,15 +100,15 @@ export const ActivityEditorWorkingCopyDialogMixin = superclass => class extends 
 		return false;
 	}
 
+	_hasSkipAlertAncestor(node) {
+		return null !== findComposedAncestor(node, elm => elm && elm.hasAttribute && elm.hasAttribute('skip-alert'));
+	}
+
 	_resetProps() {
 		this.dialogHref = '';
 		this.errorTerm = '';
 		this.isError = false;
 		this.isSaving = false;
-	}
-
-	_hasSkipAlertAncestor(node) {
-		return null !== findComposedAncestor(node, elm => elm && elm.hasAttribute && elm.hasAttribute('skip-alert'));
 	}
 
 	async _verifyAllInputsValid() {

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-working-copy-dialog-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-working-copy-dialog-mixin.js
@@ -56,7 +56,7 @@ export const ActivityEditorWorkingCopyDialogMixin = superclass => class extends 
 
 		try {
 			await entity.checkin(this.store);
-		} catch {
+		} catch (e) {
 			this.isError = true;
 			this.errorTerm = this.serverErrorTerm;
 			return;


### PR DESCRIPTION
Like the validation, the setting of `isError` is again inspired by the `activity-editor-container-mixin` https://github.com/BrightspaceHypermediaComponents/activities/blob/b7db0429ed7039258ed8d0e8270a229215c2ebdd/components/d2l-activity-editor/mixins/d2l-activity-editor-container-mixin.js

The timing/workingcopy component needs to include a `d2l-alert` that uses the `isError` and `errorTerm` properties to determine what to display. The `isError` and `errorTerm` are set in the mixin based on whether the input validation and the `checkin` succeed or fail. The error term is set to the `validationErrorTerm` if the input validation check fails or `serverErrorTerm` if the `checkin` fails. The `validationErrorTerm` and `serverErrorTerm` properties are set in the `firstUpdated` function of the timing component. (I tried setting it in the constructor, but `this.localize(...)` returns nothing.

This PR also adds an `isSaving` property which is used to disable the 'OK' and 'Cancel' buttons. This is important because the dialog needs to wait for the `checkin` to complete before closing and thus there is a delay. If it fails, the dialog stays open and shows the `serverErrorTerm` in the alert as detailed above.


https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F478606416460%2Ftasks


See this other PR that changes the `checkin` function to reject the promise if it fails: https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/279