### PR TITLE
fix: trigger visual_diff tests manually only, not on pull_request.

### DIFF
--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -1,5 +1,5 @@
 name: Visual Diff
-on: pull_request
+on: workflow_dispatch
 jobs:
   build:
     name: Visual Diff


### PR DESCRIPTION
Given the frequent visual diff test flakes that prevent unrelated code changes from being merged, I am proposing that these tests not be run on every pull request. Instead, they can be triggered manually whenever a related change needs to be tested. I realize this will not catch random changes to dependent components that may affect the components checked by these tests. Perhaps a cron job may be a better solution. 

Discussion is welcome, I am just proposing one option here. But would like to find a better solution than what we currently have in place.  