### PR TITLE
Quick Eval Widget handle unexpected activity types

### DIFF
--- a/components/d2l-quick-eval-widget/d2l-quick-eval-widget-controller.js
+++ b/components/d2l-quick-eval-widget/d2l-quick-eval-widget-controller.js
@@ -58,7 +58,7 @@ export async function setToggleState(href, toggleState) {
 
 export function validateActivity(activityUsageEntity) {
 	const expectedType = activityUsageEntity.class.some(activityClass => expectedClasses.includes(activityClass));
-	if(!expectedType) {
+	if (!expectedType) {
 		console.error('[%s] is not an expected activity class and will not be displayed.', activityUsageEntity.class.toString());
 		return false;
 	}

--- a/components/d2l-quick-eval-widget/d2l-quick-eval-widget-controller.js
+++ b/components/d2l-quick-eval-widget/d2l-quick-eval-widget-controller.js
@@ -1,6 +1,8 @@
 import 'd2l-fetch/d2l-fetch.js';
 import 'd2l-polymer-siren-behaviors/store/entity-store.js';
 
+const expectedClasses = ['assignment-activity', 'discussion-activity', 'quiz-activity'];
+
 async function fetch(href, token) {
 	return (await window.D2L.Siren.EntityStore.fetch(href, token)).entity;
 }
@@ -52,4 +54,13 @@ export async function setToggleState(href, toggleState) {
 			}
 		)
 	);
+}
+
+export function validateActivity(activityUsageEntity) {
+	const expectedType = activityUsageEntity.class.some(activityClass => expectedClasses.includes(activityClass));
+	if(!expectedType) {
+		console.error('[%s] is not an expected activity class and will not be displayed.', activityUsageEntity.class.toString());
+		return false;
+	}
+	return true;
 }

--- a/components/d2l-quick-eval-widget/d2l-quick-eval-widget.js
+++ b/components/d2l-quick-eval-widget/d2l-quick-eval-widget.js
@@ -8,7 +8,6 @@ import { css, html, LitElement } from 'lit-element';
 import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { fetchActivities, fetchEvaluationHref, fetchSubmissionCount, setToggleState } from './d2l-quick-eval-widget-controller.js';
 import { LocalizeQuickEvalWidget } from './lang/localize-quick-eval-widget.js';
-import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
 const errorState = 'error';
