### PR TITLE
De42959/certfix html editor move images

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -42,7 +42,7 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 				label-hidden
 				?disabled="${this.disabled}"
 				height="${this.htmlEditorHeight}"
-				paste-local-images="${allowPaste}">
+				?paste-local-images="${allowPaste}">
 			</d2l-htmleditor>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -49,6 +49,9 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 
 	async save() {
 		const editor = this.shadowRoot.querySelector('d2l-htmleditor');
+
+		this._dispatchChangeEvent(editor.html);
+
 		if (!editor || !editor.files || !editor.files.length || !editor.isDirty) return;
 
 		const tempFiles = editor.files.filter(file => file.FileSystemType === 'Temp');

--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -1,15 +1,16 @@
 import '@brightspace-ui/htmleditor/htmleditor.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
 import { LocalizeActivityEditorMixin } from './mixins/d2l-activity-editor-lang-mixin.js';
-
-class ActivityHtmlNewEditor extends LocalizeActivityEditorMixin(LitElement) {
+class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMixin(LitElement)) {
 
 	static get properties() {
 		return {
 			value: { type: String },
 			ariaLabel: { type: String },
 			disabled: { type: Boolean },
-			htmlEditorHeight: { type: String }
+			htmlEditorHeight: { type: String },
+			_filesToReplace: { type: Object }
 		};
 	}
 
@@ -26,9 +27,14 @@ class ActivityHtmlNewEditor extends LocalizeActivityEditorMixin(LitElement) {
 	constructor() {
 		super();
 		this.htmlEditorHeight = '10rem';
+		this._context = JSON.parse(document.documentElement.getAttribute('data-he-context'));
+		this._filesToReplace = {};
+		this.saveOrder = 500;
 	}
 
 	render() {
+		const allowPaste = this._isPasteAllowed();
+
 		return html`
 			<d2l-htmleditor
 				html="${this.value}"
@@ -36,13 +42,25 @@ class ActivityHtmlNewEditor extends LocalizeActivityEditorMixin(LitElement) {
 				label-hidden
 				?disabled="${this.disabled}"
 				height="${this.htmlEditorHeight}"
-				@d2l-htmleditor-blur="${this._onContentChange}">
+				paste-local-images="${allowPaste}">
 			</d2l-htmleditor>
 		`;
 	}
 
-	_onContentChange() {
-		const content = this.shadowRoot.querySelector('d2l-htmleditor').html;
+	async save() {
+		const editor = this.shadowRoot.querySelector('d2l-htmleditor');
+		if (!editor || !editor.files || !editor.files.length || !editor.isDirty) return;
+
+		const tempFiles = editor.files.filter(file => file.FileSystemType === 'Temp');
+		if (!tempFiles || !tempFiles.length) return;
+
+		const moveFilePromises = tempFiles.map(file => this._moveFile(file));
+		await Promise.all(moveFilePromises).catch(() => { });
+
+		this._parseHtml();
+	}
+
+	_dispatchChangeEvent(content) {
 		this.dispatchEvent(new CustomEvent('d2l-activity-html-editor-change', {
 			bubbles: true,
 			composed: true,
@@ -50,6 +68,43 @@ class ActivityHtmlNewEditor extends LocalizeActivityEditorMixin(LitElement) {
 				content: content
 			}
 		}));
+	}
+
+	_isPasteAllowed() {
+		return this._context.uploadFiles && this._context.viewFiles;
+	}
+
+	_moveFile(file) {
+		const { orgUnitId } = this._context;
+
+		return new Promise((resolve, reject) => {
+			D2L.LP.Web.UI.Rpc.Connect(D2L.LP.Web.UI.Rpc.Verbs.POST,
+				new D2L.LP.Web.Http.UrlLocation('/d2l/lp/htmleditor/tinymce/moveUploadedFile'),
+				{ orgUnitId: orgUnitId, fileId: file.Id },
+				{
+					success: result => {
+						this._filesToReplace[file.Location] = result.FileUrl;
+						resolve(result);
+					},
+					failure: error => {
+						reject(error);
+					}
+				});
+		});
+	}
+
+	_parseHtml() {
+		const editor = this.shadowRoot.querySelector('d2l-htmleditor');
+		if (!editor) return;
+
+		const currentHtml = editor.html;
+
+		// Dynamically generates regex like: /oldLocation1|oldLocation2|oldLocation3/gi
+		const regex = new RegExp(Object.keys(this._filesToReplace).join('|'), 'gi');
+
+		editor.html = currentHtml.replace(regex, (matched) => this._filesToReplace[matched]);
+
+		this._dispatchChangeEvent(editor.html);
 	}
 }
 


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fdefect%2F514561889664

For this certfix I cherry picked 3 commits which make up all the changes for the new HTML editor behaviour:

1. https://github.com/BrightspaceHypermediaComponents/activities/commit/2d877a6922a6a0ab031b9b5898f13726d32b8967
2. https://github.com/BrightspaceHypermediaComponents/activities/commit/506e03259616717f281d347244938d147c10ba38
3. https://github.com/BrightspaceHypermediaComponents/activities/commit/8a58e8ecdfb348d57758a52e35fe2220ea7e2e21