### PR TITLE
Fix incorrect existing grade displayed after saving

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-grades/state/grade-candidate-collection.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/state/grade-candidate-collection.js
@@ -15,8 +15,8 @@ export class GradeCandidateCollection {
 		this.selected = null;
 	}
 
-	async fetch() {
-		const sirenEntity = await fetchEntity(this.href, this.token);
+	async fetch(bypassCache) {
+		const sirenEntity = await fetchEntity(this.href, this.token, bypassCache);
 		if (sirenEntity) {
 			const entity = new GradeCandidateCollectionEntity(sirenEntity, this.token, { remove: () => { } });
 			await this.load(entity);

--- a/components/d2l-activity-editor/state/activity-score-grade.js
+++ b/components/d2l-activity-editor/state/activity-score-grade.js
@@ -25,7 +25,7 @@ export class ActivityScoreGrade {
 		}
 
 		this.gradeCandidateCollection = new GradeCandidateCollection(this.gradeCandidatesHref, this.token);
-		await this.gradeCandidateCollection.fetch();
+		await this.gradeCandidateCollection.fetch(true);
 	}
 	async fetchNewGradeCandidates() {
 		if (this.newGradeCandidatesCollection) {
@@ -33,7 +33,7 @@ export class ActivityScoreGrade {
 		}
 
 		this.newGradeCandidatesCollection = new GradeCandidateCollection(this.newGradeCandidatesHref, this.token);
-		await this.newGradeCandidatesCollection.fetch();
+		await this.newGradeCandidatesCollection.fetch(true);
 	}
 	async fetchUpdatedScoreOutOf(entity, bypassCache) {
 		await entity.fetchLinkedScoreOutOfEntity(fetchEntity, bypassCache);
@@ -151,8 +151,8 @@ decorate(ActivityScoreGrade, {
 	gradeCandidateCollection: observable,
 	newGradeName: observable,
 	createNewGrade: observable,
-	gradeCategoriesHref: observable,
-	gradeCategoryCollection: observable,
+	newGradeCandidatesHref: observable,
+	newGradeCandidatesCollection: observable,
 	// actions
 	setScoreOutOf: action,
 	setUngraded: action,


### PR DESCRIPTION
The bug comes down to the `gradeCandidateCollection` being set when the dialog is opened. And when we save, we do not re-fetch the collection. So when we open the dialog again after save, it shows old data.

We had the right idea to set the `gradeCollectionCollection` mobX property to `null`. But when the dialog is re-opened, it does not bypass the cache to re-fetch the entity, instead it retrieves our stale candidate collection from the store.

This also fixes a problem where when we "Create new grade" and "save", the `gradeCandidateCollection` isn't re-fetched, so the grade we just created and linked to does not appear in the "link to existing dropdown" even though the assignment is linked to it.

https://trello.com/c/IPhZb0hO/5-choose-grades-incorrect-selected-existing-grade-item-showing-after-save