### PR TITLE
Display/hide description will be displayed warning message based on original value of description being empty or not

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
@@ -100,13 +100,14 @@ class QuizEditorDetail extends ActivityEditorTelemetryMixin(ActivityEditorMixin(
 			canEditDescription,
 			descriptionRichTextEditorConfig,
 			descriptionIsDisplayed,
+			originalDescriptionIsEmpty,
 			introIsAppendedToDescription,
 		} = quiz || {};
 
 		const descriptionLang = this.localize('description');
 
 		return html`
-			<d2l-alert has-close-button ?hidden=${this.skeleton || descriptionIsDisplayed || !description || description.length === 0}>
+			<d2l-alert has-close-button ?hidden=${this.skeleton || descriptionIsDisplayed || originalDescriptionIsEmpty}>
 				${this.localize('textIsDisplayedPart1')}
 				${this.localize('textIsDisplayedSingularPart2', 'field', descriptionLang)}
 			</d2l-alert>

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz.js
@@ -117,6 +117,7 @@ export class Quiz {
 		this.description = entity.canEditDescription() ? entity.descriptionEditorHtml() : entity.descriptionHtml();
 		this.canEditDescription = entity.canEditDescription();
 		this.descriptionIsDisplayed = entity.descriptionIsDisplayed();
+		this.originalDescriptionIsEmpty = entity.originalDescriptionIsEmpty();
 		this.descriptionRichTextEditorConfig = entity.descriptionRichTextEditorConfig();
 		this.introIsAppendedToDescription = entity.introIsAppendedToDescription();
 		this.header = entity.canEditHeader() ? entity.headerEditorHtml() : entity.headerHtml();
@@ -235,6 +236,7 @@ decorate(Quiz, {
 	description: observable,
 	canEditDescription: observable,
 	descriptionIsDisplayed: observable,
+	originalDescriptionIsEmpty: observable,
 	descriptionRichTextEditorConfig: observable,
 	introIsAppendedToDescription: observable,
 	header: observable,

--- a/test/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz.spec.js
@@ -46,6 +46,7 @@ describe('Quiz', function() {
 				descriptionEditorHtml: () => 'This is a description',
 				canEditDescription: () => true,
 				descriptionIsDisplayed: () => true,
+				originalDescriptionIsEmpty: () => true,
 				descriptionRichTextEditorConfig: () => {},
 				headerEditorHtml: () => 'This is an header',
 				headerIsDisplayed: () => true,


### PR DESCRIPTION
### Summary of Changes
* Added MobX state for `originalDescriptionIsEmpty` to represent the initial state being empty or not
  * Hide warning if description is empty and display warning if description is not empty
* Display/hide the warning based on `originalDescriptionIsEmpty` instead of the `description` value which changes on edit
* Added `siren-sdk` mock function to the test file
* See this related PR: https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/292

### Rally Story / Trello Card
https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F479012712268&fdp=true?fdp=true
https://trello.com/c/uTnkTSwn/329-description-hidden-warning-message-should-not-trigger-while-in-face