### PR TITLE
DE42834 Content > Fix attributes and properties on new html editor

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -90,9 +90,9 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 						.value="${descriptionRichText}"
 						@d2l-activity-text-editor-change="${this._onRichtextChange}"
 						.richtextEditorConfig="${{}}"
-						htmlEditorHeight="100%"
-						fullPage="true"
-						fullPageFontSize="12pt"
+						html-editor-height="100%"
+						full-page="true"
+						full-page-font-size="12pt"
 					>
 					</d2l-activity-text-editor>
 				</div>

--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -91,7 +91,7 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 						@d2l-activity-text-editor-change="${this._onRichtextChange}"
 						.richtextEditorConfig="${{}}"
 						html-editor-height="100%"
-						full-page="true"
+						full-page
 						full-page-font-size="12pt"
 					>
 					</d2l-activity-text-editor>

--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -9,8 +9,8 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 			value: { type: String },
 			ariaLabel: { type: String },
 			disabled: { type: Boolean },
-			htmlEditorHeight: { type: String },
 			_filesToReplace: { type: Object },
+			htmlEditorHeight: { type: String },
 			fullPage: { type: Boolean },
 			fullPageFontSize: { type: String }
 		};
@@ -43,7 +43,7 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 				label-hidden
 				?disabled="${this.disabled}"
 				height="${this.htmlEditorHeight}"
-				full-page="${this.fullPage}"
+				?full-page="${this.fullPage}"
 				full-page-font-size="${this.fullPageFontSize}"
 				?paste-local-images="${allowPaste}">
 			</d2l-htmleditor>

--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -1,7 +1,9 @@
 import '@brightspace-ui/htmleditor/htmleditor.js';
 import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from './mixins/d2l-activity-editor-mixin.js';
+import { ifDefined } from 'lit-html/directives/if-defined';
 import { LocalizeActivityEditorMixin } from './mixins/d2l-activity-editor-lang-mixin.js';
+
 class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMixin(LitElement)) {
 
 	static get properties() {
@@ -10,9 +12,9 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 			ariaLabel: { type: String },
 			disabled: { type: Boolean },
 			_filesToReplace: { type: Object },
-			htmlEditorHeight: { type: String },
-			fullPage: { type: Boolean },
-			fullPageFontSize: { type: String }
+			htmlEditorHeight: { type: String, attribute: 'html-editor-height' },
+			fullPage: { type: Boolean, attribute: 'full-page' },
+			fullPageFontSize: { type: String, attribute: 'full-page-font-size' }
 		};
 	}
 
@@ -31,6 +33,7 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 		this._context = JSON.parse(document.documentElement.getAttribute('data-he-context'));
 		this._filesToReplace = {};
 		this.saveOrder = 500;
