### PR TITLE
US126109 handle update-total-quiz-points event in quiz editor and ref…

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -53,7 +53,7 @@ class QuizEditor extends AsyncContainerMixin(RtlMixin(LocalizeActivityQuizEditor
 				?isnew="${this.isNew}"
 				?html-editor-enabled="${this.htmlEditorEnabled}"
 				?html-new-editor-enabled="${this.htmlNewEditorEnabled}"
-				@update-total-quiz-points="${this._updateTotalQuizPoints}">
+				@d2l-question-updated="${this._updateTotalQuizPoints}">
 
 				${this._editorTemplate}
 

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -53,7 +53,7 @@ class QuizEditor extends AsyncContainerMixin(RtlMixin(LocalizeActivityQuizEditor
 				?isnew="${this.isNew}"
 				?html-editor-enabled="${this.htmlEditorEnabled}"
 				?html-new-editor-enabled="${this.htmlNewEditorEnabled}"
-				@d2l-question-updated="${this._updateTotalQuizPoints}">
+				@d2l-question-updated="${this._handleQuestionUpdated}">
 
 				${this._editorTemplate}
 
@@ -85,7 +85,7 @@ class QuizEditor extends AsyncContainerMixin(RtlMixin(LocalizeActivityQuizEditor
 			</div>
 		`;
 	}
-	_updateTotalQuizPoints() {
+	_handleQuestionUpdated() {
 		const activity = store.get(this.href);
 		if (activity) {
 			activity.fetchUpdatedScoreAndGrade(true);

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -52,7 +52,8 @@ class QuizEditor extends AsyncContainerMixin(RtlMixin(LocalizeActivityQuizEditor
 				error-term="${this.localize('quizSaveError')}"
 				?isnew="${this.isNew}"
 				?html-editor-enabled="${this.htmlEditorEnabled}"
-				?html-new-editor-enabled="${this.htmlNewEditorEnabled}">
+				?html-new-editor-enabled="${this.htmlNewEditorEnabled}"
+				@update-total-quiz-points="${this._updateTotalQuizPoints}">
 
 				${this._editorTemplate}
 
@@ -83,6 +84,12 @@ class QuizEditor extends AsyncContainerMixin(RtlMixin(LocalizeActivityQuizEditor
 				</d2l-activity-quiz-editor-secondary>
 			</div>
 		`;
+	}
+	_updateTotalQuizPoints() {
+		const activity = store.get(this.href);
+		if (activity) {
+			activity.fetchUpdatedScoreAndGrade(true);
+		}
 	}
 }
 customElements.define('d2l-activity-quiz-editor', QuizEditor);

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor.js
@@ -88,7 +88,7 @@ class QuizEditor extends AsyncContainerMixin(RtlMixin(LocalizeActivityQuizEditor
 	_handleQuestionUpdated() {
 		const activity = store.get(this.href);
 		if (activity) {
-			activity.fetchUpdatedScoreAndGrade(true);
+			activity.fetchScoreAndGradeScoreOutOf(true);
 		}
 	}
 }

--- a/components/d2l-activity-editor/state/activity-score-grade.js
+++ b/components/d2l-activity-editor/state/activity-score-grade.js
@@ -27,7 +27,6 @@ export class ActivityScoreGrade {
 		this.gradeCandidateCollection = new GradeCandidateCollection(this.gradeCandidatesHref, this.token);
 		await this.gradeCandidateCollection.fetch();
 	}
-
 	async fetchNewGradeCandidates() {
 		if (this.newGradeCandidatesCollection) {
 			return;
@@ -35,6 +34,10 @@ export class ActivityScoreGrade {
 
 		this.newGradeCandidatesCollection = new GradeCandidateCollection(this.newGradeCandidatesHref, this.token);
 		await this.newGradeCandidatesCollection.fetch();
+	}
+	async fetchUpdatedScoreOutOf(entity, bypassCache) {
+		await entity.fetchLinkedScoreOutOfEntity(fetchEntity, bypassCache);
+		this.loadScoreOutOf(entity);
 	}
 
 	getAssociatedGradeEntity() {
@@ -86,7 +89,9 @@ export class ActivityScoreGrade {
 		this.newGradeCandidatesHref = entity.newGradeCandidatesHref();
 		this.newGradeCandidatesCollection = null;
 	}
-
+	loadScoreOutOf(entity) {
+		this.scoreOutOf = entity.scoreOutOf() ? entity.scoreOutOf().toString() : '';
+	}
 	async primeGradeSave() {
 		if (this.inGrades && this.createNewGrade) {
 			await this.fetchNewGradeCandidates();
@@ -98,12 +103,10 @@ export class ActivityScoreGrade {
 			this.scoreOutOfError = null;
 		}
 	}
-
 	setGraded() {
 		this.inGrades = true;
 		this.isUngraded = false;
 	}
-
 	setNewGradeName(name) {
 		this.newGradeName = name;
 	}
@@ -112,13 +115,11 @@ export class ActivityScoreGrade {
 		this.scoreOutOfError = null;
 		this.validate();
 	}
-
 	setUngraded() {
 		this.inGrades = false;
 		this.isUngraded = true;
 		this.setScoreOutOf('');
 	}
-
 	validate() {
 		// This validation was hardcoded in the original UI implementation.
 		// It might have been better to come up with a way to represent this in the Siren representation
@@ -165,5 +166,6 @@ decorate(ActivityScoreGrade, {
 	linkToNewGrade: action,
 	setNewGradeName: action,
 	primeGradeSave: action,
-	load: action
+	load: action,
+	loadScoreOutOf: action
 });

--- a/components/d2l-activity-editor/state/activity-score-grade.js
+++ b/components/d2l-activity-editor/state/activity-score-grade.js
@@ -1,4 +1,4 @@
-import { action, configure as configureMobx, decorate, observable, runInAction } from 'mobx';
+import { action, configure as configureMobx, decorate, observable } from 'mobx';
 import { fetchEntity } from './fetch-entity.js';
 import { GradeCandidateCollection } from '../d2l-activity-grades/state/grade-candidate-collection.js';
 
@@ -14,23 +14,9 @@ export class ActivityScoreGrade {
 		this.inGrades = true;
 	}
 
-	async fetch(entity) {
-		await entity.fetchLinkedScoreOutOfEntity(fetchEntity);
-		runInAction(() => {
-			this.scoreOutOf = entity.scoreOutOf() ? entity.scoreOutOf().toString() : '';
-			this.scoreOutOfError = null;
-			this.inGrades = entity.inGrades();
-			this.gradeType = (entity.gradeType() || entity.numericGradeTypeTitle()).toLowerCase();
-			this.isUngraded = !this.inGrades && !this.scoreOutOf;
-			this.canEditScoreOutOf = entity.canEditScoreOutOf();
-			this.canSeeGrades = entity.canSeeGrades();
-			this.canEditGrades = entity.canEditGrades();
-			this.gradeCandidatesHref = entity.gradeCandidatesHref();
-			this.gradeCandidateCollection = null;
-			this.createNewGrade = !entity.gradeHref();
-			this.newGradeCandidatesHref = entity.newGradeCandidatesHref();
-			this.newGradeCandidatesCollection = null;
-		});
+	async fetch(entity, bypassCache) {
+		await entity.fetchLinkedScoreOutOfEntity(fetchEntity, bypassCache);
+		this.load(entity);
 	}
 
 	async fetchGradeCandidates() {
@@ -85,6 +71,22 @@ export class ActivityScoreGrade {
 		this.createNewGrade = true;
 		this.setGraded();
 	}
+	load(entity) {
+		this.scoreOutOf = entity.scoreOutOf() ? entity.scoreOutOf().toString() : '';
+		this.scoreOutOfError = null;
+		this.inGrades = entity.inGrades();
+		this.gradeType = (entity.gradeType() || entity.numericGradeTypeTitle()).toLowerCase();
+		this.isUngraded = !this.inGrades && !this.scoreOutOf;
+		this.canEditScoreOutOf = entity.canEditScoreOutOf();
+		this.canSeeGrades = entity.canSeeGrades();
+		this.canEditGrades = entity.canEditGrades();
+		this.gradeCandidatesHref = entity.gradeCandidatesHref();
+		this.gradeCandidateCollection = null;
+		this.createNewGrade = !entity.gradeHref();
+		this.newGradeCandidatesHref = entity.newGradeCandidatesHref();
+		this.newGradeCandidatesCollection = null;
+	}
+
 	async primeGradeSave() {
 		if (this.inGrades && this.createNewGrade) {
 			await this.fetchNewGradeCandidates();
@@ -162,5 +164,6 @@ decorate(ActivityScoreGrade, {
 	fetchNewGradeCandidates: action,
 	linkToNewGrade: action,
 	setNewGradeName: action,
-	primeGradeSave: action
+	primeGradeSave: action,
+	load: action
 });

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -28,11 +28,7 @@ export class ActivityUsage {
 		return this;
 	}
 	async fetchScoreAndGradeScoreOutOf(bypassCache) {
-		const sirenEntity = await fetchEntity(this.href, this.token);
-		if (sirenEntity) {
-			const entity = new ActivityUsageEntity(sirenEntity, this.token, { remove: () => { } });
-			await this.scoreAndGrade.fetchUpdatedScoreOutOf(entity, bypassCache);
-		}
+		await this.scoreAndGrade.fetchUpdatedScoreOutOf(this._entity, bypassCache);
 	}
 
 	async load(entity) {

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -27,6 +27,13 @@ export class ActivityUsage {
 		}
 		return this;
 	}
+	async fetchUpdatedScoreAndGrade(bypassCache) {
+		const sirenEntity = await fetchEntity(this.href, this.token);
+		if (sirenEntity) {
+			const entity = new ActivityUsageEntity(sirenEntity, this.token, { remove: () => { } });
+			await this.scoreAndGrade.fetch(entity, bypassCache);
+		}
+	}
 
 	async load(entity) {
 		this._entity = entity;
@@ -43,7 +50,7 @@ export class ActivityUsage {
 		await Promise.all([
 			this._loadSpecialAccess(entity),
 			this._loadCompetencyOutcomes(entity),
-			this.scoreAndGrade.fetch(entity)
+			this.scoreAndGrade.fetch(entity, false)
 		]);
 	}
 

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -27,11 +27,11 @@ export class ActivityUsage {
 		}
 		return this;
 	}
-	async fetchUpdatedScoreAndGrade(bypassCache) {
+	async fetchScoreAndGradeScoreOutOf(bypassCache) {
 		const sirenEntity = await fetchEntity(this.href, this.token);
 		if (sirenEntity) {
 			const entity = new ActivityUsageEntity(sirenEntity, this.token, { remove: () => { } });
-			await this.scoreAndGrade.fetch(entity, bypassCache);
+			await this.scoreAndGrade.fetchUpdatedScoreOutOf(entity, bypassCache);
 		}
 	}
 


### PR DESCRIPTION
…resh total points UI

- `d2l-activity-quiz-editor` handles the `d2l-question-updated` event triggered in `hmc` .
- `ActivityUsage` calls  `this.scoreAndGrade.fetchUpdatedScoreOutOf(entity, bypassCache = true)` which refetches the `linked score-out-of subentity`  so the Total Points UI gets updated
- refactored the setters in `activity-score-grade` fetch method into a new `load(..)` method

**Related PRs:**
`hmc`: https://github.com/BrightspaceHypermediaComponents/foundation-components/pull/150
`siren-sdk`: https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/301

[US126109](https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F512322551332&fdp=true?fdp=true): Refresh total points on edit

https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F512322551332&fdp=true?fdp=true