### PR TITLE
Cprajapati/DE42809

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -29,7 +29,7 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 					margin-bottom: 7px;
 				}
 				.d2l-new-html-editor-container {
-					flex-grow: 1;
+					flex: 1;
 					min-height: 300px;
 				}
 				#content-description-container {

--- a/components/d2l-activity-editor/d2l-activity-text-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-text-editor.js
@@ -1,5 +1,5 @@
 import 'd2l-inputs/d2l-input-textarea';
-import { css, html, LitElement } from 'lit-element/lit-element';
+import { html, LitElement } from 'lit-element/lit-element';
 
 class ActivityTextEditor extends LitElement {
 
@@ -12,16 +12,6 @@ class ActivityTextEditor extends LitElement {
 			key: { type: String },
 			htmlEditorHeight: { type: String }
 		};
-	}
-	
-	static get styles() {
-		return  [
-			css`
-				d2l-activity-html-new-editor {
-					height: 100%;
-				}
-			`
-		];
 	}
 
 	render() {

--- a/components/d2l-activity-editor/d2l-activity-text-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-text-editor.js
@@ -1,5 +1,5 @@
 import 'd2l-inputs/d2l-input-textarea';
-import { html, LitElement } from 'lit-element/lit-element';
+import { css, html, LitElement } from 'lit-element/lit-element';
 
 class ActivityTextEditor extends LitElement {
 
@@ -12,6 +12,16 @@ class ActivityTextEditor extends LitElement {
 			key: { type: String },
 			htmlEditorHeight: { type: String }
 		};
+	}
+	
+	static get styles() {
+		return  [
+			css`
+				d2l-activity-html-new-editor {
+					height: 100%;
+				}
+			`
+		];
 	}
 
 	render() {


### PR DESCRIPTION
DE42809 ([ios/Mac] Lessons FACE > html editor text area not usable on iPad or Mac Safari): https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F508442975604

Before:
![image](https://user-images.githubusercontent.com/29843252/111678351-2f45c580-87ee-11eb-8073-356f3e026505.png)

After:
![image](https://user-images.githubusercontent.com/29843252/111678423-45538600-87ee-11eb-8c8a-97705e838708.png)

Related to change (for some reason Safari feels information is missing/wonky when `flex-grow` is used in place of 'flex'):
![image](https://user-images.githubusercontent.com/29843252/111678820-af6c2b00-87ee-11eb-8c41-9cb89d5b492a.png)