+		this.fullPage = false;
 	}
 
 	render() {
@@ -42,9 +45,9 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 				label="${this.ariaLabel}"
 				label-hidden
 				?disabled="${this.disabled}"
-				height="${this.htmlEditorHeight}"
+				height=${ifDefined(this.htmlEditorHeight)}
 				?full-page="${this.fullPage}"
-				full-page-font-size="${this.fullPageFontSize}"
+				full-page-font-size="${ifDefined(this.fullPageFontSize)}"
 				?paste-local-images="${allowPaste}">
 			</d2l-htmleditor>
 		`;

--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -34,6 +34,7 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 		this._filesToReplace = {};
 		this.saveOrder = 500;
 		this.fullPage = false;
+		this.htmlEditorHeight = '10rem';
 	}
 
 	render() {

--- a/components/d2l-activity-editor/d2l-activity-text-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-text-editor.js
@@ -1,5 +1,6 @@
 import 'd2l-inputs/d2l-input-textarea';
 import { html, LitElement } from 'lit-element/lit-element';
+import { ifDefined } from 'lit-html/directives/if-defined';
 
 class ActivityTextEditor extends LitElement {
 
@@ -10,17 +11,10 @@ class ActivityTextEditor extends LitElement {
 			disabled: { type: Boolean },
 			ariaLabel: { type: String },
 			key: { type: String },
-			htmlEditorHeight: { type: String },
-			fullPage: { type: Boolean },
-			fullPageFontSize: { type: String }
+			htmlEditorHeight: { type: String, attribute: 'html-editor-height' },
+			fullPage: { type: Boolean, attribute: 'full-page' },
+			fullPageFontSize: { type: String, attribute: 'full-page-font-size' }
 		};
-	}
-
-	constructor() {
-		super();
-		this.htmlEditorHeight = '10rem';
-		this.fullPage = false;
-		this.fullPageFontSize = '14pt';
 	}
 
 	render() {
@@ -53,9 +47,9 @@ class ActivityTextEditor extends LitElement {
 						ariaLabel="${this.ariaLabel}"
 						?disabled="${this.disabled}"
 						@d2l-activity-html-editor-change="${this._onRichtextChange}"
-						.htmlEditorHeight="${this.htmlEditorHeight}"
-						?fullPage="${this.fullPage}"
-						.fullPageFontSize="${this.fullPageFontSize}">
+						html-editor-height=${ifDefined(this.htmlEditorHeight)}
+						?full-page="${this.fullPage}"
+						full-page-font-size="${ifDefined(this.fullPageFontSize)}">
 					</d2l-activity-html-new-editor>
 				`;
 			} else {

--- a/components/d2l-activity-editor/d2l-activity-text-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-text-editor.js
@@ -10,19 +10,17 @@ class ActivityTextEditor extends LitElement {
 			disabled: { type: Boolean },
 			ariaLabel: { type: String },
 			key: { type: String },
-			htmlEditorHeight: {
-				type: String,
-				value: '10rem'
-			},
-			fullPage: {
-				type: Boolean,
-				value: false
-			},
-			fullPageFontSize: {
-				type: String,
-				value: '14pt'
-			}
+			htmlEditorHeight: { type: String },
+			fullPage: { type: Boolean },
+			fullPageFontSize: { type: String }
 		};
+	}
+
+	constructor() {
+		super();
+		this.htmlEditorHeight = '10rem';
+		this.fullPage = false;
+		this.fullPageFontSize = '14pt';
 	}
 
 	render() {
@@ -55,9 +53,9 @@ class ActivityTextEditor extends LitElement {
 						ariaLabel="${this.ariaLabel}"
 						?disabled="${this.disabled}"
 						@d2l-activity-html-editor-change="${this._onRichtextChange}"
-						htmlEditorHeight="${this.htmlEditorHeight}"
-						fullPage="${this.fullPage}"
-						fullPageFontSize="${this.fullPageFontSize}">
+						.htmlEditorHeight="${this.htmlEditorHeight}"
+						?fullPage="${this.fullPage}"
+						.fullPageFontSize="${this.fullPageFontSize}">
 					</d2l-activity-html-new-editor>
 				`;
 			} else {

--- a/components/d2l-activity-editor/d2l-activity-text-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-text-editor.js
@@ -17,6 +17,11 @@ class ActivityTextEditor extends LitElement {
 		};
 	}
 
+	constructor() {
+		super();
+		this.fullPage = false;
+	}
+
 	render() {
 		const editorEvent = new CustomEvent('d2l-request-provider', {
 			detail: { key: 'd2l-provider-html-editor-enabled' },


### PR DESCRIPTION
Previously, we were passing data down as attributes but treating them like properties. This had no visible real negative impact, but cluttered things up with several attributes showing up as `undefined`. Also, there was an instance of a boolean attribute that was not prepended with the `?` so it was not treated like a true boolean attribute.

This pr makes the attributes look more like attributes (lowercase kebab case) and uses `ifDefined` to prevent attributes from being rendered if they don't exist.

### Content Editor - Has values to pass down:

![image](https://user-images.githubusercontent.com/14796305/112194336-bcb25c80-8bd6-11eb-840a-fa61a1863791.png)

### Assignment Editor - Has no values to pass down and will not render undefined:

![image](https://user-images.githubusercontent.com/14796305/112194409-d05dc300-8bd6-11eb-9856-6d21f2fc128a.png)
