### PR TITLE
DE42624: Increasing editor size to take up all available vertical space

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
@@ -24,7 +24,7 @@ class ContentEditorDetail extends MobxLitElement {
 				}
 				d2l-activity-content-module-detail {
 					display: flex;
-					flex-flow: column;
+					flex-direction: column;
 					height: inherit;
 				}
 			`

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
@@ -22,6 +22,11 @@ class ContentEditorDetail extends MobxLitElement {
 				d2l-loading-spinner {
 					width: 100%;
 				}
+				d2l-activity-content-module-detail {
+					display: flex;
+					flex-flow: column;
+					height: inherit;
+				}
 			`
 		];
 	}

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
@@ -40,6 +40,12 @@ class ContentEditor extends LocalizeActivityEditorMixin(RtlMixin(ActivityEditorM
 				padding-left: 1rem;
 				padding-right: 0;
 			}
+			#d2l-activity-content-editor-primary-panel {
+				height: 100%;
+			}
+			d2l-activity-content-editor-detail {
+				height: inherit;
+			}
 		`;
 	}
 
@@ -90,7 +96,7 @@ class ContentEditor extends LocalizeActivityEditorMixin(RtlMixin(ActivityEditorM
 	get _editorTemplate() {
 		return html`
 			<slot name="editor-nav" slot="header"></slot>
-			<div slot="primary">
+			<div slot="primary" id="d2l-activity-content-editor-primary-panel">
 				<d2l-activity-content-editor-detail
 					.href="${this.href}"
 					.token="${this.token}"

--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -34,7 +34,7 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 				}
 				#content-description-container {
 					display: flex;
-					flex-flow: column;
+					flex-direction: column;
 					height: inherit;
 				}
 			`

--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -27,6 +27,17 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 			css`
 				.d2l-activity-label-container {
 					margin-bottom: 7px;
+					display: inline-block;
+					vertical-align: bottom;
+				}
+				#content-description-container {
+					display: flex;
+					flex-flow: column;
+					height: inherit;
+				}
+				#html-editor-container {
+					flex-grow: 1;
+					min-height: 300px;
 				}
 			`
 		];
@@ -63,13 +74,15 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 				<div class="d2l-activity-label-container d2l-label-text d2l-skeletize">
 					${this.localize('content.description')}
 				</div>
-				<div class="d2l-skeletize">
+				<div id="html-editor-container" class="d2l-skeletize">
 					<d2l-activity-text-editor
-						.ariaLabel="content-description"
+						id="d2l-activity-text-editor"
+						ariaLabel="${this.localize('content.description')}"
 						.key="content-description"
 						.value="${descriptionRichText}"
 						@d2l-activity-text-editor-change="${this._onRichtextChange}"
 						.richtextEditorConfig="${{}}"
+						height="100%"
 					>
 					</d2l-activity-text-editor>
 				</div>

--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -30,7 +30,7 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 				}
 				.d2l-new-html-editor-container {
 					flex-grow: 1;
-					min-height: 10rem;
+					min-height: 300px;
 				}
 				#content-description-container {
 					display: flex;

--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -82,7 +82,7 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 						.value="${descriptionRichText}"
 						@d2l-activity-text-editor-change="${this._onRichtextChange}"
 						.richtextEditorConfig="${{}}"
-						height="100%"
+						htmlEditorHeight="100%"
 					>
 					</d2l-activity-text-editor>
 				</div>

--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -84,7 +84,7 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 				<div class="d2l-activity-label-container d2l-label-text d2l-skeletize">
 					${this.localize('content.description')}
 				</div>
-				<div class="${htmlNewEditorEnabled ? 'd2l-new-html-editor-container' : ''} d2l-skeletize">
+				<div class="d2l-skeletize ${htmlNewEditorEnabled ? 'd2l-new-html-editor-container' : ''}">
 					<d2l-activity-text-editor
 						.ariaLabel="${this.localize('content.description')}"
 						.key="content-description"

--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -57,22 +57,21 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 	render() {
 		const moduleEntity = moduleStore.getContentModuleActivity(this.href);
 		let descriptionRichText = undefined;
-		let htmlNewEditorEnabled = false;
 
 		if (moduleEntity) {
 			this.skeleton = false;
 			descriptionRichText = moduleEntity.descriptionRichText;
-
-			let newEditorEvent = new CustomEvent('d2l-request-provider', {
-				detail: { key: 'd2l-provider-html-new-editor-enabled' },
-				bubbles: true,
-				composed: true,
-				cancelable: true
-			});
-
-			this.dispatchEvent(newEditorEvent);
-			htmlNewEditorEnabled = newEditorEvent.detail.provider;
 		}
+
+		let newEditorEvent = new CustomEvent('d2l-request-provider', {
+			detail: { key: 'd2l-provider-html-new-editor-enabled' },
+			bubbles: true,
+			composed: true,
+			cancelable: true
+		});
+
+		this.dispatchEvent(newEditorEvent);
+		let htmlNewEditorEnabled = newEditorEvent.detail.provider;
 
 		return html`
 			<d2l-activity-content-editor-title

