### PR TITLE
fix: removing unnecessary table variables

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-submissions-table.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions-table.js
@@ -30,10 +30,6 @@ class D2LQuickEvalSubmissionsTable extends QuickEvalLogging(QuickEvalLocalize(Po
 				:host {
 					display: block;
 				}
-				.d2l-quick-eval-table {
-					--d2l-table-body-background-color: transparent;
-					--d2l-table-light-header-background-color: transparent;
-				}
 				d2l-td {
 					font-size: 0.7rem;
 				}
@@ -152,7 +148,7 @@ class D2LQuickEvalSubmissionsTable extends QuickEvalLogging(QuickEvalLocalize(Po
 			<template is="dom-if" if="[[courseLevel]]">
 				<h2 title="[[courseLevelName]]" class="d2l-quick-eval-submissions-course-name-heading">[[courseLevelName]]</h2>
 			</template>
-			<d2l-table class="d2l-quick-eval-table" type="light" hidden$="[[showLoadingSkeleton]]" aria-describedby$="[[_tableDescriptionId]]" aria-colcount$="[[headerColumns.length]]" aria-rowcount$="[[_data.length]]">
+			<d2l-table type="light" hidden$="[[showLoadingSkeleton]]" aria-describedby$="[[_tableDescriptionId]]" aria-colcount$="[[headerColumns.length]]" aria-rowcount$="[[_data.length]]">
 				<d2l-thead>
 					<d2l-tr>
 						<dom-repeat items="[[headerColumns]]" as="headerColumn">


### PR DESCRIPTION
As part of the Lit migration for `d2l-table`, I'm also simplifying things and removing variables that aren't needed. These two default to "white", and Quick Eval is on a page with a white background anyway, so setting them to transparent isn't necessary.

I've tested this and did not notice any visual change.