### PR TITLE
US127307 Catch telemetry error when missing endpoint

### DIFF
--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-telemetry-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-telemetry-mixin.js
@@ -23,6 +23,13 @@ export const ActivityEditorTelemetryMixin = superclass => class extends supercla
 	async logTelemetryEvent(href, action, type, telemetryId) {
 		if (!href || !action || !type || !telemetryId) return;
 
+		let client;
+		try {
+			client = await D2L.Telemetry.CreateClient();
+		} catch (e) {
+			return;
+		}
+
 		const eventBody = new Events.EventBody()
 			.setAction(action)
 			.setObject(href, type);
@@ -31,7 +38,6 @@ export const ActivityEditorTelemetryMixin = superclass => class extends supercla
 			.setDate(new Date())
 			.setSourceId(telemetryId)
 			.setBody(eventBody);
-		const client = await D2L.Telemetry.CreateClient();
 		client.logUserEvent(event);
 	}
 


### PR DESCRIPTION
Removing the endpoint for PBMM clients causes the client creation to fail and throw (see [here](https://github.com/Brightspace/brightspace-integration/blob/master/web-components/bsi-unbundled.js#L43)), so this catches that error so those clients don't get a bunch of console errors.

https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F600523947568