### PR TITLE
Temporarily copy quick-eval-widget es.js to es-es.js

### DIFF
--- a/components/d2l-quick-eval-widget/lang/es-es.js
+++ b/components/d2l-quick-eval-widget/lang/es-es.js
@@ -1,0 +1,8 @@
+/* eslint quotes: 0 */
+
+export default {
+	"CaughtUp": "Ya está al día.",
+	"Error": "¡Ups! Se produjo un error y no se pudieron cargar los elementos. Actualice esta página o vuelva a intentarlo más tarde.",
+	"NoSubmissions": "No tiene envíos que necesiten evaluación. Vuelva a revisar más tarde para ver los envíos nuevos.",
+	"ViewAllActivities": "Ver todas las actividades",
+};


### PR DESCRIPTION
`es-es.js` was deleted in https://github.com/BrightspaceHypermediaComponents/activities/pull/1612 because it was untranslated (because of a bad serge rewrite config). That PR made it fall back to `es` (effectively `es-mx`) instead of delivering english strings, but because quick-eval-widget does not use dynamic imports, the BSI build tried to bundle `es-es` and failed.

Serge will replace this with proper `es-es` strings when the pending round of translations come back.