### PR TITLE
Adjusted check to ensure there is a selected category before renderin…

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-categories-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-categories-summary.js
@@ -28,8 +28,8 @@ class AssignmentCategoriesSummary extends ActivityEditorMixin(RtlMixin(LocalizeA
 
 	render() {
 		const categories = store.get(this.href);
-		if (categories) {
-			const categoryName = categories.selectedCategory && categories.selectedCategory.properties.name;
+		if (categories && categories.selectedCategory) {
+			const categoryName =  categories.selectedCategory.properties.name;
 
 			return html`${this.localize('categorySummaryPrefix')}: ${categoryName}`;
 		}


### PR DESCRIPTION
…g summary

https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F516602044064%2Ftasks

This was previously rendering `Category: ` even if there was no selected category. 
