### PR TITLE
US123706 Fix: restore attempts dialog height

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-manage-attempts-container.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-manage-attempts-container.js
@@ -17,7 +17,7 @@ class ActivityQuizManageAttemptsContainer extends ActivityEditorWorkingCopyDialo
 			labelStyles,
 			css`
 			#manage-attempts-dialog-attempts-editor {
-				height: 830px;
+				height: 430px;
 			}
 
 			d2l-alert {


### PR DESCRIPTION
[US123706](https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F478977336380&fdp=true&fdp=true?fdp=true): [ui] Manage Attempts (Attempts allowed, RIO, Attempt conditions)