### PR TITLE
Updated categories implementation to ensure summary reflects selected…

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-categories-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-categories-editor.js
@@ -10,7 +10,7 @@ import { selectStyles } from '@brightspace-ui/core/components/inputs/input-selec
 import { sharedCategories as store } from './state/assignment-store.js';
 
 const NEW_CATEGORY = 'new category';
-const UNSELECTED_ID = '0'; // API expects 0 to unselect an ID
+const UNSELECTED_ID = '0'; // API expects 0 to unselect a category
 
 class AssignmentCategoriesEditor extends ActivityEditorMixin(ActivityEditorDialogMixin(RtlMixin(LocalizeActivityAssignmentEditorMixin(MobxLitElement)))) {
 
@@ -132,6 +132,12 @@ class AssignmentCategoriesEditor extends ActivityEditorMixin(ActivityEditorDialo
 		this.handleClose();
 	}
 
+	_handleNewCategory(categoriesStore) {
+		this.open();
+
+		return this._resetCategory(categoriesStore);
+	}
+
 	_renderDialog(store) {
 		return html`
 			<d2l-dialog
@@ -141,7 +147,7 @@ class AssignmentCategoriesEditor extends ActivityEditorMixin(ActivityEditorDialo
 				title-text="${this.localize('newAssignmentCategory')}">
 
 					<d2l-input-text
-						value="${store.categoryName}"
+						value="${store.newCategoryName}"
 						label="${this.localize('inputCategoryLabel')}"
 						maxlength="128"
 						novalidate
@@ -153,7 +159,7 @@ class AssignmentCategoriesEditor extends ActivityEditorMixin(ActivityEditorDialo
 					<d2l-button
 						data-dialog-action="save"
 						slot="footer"
-						?disabled="${!store.categoryName}"
+						?disabled="${!store.newCategoryName}"
 						primary>
 						${this.localize('btnAssignmentCategoryCreate')}
 					</d2l-button>
@@ -181,17 +187,30 @@ class AssignmentCategoriesEditor extends ActivityEditorMixin(ActivityEditorDialo
 		categoriesStore.setNewCategoryName(e.target.value);
 	}
 
+	_setSelectedCategory(e, categoriesStore) {
+		const selectedCategoryIndex = e.target.selectedIndex;
+		const selectedCategory = e.target.options[selectedCategoryIndex];
+
+		const { value, text } = selectedCategory;
+
+		categoriesStore.setSelectedCategory(value, text);
+	}
+
 	_updateCategory(e) {
+		if (!e || !e.target || !e.target.value) return;
+
 		const categoriesStore = store.get(this.href);
 		if (!categoriesStore) return;
 
-		if (e && e.target && e.target.value === NEW_CATEGORY) {
-			this.open();
-
-			return this._resetCategory(categoriesStore);
+		if (e.target.value === NEW_CATEGORY) {
+			return this._handleNewCategory(categoriesStore);
 		}
 
-		categoriesStore.setSelectedCategoryId(e.target.value);
+		if (e.target.value === UNSELECTED_ID) {
+			return categoriesStore.setSelectedCategory(UNSELECTED_ID, '');
+		}
+
+		this._setSelectedCategory(e, categoriesStore);
 	}
 }
 customElements.define('d2l-activity-assignment-categories-editor', AssignmentCategoriesEditor);

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-categories-summary.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-categories-summary.js
@@ -28,10 +28,8 @@ class AssignmentCategoriesSummary extends ActivityEditorMixin(RtlMixin(LocalizeA
 
 	render() {
 		const categories = store.get(this.href);
-		if (categories && categories.selectedCategory) {
-			const categoryName =  categories.selectedCategory.properties.name;
-
-			return html`${this.localize('categorySummaryPrefix')}: ${categoryName}`;
+		if (categories && categories.selectedCategoryName) {
+			return html`${this.localize('categorySummaryPrefix')}: ${categories.selectedCategoryName}`;
 		}
 	}
 }

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-categories.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-categories.js
@@ -29,8 +29,9 @@ export class AssignmentCategories {
 		this.categories = entity.getCategories();
 		this.canEditCategories = entity.canEditCategories();
 		this.selectedCategory = entity.getSelectedCategory();
+		this.selectedCategoryName = this.selectedCategory && this.selectedCategory.properties.name;
 		this.selectedCategoryId = this.selectedCategory && this.selectedCategory.properties.categoryId;
-		this.categoryName = '';
+		this.newCategoryName = '';
 	}
 
 	async save() {
@@ -50,18 +51,19 @@ export class AssignmentCategories {
 	}
 
 	setNewCategoryName(name) {
-		this.categoryName = name;
+		this.newCategoryName = name;
 	}
 
-	setSelectedCategoryId(categoryId) {
+	setSelectedCategory(categoryId, categoryName) {
 		this.selectedCategoryId = categoryId;
+		this.selectedCategoryName = categoryName;
 	}
 
 	_makeCategoriesData() {
 		const data = {};
 
-		if (this.categoryName) {
-			data.categoryName = this.categoryName;
+		if (this.newCategoryName) {
+			data.categoryName = this.newCategoryName;
 		}
 
 		if (this.selectedCategoryId) {
@@ -83,9 +85,10 @@ decorate(AssignmentCategories, {
 	selectedCategory: observable,
 	canEditCategories: observable,
 	selectedCategoryId: observable,
-	categoryName: observable,
+	newCategoryName: observable,
+	selectedCategoryName: observable,
 	// actions
 	load: action,
-	setSelectedCategoryId: action,
+	setSelectedCategory: action,
 	setNewCategoryName: action
 });


### PR DESCRIPTION
… category

Fix addresses [this trello card](https://trello.com/c/6Mz8lmGe/366-categories-when-a-category-is-changed-and-accordion-is-collapsed-the-summarizer-text-shows-the-old-category-until-the-assignment).

Previously the summarizer was only updating once the 'save' network request competed. Now it should render based on the current UI state. 