--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -63,7 +63,7 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 			descriptionRichText = moduleEntity.descriptionRichText;
 		}
 
-		let newEditorEvent = new CustomEvent('d2l-request-provider', {
+		const newEditorEvent = new CustomEvent('d2l-request-provider', {
 			detail: { key: 'd2l-provider-html-new-editor-enabled' },
 			bubbles: true,
 			composed: true,
@@ -71,7 +71,7 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 		});
 
 		this.dispatchEvent(newEditorEvent);
-		let htmlNewEditorEnabled = newEditorEvent.detail.provider;
+		const htmlNewEditorEnabled = newEditorEvent.detail.provider;
 
 		return html`
 			<d2l-activity-content-editor-title

--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -25,15 +25,10 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 			labelStyles,
 			activityContentEditorStyles,
 			css`
-				:host([skeleton]) .d2l-skeletize::before {
-					z-index: 3;
-				}
 				.d2l-activity-label-container {
 					margin-bottom: 7px;
-					display: inline-block;
-					vertical-align: bottom;
 				}
-				.new-html-editor-container {
+				.d2l-new-html-editor-container {
 					flex-grow: 1;
 					min-height: 300px;
 				}
@@ -62,20 +57,22 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 	render() {
 		const moduleEntity = moduleStore.getContentModuleActivity(this.href);
 		let descriptionRichText = undefined;
+		let htmlNewEditorEnabled = false;
+
 		if (moduleEntity) {
 			this.skeleton = false;
 			descriptionRichText = moduleEntity.descriptionRichText;
+
+			let newEditorEvent = new CustomEvent('d2l-request-provider', {
+				detail: { key: 'd2l-provider-html-new-editor-enabled' },
+				bubbles: true,
+				composed: true,
+				cancelable: true
+			});
+
+			this.dispatchEvent(newEditorEvent);
+			htmlNewEditorEnabled = newEditorEvent.detail.provider;
 		}
-
-		const newEditorEvent = new CustomEvent('d2l-request-provider', {
-			detail: { key: 'd2l-provider-html-new-editor-enabled' },
-			bubbles: true,
-			composed: true,
-			cancelable: true
-		});
-		this.dispatchEvent(newEditorEvent);
-
-		const htmlNewEditorEnabled = newEditorEvent.detail.provider;
 
 		return html`
 			<d2l-activity-content-editor-title
@@ -87,10 +84,9 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 				<div class="d2l-activity-label-container d2l-label-text d2l-skeletize">
 					${this.localize('content.description')}
 				</div>
-				<div class="${htmlNewEditorEnabled ? 'new-html-editor-container' : ''} d2l-skeletize">
+				<div class="${htmlNewEditorEnabled ? 'd2l-new-html-editor-container' : ''} d2l-skeletize">
 					<d2l-activity-text-editor
-						id="d2l-activity-text-editor"
-						ariaLabel="${this.localize('content.description')}"
+						.ariaLabel="${this.localize('content.description')}"
 						.key="content-description"
 						.value="${descriptionRichText}"
 						@d2l-activity-text-editor-change="${this._onRichtextChange}"

--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -30,7 +30,7 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 				}
 				.d2l-new-html-editor-container {
 					flex-grow: 1;
-					min-height: 300px;
+					min-height: 10rem;
 				}
 				#content-description-container {
 					display: flex;

--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -25,19 +25,22 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 			labelStyles,
 			activityContentEditorStyles,
 			css`
+				:host([skeleton]) .d2l-skeletize::before {
+					z-index: 3;
+				}
 				.d2l-activity-label-container {
 					margin-bottom: 7px;
 					display: inline-block;
 					vertical-align: bottom;
 				}
+				.new-html-editor-container {
+					flex-grow: 1;
+					min-height: 300px;
+				}
 				#content-description-container {
 					display: flex;
 					flex-flow: column;
 					height: inherit;
-				}
-				#html-editor-container {
-					flex-grow: 1;
-					min-height: 300px;
 				}
 			`
 		];
@@ -64,6 +67,16 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 			descriptionRichText = moduleEntity.descriptionRichText;
 		}
 
+		const newEditorEvent = new CustomEvent('d2l-request-provider', {
+			detail: { key: 'd2l-provider-html-new-editor-enabled' },
+			bubbles: true,
+			composed: true,
+			cancelable: true
+		});
+		this.dispatchEvent(newEditorEvent);
+
+		const htmlNewEditorEnabled = newEditorEvent.detail.provider;
+
 		return html`
 			<d2l-activity-content-editor-title
 				.entity=${moduleEntity}
@@ -74,7 +87,7 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 				<div class="d2l-activity-label-container d2l-label-text d2l-skeletize">
 					${this.localize('content.description')}
 				</div>
-				<div id="html-editor-container" class="d2l-skeletize">
+				<div class="${htmlNewEditorEnabled ? 'new-html-editor-container' : ''} d2l-skeletize">
 					<d2l-activity-text-editor
 						id="d2l-activity-text-editor"
 						ariaLabel="${this.localize('content.description')}"

--- a/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-styles.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-styles.js
@@ -7,6 +7,9 @@ export const activityContentEditorStyles = css`
 	:host([hidden]) {
 		display: none;
 	}
+	:host([skeleton]) .d2l-skeletize::before {
+		z-index: 3;
+	}
 	:host > div {
 		padding-bottom: 20px;
 	}

--- a/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-styles.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-styles.js
@@ -7,9 +7,6 @@ export const activityContentEditorStyles = css`
 	:host([hidden]) {
 		display: none;
 	}
-	:host([skeleton]) .d2l-skeletize::before {
-		z-index: 3;
-	}
 	:host > div {
 		padding-bottom: 20px;
 	}

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -41,6 +41,8 @@ class ActivityEditor extends ActivityEditorContainerMixin(ActivityEditorTelemetr
 			}
 			.d2l-primary-panel {
 				padding: 20px;
+				height: 100%;
+				box-sizing: border-box;
 			}
 			.d2l-secondary-panel {
 				padding: 10px;

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -40,9 +40,9 @@ class ActivityEditor extends ActivityEditorContainerMixin(ActivityEditorTelemetr
 				padding: 20px;
 			}
 			.d2l-primary-panel {
-				padding: 20px;
-				height: 100%;
 				box-sizing: border-box;
+				height: 100%;
+				padding: 20px;
 			}
 			.d2l-secondary-panel {
 				padding: 10px;

--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -25,7 +25,7 @@ class ActivityHtmlNewEditor extends LocalizeActivityEditorMixin(LitElement) {
 
 	constructor() {
 		super();
-		this.htmlEditorHeight = "10rem";
+		this.htmlEditorHeight = '10rem';
 	}
 
 	render() {

--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -1,5 +1,5 @@
 import '@brightspace-ui/htmleditor/htmleditor.js';
-import { html, LitElement } from 'lit-element/lit-element.js';
+import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { LocalizeActivityEditorMixin } from './mixins/d2l-activity-editor-lang-mixin.js';
 
 class ActivityHtmlNewEditor extends LocalizeActivityEditorMixin(LitElement) {
@@ -9,13 +9,23 @@ class ActivityHtmlNewEditor extends LocalizeActivityEditorMixin(LitElement) {
 			value: { type: String },
 			ariaLabel: { type: String },
 			disabled: { type: Boolean },
-			height: { type: String }
+			htmlEditorHeight: { type: String }
 		};
+	}
+
+	static get styles() {
+		return  [
+			css`
+				d2l-htmleditor {
+					height: 100%;
+				}
+			`
+		];
 	}
 
 	constructor() {
 		super();
-		this.height = "10rem";
+		this.htmlEditorHeight = "10rem";
 	}
 
 	render() {
@@ -25,8 +35,7 @@ class ActivityHtmlNewEditor extends LocalizeActivityEditorMixin(LitElement) {
 				label="${this.ariaLabel}"
 				label-hidden
 				?disabled="${this.disabled}"
-				height="${this.height}"
-				style="height:100%;"
+				height="${this.htmlEditorHeight}"
 				@d2l-htmleditor-blur="${this._onContentChange}">
 			</d2l-htmleditor>
 		`;

--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -8,8 +8,14 @@ class ActivityHtmlNewEditor extends LocalizeActivityEditorMixin(LitElement) {
 		return {
 			value: { type: String },
 			ariaLabel: { type: String },
-			disabled: { type: Boolean }
+			disabled: { type: Boolean },
+			height: { type: String }
 		};
+	}
+
+	constructor() {
+		super();
+		this.height = "10rem";
 	}
 
 	render() {
@@ -19,7 +25,8 @@ class ActivityHtmlNewEditor extends LocalizeActivityEditorMixin(LitElement) {
 				label="${this.ariaLabel}"
 				label-hidden
 				?disabled="${this.disabled}"
-				height="10rem"
+				height="${this.height}"
+				style="height:100%;"
 				@d2l-htmleditor-blur="${this._onContentChange}">
 			</d2l-htmleditor>
 		`;

--- a/components/d2l-activity-editor/d2l-activity-text-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-text-editor.js
@@ -9,7 +9,8 @@ class ActivityTextEditor extends LitElement {
 			richtextEditorConfig: { type: Object },
 			disabled: { type: Boolean },
 			ariaLabel: { type: String },
-			key: { type: String }
+			key: { type: String },
+			height: { type: String }
 		};
 	}
 
@@ -42,7 +43,8 @@ class ActivityTextEditor extends LitElement {
 						value="${this.value}"
 						ariaLabel="${this.ariaLabel}"
 						?disabled="${this.disabled}"
-						@d2l-activity-html-editor-change="${this._onRichtextChange}">
+						@d2l-activity-html-editor-change="${this._onRichtextChange}"
+						height="${this.height}">
 					</d2l-activity-html-new-editor>
 				`;
 			} else {

--- a/components/d2l-activity-editor/d2l-activity-text-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-text-editor.js
@@ -10,7 +10,7 @@ class ActivityTextEditor extends LitElement {
 			disabled: { type: Boolean },
 			ariaLabel: { type: String },
 			key: { type: String },
-			height: { type: String }
+			htmlEditorHeight: { type: String }
 		};
 	}
 
@@ -44,7 +44,7 @@ class ActivityTextEditor extends LitElement {
 						ariaLabel="${this.ariaLabel}"
 						?disabled="${this.disabled}"
 						@d2l-activity-html-editor-change="${this._onRichtextChange}"
-						height="${this.height}">
+						htmlEditorHeight="${this.htmlEditorHeight}">
 					</d2l-activity-html-new-editor>
 				`;
 			} else {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@brightspace-ui-labs/accordion": "^2.0.2",
     "@brightspace-ui-labs/edit-in-place": "^1.0.11",
     "@brightspace-ui-labs/list-item-accumulator": "^1",
-    "@brightspace-ui/core": "^1.116.0",
+    "@brightspace-ui/core": "^1.118.2",
     "@brightspace-ui/htmleditor": "^1.2.6",
     "@brightspace-ui/intl": "^3.0.1",
     "@d2l/d2l-attachment": "Brightspace/attachment#semver:^1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@brightspace-ui-labs/edit-in-place": "^1.0.11",
     "@brightspace-ui-labs/list-item-accumulator": "^1",
     "@brightspace-ui/core": "^1.116.0",
-    "@brightspace-ui/htmleditor": "^1",
+    "@brightspace-ui/htmleditor": "^1.2.6",
     "@brightspace-ui/intl": "^3.0.1",
     "@d2l/d2l-attachment": "Brightspace/attachment#semver:^1",
     "@polymer/iron-resizable-behavior": "^3.0.0",


### PR DESCRIPTION
[DE42624](https://rally1.rallydev.com/#/289692574792/custom/355050439968?detail=%2Fdefect%2F502198563680&fdp=true): Lessons FACE > new HTML editor default size too small

**Actual behaviour**:
When editing/creating a module, the default size of the HTML editor size is really small.

**Expected behaviour**:
When editing/creating a module, the HTML editor should take up all available vertical space/dynamically resize with the window.

![dynamic-height](https://user-images.githubusercontent.com/52549862/110068808-1ba15600-7d3c-11eb-8ed3-f1446e9f1c75.gif)

**Note**: This requires `@brightspace-ui/htmleditor` version 1.2.6 or higher.