### PR TITLE
fix: US125529 wrap activity-score-grade setters with runInAction

### DIFF
--- a/components/d2l-activity-editor/state/activity-score-grade.js
+++ b/components/d2l-activity-editor/state/activity-score-grade.js
@@ -1,4 +1,4 @@
-import { action, configure as configureMobx, decorate, observable } from 'mobx';
+import { action, configure as configureMobx, decorate, observable, runInAction } from 'mobx';
 import { fetchEntity } from './fetch-entity.js';
 import { GradeCandidateCollection } from '../d2l-activity-grades/state/grade-candidate-collection.js';
 
@@ -16,19 +16,21 @@ export class ActivityScoreGrade {
 
 	async fetch(entity) {
 		await entity.fetchLinkedScoreOutOfEntity(fetchEntity);
-		this.scoreOutOf = entity.scoreOutOf() ? entity.scoreOutOf().toString() : '';
-		this.scoreOutOfError = null;
-		this.inGrades = entity.inGrades();
-		this.gradeType = (entity.gradeType() || entity.numericGradeTypeTitle()).toLowerCase();
-		this.isUngraded = !this.inGrades && !this.scoreOutOf;
-		this.canEditScoreOutOf = entity.canEditScoreOutOf();
-		this.canSeeGrades = entity.canSeeGrades();
-		this.canEditGrades = entity.canEditGrades();
-		this.gradeCandidatesHref = entity.gradeCandidatesHref();
-		this.gradeCandidateCollection = null;
-		this.createNewGrade = !entity.gradeHref();
-		this.newGradeCandidatesHref = entity.newGradeCandidatesHref();
-		this.newGradeCandidatesCollection = null;
+		runInAction(() => {
+			this.scoreOutOf = entity.scoreOutOf() ? entity.scoreOutOf().toString() : '';
+			this.scoreOutOfError = null;
+			this.inGrades = entity.inGrades();
+			this.gradeType = (entity.gradeType() || entity.numericGradeTypeTitle()).toLowerCase();
+			this.isUngraded = !this.inGrades && !this.scoreOutOf;
+			this.canEditScoreOutOf = entity.canEditScoreOutOf();
+			this.canSeeGrades = entity.canSeeGrades();
+			this.canEditGrades = entity.canEditGrades();
+			this.gradeCandidatesHref = entity.gradeCandidatesHref();
+			this.gradeCandidateCollection = null;
+			this.createNewGrade = !entity.gradeHref();
+			this.newGradeCandidatesHref = entity.newGradeCandidatesHref();
+			this.newGradeCandidatesCollection = null;
+		});
 	}
 
 	async fetchGradeCandidates() {


### PR DESCRIPTION
`bug`: mobX error being thrown when `Save & Close` or `Save` was being clicked on FACE Quiz.

Wrapped setters in `fetch` function with `runInAction` because observable properties can only be modified by mobX actions. 

[US125529](https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F505601651720&fdp=true?fdp=true): [ui] Display total points for a quiz

https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F505601651720&fdp=true?fdp=true