### PR TITLE
US125926 added new lang terms and changed labels to sentence case

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-timing-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-timing-summary.js
@@ -17,9 +17,10 @@ class ActivityQuizTimingSummary
 		if (!entity) {
 			return html``;
 		}
-		const { isTimingEnforced, recommendedTimeLimit, enforcedTimeLimit, timingType } = entity;
+		const { isTimingEnforced, recommendedTimeLimit, enforcedTimeLimit } = entity;
 		const timeLimit = isTimingEnforced ? enforcedTimeLimit.value : recommendedTimeLimit.value;
-		return html`${this.localize('quizTimingSummary', 'timingType', timingType.title, 'numMinutes', timeLimit)}`;
+		const quizTimingSummary = isTimingEnforced ? 'quizTimingEnforcedSummary' : 'quizTimingRecommendedSummary';
+		return html`${this.localize(quizTimingSummary, 'numMinutes', timeLimit)}`;
 	}
 }
 

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
@@ -110,7 +110,8 @@ export default {
 	"ipRestrictionsInnerSummary" : "{count, plural, =1 {1 restriction} other {{count} restrictions}}", // summary to be displayed when accordion is expanded
 	"quizTimingValidationError": "Timing cannot be changed, please correct the outlined fields.", // Appears in error alert when validation fails in Manage Timing dialog
 	"quizTimingServerError": "Something went wrong. Please try again.", // Timing save server error alert message
-	"quizTimingSummary": "{timingType} ({numMinutes, plural, =1 {1 minute} other {{numMinutes} minutes}})", // Timing type followed by (x minute) or (x minutes). e.g. Recommended time limit (120 minutes)
+	"quizTimingRecommendedSummary": "Recommended time limit ({numMinutes, plural, =1 {1 minute} other {{numMinutes} minutes}})", // Recommended time limit (x minute) or (x minutes).
+	"quizTimingEnforcedSummary": "Enforced time limit ({numMinutes, plural, =1 {1 minute} other {{numMinutes} minutes}})", // Enforced time limit(x minute) or (x minutes).
 	"ipRestrictionsDuplicateError": "Duplicate IP range start address. Each IP range start value must be unique.", // Error for duplicate IP
 	"ipRestrictionsRangeError": "Invalid IP address range provided. Please ensure ranges are correctly formatted.", // Error for invalid IP ranges
 	"quizAttemptsValidationError": "Attempts cannot be changed, please correct the outlined fields.", // Appears in error alert when validation fails in Manage Attempts dialog


### PR DESCRIPTION
The Timing summarizers should use sentence case, ie. `Recommended time limit` instead of `Recommended Time Limit`. Made 2 new lang terms which are conditionally selected by the `d2l-activity-quiz-timing-summary` for this fix.

[US125926](https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F509674996592&fdp=true?fdp=true): [ui] Sentence case summary text for Timing

https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F509674996592&fdp=true?fdp=true