### PR TITLE
Fire update event on save to ensure correct state

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -42,13 +42,16 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 				label-hidden
 				?disabled="${this.disabled}"
 				height="${this.htmlEditorHeight}"
-				paste-local-images="${allowPaste}">
+				?paste-local-images="${allowPaste}">
 			</d2l-htmleditor>
 		`;
 	}
 
 	async save() {
 		const editor = this.shadowRoot.querySelector('d2l-htmleditor');
+
+		this._dispatchChangeEvent(editor.html);
+
 		if (!editor || !editor.files || !editor.files.length || !editor.isDirty) return;
 
 		const tempFiles = editor.files.filter(file => file.FileSystemType === 'Temp');


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F508303488440

I need to add this event before moving files etc as otherwise if there are no files present on the HTML editor property then this line will evaluate to false and the changes won't be persisted.

```js
if (!editor || !editor.files || !editor.files.length || !editor.isDirty) return;
```