### PR TITLE
Refetch wc before checkin

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz-attempts.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz-attempts.js
@@ -8,7 +8,6 @@ export class QuizAttempts {
 	constructor(href, token) {
 		this.href = href;
 		this.token = token;
-		this._saving = null;
 	}
 
 	async fetch() {

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz-ipRestrictions.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz-ipRestrictions.js
@@ -10,7 +10,6 @@ export class QuizIpRestrictions {
 	constructor(href, token) {
 		this.href = href;
 		this.token = token;
-		this._saving = null;
 		this.ipRestrictions = [];
 		this.errors = [];
 	}

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz-timing.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/state/quiz-timing.js
@@ -8,7 +8,7 @@ export class QuizTiming {
 	constructor(href, token) {
 		this.href = href;
 		this.token = token;
-		this._saving = null;
+		this.saving = null;
 	}
 
 	async fetch(bypassCache) {
@@ -79,7 +79,9 @@ export class QuizTiming {
 	}
 
 	async updateProperty(updateFunc) {
-		const entity = await updateFunc();
+		this.saving = updateFunc();
+		const entity = await this.saving;
+		this.saving = null;
 		// The siren-sdk function called to perform an action first checks that the entity has permission to do so.
 		// If the entity lacks permission, the function returns `undefined`, otherwise it returns a reconstructed siren-sdk timing entity.
 		// If `undefined` is returned, it likely means the UI is out of sync with the entity state, and disallowed actions can be performed.
@@ -118,6 +120,7 @@ decorate(QuizTiming, {
 	maxEnforcedGraceLimit: observable,
 	submissionLateTypeIdTitle: observable,
 	timingType: observable,
+	saving: observable,
 	// actions
 	load: action,
 	setTimingType: action,

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-working-copy-dialog-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-working-copy-dialog-mixin.js
@@ -56,6 +56,9 @@ export const ActivityEditorWorkingCopyDialogMixin = superclass => class extends 
 			return;
 		}
 
+		// Refetch quiz entity in case presence of the check in action has changed
+		await entity.fetch(true);
+
 		try {
 			await entity.checkin(this.store);
 		} catch (e) {


### PR DESCRIPTION
Problem: When a `PATCH` is made to the timing entity, the existing quiz working copy in the store is not updated, so we do not know if it has a `check-in` action or not.

Solution: Refetch the working copy prior to check in.
The code fix is a bit more complicated because we need to wait for the `PATCH` to the timing endpoint to complete before refetching the quiz working copy, and the timing entity and the quiz working copy are in different stores.

These are the steps of how things will be processed...
1. Say focus is currently on input, and we click OK to check in the dialog
2. The input focus out event causes a `PATCH` request to be sent. This promise is set to the `saving` property in the `quiz-timing` MobX object.
3. The OK click on the dialog causes a call to the `_checkin` function, which will now `await` the timing `saving` property before requesting `GET` on the quiz working copy. The `GET` on the working copy is required in order to know if there will be a check in action or not. (i.e. Did our latest timing `PATCH` cause the wc to be dirty or not)
4. Then after the check in, a working copy timing fetch occurs which updates the summary in the collapsed/expanded accordion.

Also refactored the summary update into a private function.