### PR TITLE
fix: RIO help dialog

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-retake-incorrect-only-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-retake-incorrect-only-editor.js
@@ -1,4 +1,5 @@
 import { css, html } from 'lit-element/lit-element.js';
+import { ActivityEditorDialogMixin } from '../mixins/d2l-activity-editor-dialog-mixin.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { checkboxStyles } from '../styles/checkbox-styles.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles';
@@ -8,7 +9,7 @@ import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { sharedAttempts as store } from './state/quiz-store';
 
 class ActivityQuizRetakeIncorrectOnlyEditor
-	extends ActivityEditorMixin(RtlMixin(LocalizeActivityQuizEditorMixin(MobxLitElement))) {
+	extends ActivityEditorMixin(RtlMixin(ActivityEditorDialogMixin(LocalizeActivityQuizEditorMixin(MobxLitElement)))) {
 
 	static get styles() {
 		return [


### PR DESCRIPTION
Help button doesn't open dialog because dialog mixin was removed 👀 