### PR TITLE
Handle redirecting to the lesson view page from the updated activity usage

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
@@ -150,7 +150,7 @@ class ContentEditor extends LocalizeActivityEditorMixin(RtlMixin(ActivityEditorM
 		let redirectLocation = this.saveHref;
 		store.fetchContentActivity(this.href, this.token)
 			.then((contentActivity) => {
-				if (contentActivity?.lessonViewPageHref) {
+				if (contentActivity && contentActivity.lessonViewPageHref) {
 					redirectLocation = contentActivity.lessonViewPageHref;
 				}
 			})

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
@@ -57,8 +57,10 @@ class ContentEditor extends LocalizeActivityEditorMixin(RtlMixin(ActivityEditorM
 		super.connectedCallback();
 		this.addEventListener('d2l-activity-editor-save-complete', this._redirectOnSaveComplete);
 		this.addEventListener('d2l-activity-editor-cancel-complete', this._redirectOnCancelComplete);
+		this.addEventListener('d2l-content-activity-update', this._contentActivityUpdated);
 	}
 	disconnectedCallback() {
+		this.removeEventListener('d2l-content-activity-update', this._contentActivityUpdated);
 		this.removeEventListener('d2l-activity-editor-save-complete', this._redirectOnSaveComplete);
 		this.removeEventListener('d2l-activity-editor-cancel-complete', this._redirectOnCancelComplete);
 		super.disconnectedCallback();
@@ -90,6 +92,14 @@ class ContentEditor extends LocalizeActivityEditorMixin(RtlMixin(ActivityEditorM
 			this.href && this.token) {
 			super._fetch(() => store.fetchContentActivity(this.href, this.token));
 			super._fetch(() => activityStore.fetch(this.href, this.token));
+		}
+	}
+
+	_contentActivityUpdated(e) {
+		const { originalActivityUsageHref, updatedActivityUsageHref } = e.detail;
+		if (originalActivityUsageHref === this.href &&
+			originalActivityUsageHref !== updatedActivityUsageHref) {
+			this.href = updatedActivityUsageHref;
 		}
 	}
 
@@ -137,9 +147,18 @@ class ContentEditor extends LocalizeActivityEditorMixin(RtlMixin(ActivityEditorM
 	}
 
 	_redirectOnSaveComplete() {
-		if (this.saveHref) {
-			window.location.href = this.saveHref;
-		}
+		let redirectLocation = this.saveHref;
+		store.fetchContentActivity(this.href, this.token)
+			.then((contentActivity) => {
+				if (contentActivity?.lessonViewPageHref) {
+					redirectLocation = contentActivity.lessonViewPageHref;
+				}
+			})
+			.finally(() => {
+				if (redirectLocation) {
+					window.location.href = redirectLocation;
+				}
+			});
 	}
 }
 customElements.define('d2l-activity-content-editor', ContentEditor);

--- a/components/d2l-activity-editor/d2l-activity-content-editor/state/content.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/state/content.js
@@ -14,6 +14,7 @@ export class Content {
 		this.token = token;
 		this.entityType = null;
 		this.contentActivityHref = '';
+		this.lessonViewPageHref = '';
 	}
 
 	async fetch() {
@@ -39,6 +40,8 @@ export class Content {
 			this.contentActivityHref = contentEntity.getLTILinkHref();
 			ltiLinkStore.fetchContentLTILinkActivity(this.contentActivityHref, this.token);
 		}
+
+		this.lessonViewPageHref = contentEntity.getLessonViewPageHref();
 	}
 }
 decorate(Content, {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-detail.js
@@ -95,7 +95,18 @@ class ContentWebLinkDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandli
 			return;
 		}
 
-		await webLinkEntity.save();
+		const originalActivityUsageHref = webLinkEntity.activityUsageHref;
+		const updatedEntity = await webLinkEntity.save();
+		const event = new CustomEvent('d2l-content-activity-update', {
+			detail: {
+				originalActivityUsageHref: originalActivityUsageHref,
+				updatedActivityUsageHref: updatedEntity.getActivityUsageHref()
+			},
+			bubbles: true,
+			composed: true,
+			cancelable: true
+		});
+		await this.dispatchEvent(event);
 	}
 
 	saveLink(link, isExternal) {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/state/content-web-link.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/state/content-web-link.js
@@ -12,6 +12,7 @@ export class ContentWebLink {
 		this.title = '';
 		this.link = '';
 		this.isExternalResource = false;
+		this.activityUsageHref = '';
 	}
 
 	async cancelCreate() {
@@ -34,9 +35,11 @@ export class ContentWebLink {
 
 	load(webLinkEntity) {
 		this._contentWebLink = webLinkEntity;
+		this.href = webLinkEntity.self();
 		this.title = webLinkEntity.title();
 		this.link = webLinkEntity.url();
 		this.isExternalResource = webLinkEntity.isExternalResource();
+		this.activityUsageHref = webLinkEntity.getActivityUsageHref();
 	}
 
 	async save() {
@@ -49,7 +52,8 @@ export class ContentWebLink {
 		await this._contentWebLink.setWebLinkExternalResource(this.isExternalResource);
 		const committedWebLinkEntity = await this._commit(this._contentWebLink);
 		const editableWebLinkEntity = await this._checkout(committedWebLinkEntity);
-		await this.load(editableWebLinkEntity);
+		this.load(editableWebLinkEntity);
+		return this._contentWebLink;
 	}
 
 	setExternalResource(value) {

--- a/test/d2l-activity-editor/d2l-activity-content-editor/state/content-web-link.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-content-editor/state/content-web-link.spec.js
@@ -29,6 +29,8 @@ describe('Content Web Link', function() {
 				title: () => 'Test Web Link Title',
 				url: () => 'http://test.com',
 				isExternalResource: () => false,
+				self: () => 'http://test-web-link-href.com',
+				getActivityUsageHref: () => 'http://test-activity-usage-link-href.com',
 				checkoutWebLink: checkoutWebLinkMock
 			};
 		});

--- a/test/d2l-activity-editor/d2l-activity-content-editor/state/content.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-content-editor/state/content.spec.js
@@ -32,7 +32,8 @@ describe('Content', function() {
 				getModuleHref: () => 'http://test-module-href.com',
 				getWebLinkHref: () => '',
 				getLTILinkHref: () => '',
-				getEntityType: () => 'module'
+				getEntityType: () => 'module',
+				getLessonViewPageHref: () => 'http://lessons/topic/1'
 			};
 		});
 


### PR DESCRIPTION
## Relevant Rally Links 

[US126672](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F519007142480&fdp=true?fdp=true): Modify activities saveHref to handle new working copy items

## Description

NOTE: Requires https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/313 and https://github.com/Brightspace/lms/pull/9275

Adds logic to notify and update the parent content activity usage when a web link is persisted and the activity usage href may have changed.

Additionally, adds logic to use the new `lesson-view-page` href when navigating back to the lessons page.

## Goal/Solution

The `lesson-view-page` link will allow the FACE UI to navigate back to the correct topic after saving (especially useful for creating a new topic). Currently when creating a new weblink and choosing "Save And Close" the user will receive a 404 Not Found page because the topic id did not exist at the time of loading the page and so it incorrectly attempts to navigate to `-1`.

The `activity-usage` link allows the web link to raise an event with the updated activity-usage href value when saving. This is important when committing a new unsaved weblink for the first time as the activity usage href will change and the parent control needs to be aware so it can fetch this updated entity.

## Video/Screenshots

![fix-nav-on-weblink-create](https://user-images.githubusercontent.com/2243995/114772573-94c89b80-9d33-11eb-9d76-23eebe504a71.gif)