### PR TITLE
Us125748/save editor images

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -26,7 +26,7 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 	constructor() {
 		super();
 		this.htmlEditorHeight = '10rem';
-		this.context = JSON.parse(document.documentElement.getAttribute('data-he-context'));
+		this._context = JSON.parse(document.documentElement.getAttribute('data-he-context'));
 	}
 
 	render() {
@@ -61,7 +61,7 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 	}
 
 	_isPasteAllowed() {
-		return this.context.uploadFiles && this.context.viewFiles;
+		return this._context.uploadFiles && this._context.viewFiles;
 	}
 
 	_onContentChange() {
@@ -76,7 +76,7 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 	}
 
 	_uploadFile(file) {
-		const { orgUnitId } = this.context;
+		const { orgUnitId } = this._context;
 
 		return new Promise((resolve, reject) => {
 			D2L.LP.Web.UI.Rpc.Connect(D2L.LP.Web.UI.Rpc.Verbs.POST,

--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -47,7 +47,8 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 
 	async save() {
 		const editor = this.shadowRoot.querySelector('d2l-htmleditor');
-		if (editor.files && editor.files.length) {
+
+		if (editor && editor.files && editor.files.length) {
 
 			const tempFiles = editor.files.filter(file => file.FileSystemType === 'Temp');
 
@@ -57,18 +58,6 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 
 			await Promise.all(uploadFilePromises).catch(() => { });
 		}
-	}
-
-	_getFile(src, name) {
-		return window.fetch(src).then(async(response) => {
-			if (!response.ok) return;
-
-			const blob = await response.blob();
-
-			blob.name = name;
-
-			return blob;
-		});
 	}
 
 	_isPasteAllowed() {

--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -44,6 +44,13 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 		`;
 	}
 
+	save() {
+		const editor = this.shadowRoot.querySelector('d2l-htmleditor');
+		if (editor.files && editor.files.length) {
+			// upload files to content
+		}
+	}
+
 	_isPasteAllowed() {
 		const context = JSON.parse(document.documentElement.getAttribute('data-he-context'));
 

--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -54,7 +54,7 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 
 			if (!tempFiles || !tempFiles.length) return;
 
-			const uploadFilePromises = tempFiles.map(blob => this._uploadFile(blob));
+			const uploadFilePromises = tempFiles.map(file => this._uploadFile(file));
 
 			await Promise.all(uploadFilePromises).catch(() => { });
 		}

--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -83,6 +83,7 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 
 		const currentHtml = editor.html;
 
+		// Dynamically generates regex like: /oldLocation1|oldLocation2|oldLocation3/gi
 		const regex = new RegExp(Object.keys(this._filesToReplace).join('|'), 'gi');
 
 		editor.html = currentHtml.replace(regex, (matched) => this._filesToReplace[matched]);

--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -50,18 +50,15 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 	async save() {
 		const editor = this.shadowRoot.querySelector('d2l-htmleditor');
 
-		if (editor && editor.files && editor.files.length) {
+		if (!editor || !editor.files || !editor.files.length) return;
 
-			const tempFiles = editor.files.filter(file => file.FileSystemType === 'Temp');
+		const tempFiles = editor.files.filter(file => file.FileSystemType === 'Temp');
+		if (!tempFiles || !tempFiles.length) return;
 
-			if (!tempFiles || !tempFiles.length) return;
+		const uploadFilePromises = tempFiles.map(file => this._uploadFile(file));
+		await Promise.all(uploadFilePromises).catch(() => { });
 
-			const uploadFilePromises = tempFiles.map(file => this._uploadFile(file));
-
-			await Promise.all(uploadFilePromises).catch(() => { });
-
-			this._parseHtml();
-		}
+		this._parseHtml();
 	}
 
 	_dispatchChangeEvent(content) {

--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -29,6 +29,7 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 		this.htmlEditorHeight = '10rem';
 		this._context = JSON.parse(document.documentElement.getAttribute('data-he-context'));
 		this._filesToReplace = {};
+		this.saveOrder = 500;
 	}
 
 	render() {

--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -49,14 +49,13 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 
 	async save() {
 		const editor = this.shadowRoot.querySelector('d2l-htmleditor');
-
-		if (!editor || !editor.files || !editor.files.length) return;
+		if (!editor || !editor.files || !editor.files.length || !editor.isDirty) return;
 
 		const tempFiles = editor.files.filter(file => file.FileSystemType === 'Temp');
 		if (!tempFiles || !tempFiles.length) return;
 
-		const uploadFilePromises = tempFiles.map(file => this._uploadFile(file));
-		await Promise.all(uploadFilePromises).catch(() => { });
+		const moveFilePromises = tempFiles.map(file => this._moveFile(file));
+		await Promise.all(moveFilePromises).catch(() => { });
 
 		this._parseHtml();
 	}
@@ -75,21 +74,7 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 		return this._context.uploadFiles && this._context.viewFiles;
 	}
 
-	_parseHtml() {
-		const editor = this.shadowRoot.querySelector('d2l-htmleditor');
-		if (!editor) return;
-
-		const currentHtml = editor.html;
-
-		// Dynamically generates regex like: /oldLocation1|oldLocation2|oldLocation3/gi
-		const regex = new RegExp(Object.keys(this._filesToReplace).join('|'), 'gi');
-
-		editor.html = currentHtml.replace(regex, (matched) => this._filesToReplace[matched]);
-
-		this._dispatchChangeEvent(editor.html);
-	}
-
-	_uploadFile(file) {
+	_moveFile(file) {
 		const { orgUnitId } = this._context;
 
 		return new Promise((resolve, reject) => {
@@ -106,6 +91,20 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 					}
 				});
 		});
+	}
+
+	_parseHtml() {
+		const editor = this.shadowRoot.querySelector('d2l-htmleditor');
+		if (!editor) return;
+
+		const currentHtml = editor.html;
+
+		// Dynamically generates regex like: /oldLocation1|oldLocation2|oldLocation3/gi
+		const regex = new RegExp(Object.keys(this._filesToReplace).join('|'), 'gi');
+
+		editor.html = currentHtml.replace(regex, (matched) => this._filesToReplace[matched]);
+
+		this._dispatchChangeEvent(editor.html);
 	}
 }
 

--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -1,8 +1,8 @@
 import '@brightspace-ui/htmleditor/htmleditor.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
 import { LocalizeActivityEditorMixin } from './mixins/d2l-activity-editor-lang-mixin.js';
-
-class ActivityHtmlNewEditor extends LocalizeActivityEditorMixin(LitElement) {
+class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMixin(LitElement)) {
 
 	static get properties() {
 		return {
@@ -29,6 +29,8 @@ class ActivityHtmlNewEditor extends LocalizeActivityEditorMixin(LitElement) {
 	}
 
 	render() {
+		const allowPaste = this._isPasteAllowed();
+
 		return html`
 			<d2l-htmleditor
 				html="${this.value}"
@@ -36,9 +38,16 @@ class ActivityHtmlNewEditor extends LocalizeActivityEditorMixin(LitElement) {
 				label-hidden
 				?disabled="${this.disabled}"
 				height="${this.htmlEditorHeight}"
+				paste-local-images="${allowPaste}"
 				@d2l-htmleditor-blur="${this._onContentChange}">
 			</d2l-htmleditor>
 		`;
+	}
+
+	_isPasteAllowed() {
+		const context = JSON.parse(document.documentElement.getAttribute('data-he-context'));
+
+		return context.uploadFiles && context.viewFiles;
 	}
 
 	_onContentChange() {


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F508303488440

Added handler to move pasted images from /temp into /content. I couldn't work out how to clear /temp so not sure if the editor will be smart enough to pick up images directly from /content?

Also need to do something to handle any potential upload errors.

I was also concerned about duplicate uploads, e.g. saving multiple times might persist an image multiple times. This doesn't _seem_ to be the case, I assume because the file name is generated based on the temp guid ([here](https://search.d2l.dev/xref/lms/lp/framework/web/D2L.LP.Web.UI/Desktop/Controls/HtmlEditor/Renderers/WysiwygEditor/Core/TinyMCEv4/TinyMceController.cs?r=4b476021#86)) but then I wonder is this doing extra work replacing images that don't need to be replaced?