### PR TITLE
US126777 Add existing categories

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-categories-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-categories-editor.js
@@ -37,7 +37,7 @@ class AssignmentCategoriesEditor extends ActivityEditorMixin(RtlMixin(LocalizeAc
 	render() {
 		const categoriesStore = store.get(this.href);
 
-		if (!categoriesStore || !categoriesStore.categories || !categoriesStore.categories.length) {
+		if (!categoriesStore || !categoriesStore.categories) {
 			return html``;
 		}
 

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-categories-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-categories-editor.js
@@ -1,5 +1,6 @@
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
+import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles';
 import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
@@ -11,6 +12,7 @@ class AssignmentCategoriesEditor extends ActivityEditorMixin(RtlMixin(LocalizeAc
 	static get styles() {
 		return [
 			selectStyles,
+			bodyCompactStyles,
 			css`
 				:host {
 					display: block;
@@ -39,10 +41,17 @@ class AssignmentCategoriesEditor extends ActivityEditorMixin(RtlMixin(LocalizeAc
 			return html``;
 		}
 
+		if (!categoriesStore.canEditCategories) {
+			const name = categoriesStore.selectedCategory?.properties.name ?? this.localize('noCategoryLabel');
+			return html`<div class="d2l-body-compact">${name}</div>`;
+		}
+
 		return html`
 			<select
 				class="d2l-input-select d2l-block-select"
 				@change="${this._updateCategory}">
+
+				<option ?selected=${!categoriesStore.selectedCategory}>${this.localize('noCategoryLabel')}</option>
 
 				${categoriesStore.categories.map(this._formatOption)}
 

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-categories-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-categories-editor.js
@@ -1,0 +1,61 @@
+import { css, html } from 'lit-element/lit-element.js';
+import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
+import { LocalizeActivityAssignmentEditorMixin } from './mixins/d2l-activity-assignment-lang-mixin.js';
+import { MobxLitElement } from '@adobe/lit-mobx';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
+import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';
+import { sharedCategories as store } from './state/assignment-store.js';
+
+class AssignmentCategoriesEditor extends ActivityEditorMixin(RtlMixin(LocalizeActivityAssignmentEditorMixin(MobxLitElement))) {
+
+	static get styles() {
+		return [
+			selectStyles,
+			css`
+				:host {
+					display: block;
+				}
+				:host([hidden]) {
+					display: none;
+				}
+
+				.d2l-block-select {
+					display: block;
+					max-width: 300px;
+					width: 100%;
+				}
+			`
+		];
+	}
+
+	constructor() {
+		super(store);
+	}
+
+	render() {
+		const categoriesStore = store.get(this.href);
+
+		if (!categoriesStore || !categoriesStore.categories || !categoriesStore.categories.length) {
+			return html``;
+		}
+
+		return html`
+			<select
+				class="d2l-input-select d2l-block-select"
+				@change="${this._updateCategory}">
+
+				${categoriesStore.categories.map(this._formatOption)}
+
+			</select>
+		`;
+	}
+
+	_formatOption(category) {
+		return html`<option value=${category.index} ?selected=${category.selected}>${category.name}</option>`;
+	}
+
+	_updateCategory() {
+		// do something
+	}
+}
+customElements.define('d2l-activity-assignment-categories-editor', AssignmentCategoriesEditor);

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-categories-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-categories-editor.js
@@ -42,7 +42,7 @@ class AssignmentCategoriesEditor extends ActivityEditorMixin(RtlMixin(LocalizeAc
 		}
 
 		if (!categoriesStore.canEditCategories) {
-			const name = categoriesStore.selectedCategory?.properties.name ?? this.localize('noCategoryLabel');
+			const name = categoriesStore.selectedCategory ? categoriesStore.selectedCategory.properties.name : this.localize('noCategoryLabel');
 			return html`<div class="d2l-body-compact">${name}</div>`;
 		}
 

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -1,6 +1,7 @@
 import '../d2l-activity-accordion-collapse.js';
 import './d2l-activity-assignment-submission-email-notification-summary.js';
 import './d2l-activity-assignment-type-editor.js';
+import './d2l-activity-assignment-categories-editor.js';
 import './d2l-activity-assignment-type-summary.js';
 import '../d2l-activity-notification-email-editor';
 import { bodyCompactStyles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
@@ -78,6 +79,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 				<li slot="summary-items">${this._renderSubmissionEmailNotificationSummary(assignment)}</li>
 				<span slot="components">
 					${this._renderAssignmentType()}
+					${this._renderCategoriesDropdown(assignment)}
 					${this._renderAssignmentSubmissionType(assignment)}
 					${this._renderAssignmentFilesSubmissionLimit(assignment)}
 					${this._renderAssignmentSubmissionsRule(assignment)}
@@ -177,6 +179,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 	_renderAssignmentCompletionTypeSummary() {
 		return html``;
 	}
+
 	_renderAssignmentFilesSubmissionLimit(assignment) {
 		if (!assignment ||
 			!assignment.submissionAndCompletionProps ||
@@ -353,6 +356,23 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 			</d2l-activity-assignment-type-summary>
 		`;
 	}
+
+	_renderCategoriesDropdown(assignment) {
+		if (!assignment || !assignment.categoriesLink) return;
+
+		return html`
+			<div id="categories-editor-container">
+				<label class="d2l-label-text">
+					${this.localize('txtCategoriesLabel')}
+				</label>
+				<d2l-activity-assignment-categories-editor
+					href="${assignment.categoriesLink}"
+					.token="${this.token}">
+				</d2l-activity-assignment-categories-editor>
+			</div>
+	`;
+	}
+
 	_renderSubmissionEmailNotificationSummary(assignment) {
 		if (!assignment || !assignment.showNotificationEmail) {
 			return html``;

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -362,9 +362,11 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 
 		return html`
 			<div id="categories-editor-container">
+
 				<label class="d2l-label-text">
 					${this.localize('txtCategoriesLabel')}
 				</label>
+
 				<d2l-activity-assignment-categories-editor
 					href="${assignment.categoriesLink}"
 					.token="${this.token}">

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
@@ -47,4 +47,5 @@ export default {
 	"assignmentLocked": "Some settings are locked because submissions have been received.",
 	"hlpSubmissionNotificationEmail": "Enter an email or multiple emails separated by a comma, to receive notifications when an assignment is submitted.",
 	"gradeOutOf": "Grade Out Of", // Label for the grade-out-of field when creating/editing an activity
+	"txtCategoriesLabel": "Categories" // Label for categories dropdown
 };

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
@@ -47,5 +47,6 @@ export default {
 	"assignmentLocked": "Some settings are locked because submissions have been received.",
 	"hlpSubmissionNotificationEmail": "Enter an email or multiple emails separated by a comma, to receive notifications when an assignment is submitted.",
 	"gradeOutOf": "Grade Out Of", // Label for the grade-out-of field when creating/editing an activity
-	"txtCategoriesLabel": "Categories" // Label for categories dropdown
+	"txtCategoriesLabel": "Categories", // Label for categories dropdown
+	"noCategoryLabel": "No Category", // Label for when there are no categories
 };

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-categories.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-categories.js
@@ -1,0 +1,34 @@
+import { action, configure as configureMobx, decorate, observable } from 'mobx';
+import { CategoriesEntity } from 'siren-sdk/src/activities/CategoriesEntity.js';
+import { fetchEntity } from '../../state/fetch-entity.js';
+
+configureMobx({ enforceActions: 'observed' });
+
+export class AssignmentCategories {
+
+	constructor(href, token) {
+		this.href = href;
+		this.token = token;
+	}
+
+	async fetch() {
+		const sirenEntity = await fetchEntity(this.href, this.token);
+		if (sirenEntity) {
+			const entity = new CategoriesEntity(sirenEntity, this.token, { remove: () => { } });
+			this.load(entity);
+		}
+		return this;
+	}
+
+	load(entity) {
+		this._entity = entity;
+		this.categories = entity.getCategories();
+	}
+}
+
+decorate(AssignmentCategories, {
+	// props
+	categories: observable,
+	// actions
+	load: action
+});

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-categories.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-categories.js
@@ -23,12 +23,16 @@ export class AssignmentCategories {
 	load(entity) {
 		this._entity = entity;
 		this.categories = entity.getCategories();
+		this.canEditCategories = entity.canEditCategories();
+		this.selectedCategory = entity.getSelectedCategory();
 	}
 }
 
 decorate(AssignmentCategories, {
 	// props
 	categories: observable,
+	selectedCategory: observable,
+	canEditCategories: observable,
 	// actions
 	load: action
 });

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-store.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-store.js
@@ -1,4 +1,5 @@
 import { Assignment } from './assignment.js';
+import { AssignmentCategories } from './assignment-categories';
 import { ObjectStore } from '../../state/object-store.js';
 
 export class AssignmentStore extends ObjectStore {
@@ -7,4 +8,11 @@ export class AssignmentStore extends ObjectStore {
 	}
 }
 
+export class AssignmentCategoriesStore extends ObjectStore {
+	constructor() {
+		super(AssignmentCategories);
+	}
+}
+
 export const shared = new AssignmentStore();
+export const sharedCategories = new AssignmentCategoriesStore();

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -89,6 +89,8 @@ export class Assignment {
 		this.canEditFilesSubmissionLimit = entity.canEditFilesSubmissionLimit();
 		this.filesSubmissionLimit = entity.filesSubmissionLimit() || 'unlimited';
 
+		this.categoriesLink = entity.getCategoriesLink();
+
 		this.assignmentTypeProps = new AssignmentTypeProps({
 			isGroupAssignmentTypeDisabled: entity.isGroupAssignmentTypeDisabled(),
 			isIndividualAssignmentType: entity.isIndividualAssignmentType(),

--- a/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
@@ -38,6 +38,7 @@ describe('Assignment ', function() {
 				getAnonymousMarkingHelpText: () => 'Anonymous marking help text',
 				canEditAnnotations: () => undefined,
 				getAvailableAnnotationTools: () => undefined,
+				getCategoriesLink: () => 'http://categories.com',
 				activityUsageHref: () => 'http://activity/1',
 				submissionTypeOptions: () => [
 					{ title: 'File submission', value: 0, completionTypes: null, selected: false },


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F519563556284

Added basic component for rendering a categories dropdown in assignments.

Edit: I think this will always fail CI until this is merged https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/310