### PR TITLE
Ensure check-in entity is refetched

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz.js
@@ -12,7 +12,7 @@ export class Quiz {
 		this._checkedOut = null;
 	}
 
-	async checkin(quizStore) {
+	async checkin(quizStore, refetch) {
 		if (!this._entity) {
 			return;
 		}
@@ -36,6 +36,10 @@ export class Quiz {
 		const entity = new Quiz(href, this.token);
 		entity.load(sirenEntity);
 		quizStore.put(href, entity);
+
+		if (refetch) {
+			this.fetch(true);
+		}
 	}
 
 	checkout(quizStore, forcedCheckout) {
@@ -79,8 +83,8 @@ export class Quiz {
 		return isQuizDirty || isCheckedOutEntityDirty;
 	}
 
-	async fetch() {
-		const sirenEntity = await fetchEntity(this.href, this.token);
+	async fetch(bypassCache) {
+		const sirenEntity = await fetchEntity(this.href, this.token, bypassCache);
 		if (sirenEntity) {
 			const entity = new QuizEntity(sirenEntity, this.token, {
 				remove: () => { },

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-working-copy-dialog-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-working-copy-dialog-mixin.js
@@ -88,7 +88,7 @@ export const ActivityEditorWorkingCopyDialogMixin = superclass => class extends 
 		const entity = this.store.get(this.checkedOutHref);
 		if (!entity) return;
 
-		await entity.checkin(this.store);
+		await entity.checkin(this.store, true);
 	}
 
 	async _focusOnInvalid() {


### PR DESCRIPTION
The checked out working copy of a base quiz needs to be re-fetched when it is checked-in as the working copy should theoretically no longer have a check-in action anymore (and to make sure everything is in sync).
https://trello.com/c/LbKqk61x/327-face-quiz-timing-saving-twice-causes-a-500-error