@@ -183,7 +182,7 @@ export class QuickEvalWidget extends LocalizeQuickEvalWidget(SkeletonMixin(LitEl
 					href="${activity.href}"
 					?skeleton=${this._loading || this.skeleton}
 					submission-count=${activity.submissionCount}
-					.token=${ifDefined(this.token)}
+					.token=${this.token}
 					@data-loaded=${this._itemLoaded}></d2l-work-to-do-activity-list-item-basic>`;
 		});
 		return html`

--- a/components/d2l-quick-eval-widget/d2l-quick-eval-widget.js
+++ b/components/d2l-quick-eval-widget/d2l-quick-eval-widget.js
@@ -118,7 +118,7 @@ export class QuickEvalWidget extends LocalizeQuickEvalWidget(SkeletonMixin(LitEl
 		}
 		return Promise.all(
 			unassessedActivityCollection.entities
-				.filter( activityUsage => {
+				.filter(activityUsage => {
 					return validateActivity(activityUsage);
 				})
 				.slice(0, this.count)

--- a/components/d2l-quick-eval-widget/d2l-quick-eval-widget.js
+++ b/components/d2l-quick-eval-widget/d2l-quick-eval-widget.js
@@ -118,10 +118,10 @@ export class QuickEvalWidget extends LocalizeQuickEvalWidget(SkeletonMixin(LitEl
 		}
 		return Promise.all(
 			unassessedActivityCollection.entities
-				.slice(0, this.count)
 				.filter( activityUsage => {
 					return validateActivity(activityUsage);
 				})
+				.slice(0, this.count)
 				.map(async activityUsage => {
 					const submissionCount = await fetchSubmissionCount(activityUsage, token);
 

--- a/components/d2l-quick-eval-widget/d2l-quick-eval-widget.js
+++ b/components/d2l-quick-eval-widget/d2l-quick-eval-widget.js
@@ -6,7 +6,7 @@ import '../d2l-work-to-do/d2l-work-to-do-activity-list-item-basic.js';
 
 import { css, html, LitElement } from 'lit-element';
 import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles.js';
-import { fetchActivities, fetchEvaluationHref, fetchSubmissionCount, setToggleState } from './d2l-quick-eval-widget-controller.js';
+import { fetchActivities, fetchEvaluationHref, fetchSubmissionCount, setToggleState, validateActivity } from './d2l-quick-eval-widget-controller.js';
 import { LocalizeQuickEvalWidget } from './lang/localize-quick-eval-widget.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
@@ -119,6 +119,9 @@ export class QuickEvalWidget extends LocalizeQuickEvalWidget(SkeletonMixin(LitEl
 		return Promise.all(
 			unassessedActivityCollection.entities
 				.slice(0, this.count)
+				.filter( activityUsage => {
+					return validateActivity(activityUsage);
+				})
 				.map(async activityUsage => {
 					const submissionCount = await fetchSubmissionCount(activityUsage, token);
 

--- a/demo/d2l-quick-eval-widget/d2l-quick-eval-widget.html
+++ b/demo/d2l-quick-eval-widget/d2l-quick-eval-widget.html
@@ -22,7 +22,7 @@
 					quick-eval-href=""
 					toggle-href=""
 					toggle-state="activities"
-					count="3">
+					count="4">
 				</d2l-quick-eval-widget>
 			</d2l-demo-snippet>
 

--- a/demo/d2l-quick-eval-widget/data/activity-collection.json
+++ b/demo/d2l-quick-eval-widget/data/activity-collection.json
@@ -144,6 +144,15 @@
           "href": "./data/quiz.json"
         }
       ]
+    },
+    {
+      "class": [
+        "activity-usage",
+        "checkpoint-item"
+      ],
+      "rel": [
+        "https://activities.api.brightspace.com/rels/activity-usage"
+      ]
     }
   ],
   "links": [

--- a/test/d2l-quick-eval-widget/data/activity-collection-many-items.json
+++ b/test/d2l-quick-eval-widget/data/activity-collection-many-items.json
@@ -339,6 +339,15 @@
           "href": "../data/organization1.json"
         }
       ]
+    },
+    {
+      "class": [
+        "activity-usage",
+        "checkpoint-item"
+      ],
+      "rel": [
+        "https://activities.api.brightspace.com/rels/activity-usage"
+      ]
     }
   ],
   "links": [

--- a/test/d2l-quick-eval-widget/perceptual/d2l-quick-eval-widget.visual-diff.html
+++ b/test/d2l-quick-eval-widget/perceptual/d2l-quick-eval-widget.visual-diff.html
@@ -23,7 +23,7 @@
 		<div id="default" class="visual-diff">
 			<d2l-quick-eval-widget
 				token="token"
-				href="../data/activity-collection-seven-items.json"
+				href="../data/activity-collection-many-items.json"
 				quick-eval-href=""
 				toggle-href=""
 				toggle-state="activities">
@@ -33,7 +33,7 @@
 		<div id="limits-count" class="visual-diff">
 			<d2l-quick-eval-widget
 				token="token"
-				href="../data/activity-collection-seven-items.json"
+				href="../data/activity-collection-many-items.json"
 				quick-eval-href=""
 				toggle-href=""
 				toggle-state="activities"


### PR DESCRIPTION
Currently if a single unexpected activity type is returned for the QE widget it will display an error message rather than loading the list.

This change has the widget display activities of valid types even if it receives unexpected ones and output an error message containing the unexpected type to the console for easier identification of further issues.