### PR TITLE
Add ESlint plugins for activity editor components

### DIFF
--- a/components/d2l-activity-editor/.eslintrc.json
+++ b/components/d2l-activity-editor/.eslintrc.json
@@ -4,7 +4,6 @@
     "sort-class-members/sort-class-members": "error"
   },
   "plugins": [
-    "nullishCoalescingOperator",
-  	"optionalChaining"
-	]
+    "nullishCoalescingOperator"
+  ]
 }

--- a/components/d2l-activity-editor/.eslintrc.json
+++ b/components/d2l-activity-editor/.eslintrc.json
@@ -2,5 +2,9 @@
   "extends": "brightspace/lit-config",
   "rules": {
     "sort-class-members/sort-class-members": "error"
-  }
+  },
+  "plugins": [
+    "nullishCoalescingOperator",
+  	"optionalChaining"
+	]
 }

--- a/components/d2l-activity-editor/.eslintrc.json
+++ b/components/d2l-activity-editor/.eslintrc.json
@@ -4,6 +4,6 @@
     "sort-class-members/sort-class-members": "error"
   },
   "plugins": [
-    "nullishCoalescingOperator"
+    "optionalChaining"
   ]
 }


### PR DESCRIPTION
It would be nice to take advantage of the `?.` ~~and `??`~~ operators.
`?.` https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining

https://eslint.org/blog/2020/06/eslint-v7.2.0-released mentions that `??` is supported and our ESLint is at `7.24.0`
`??` https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator

Opinions?

~~Adds: `eslint-plugin-nullishCoalescingOperator@latest --save-dev` as a dev dependency~~
