### PR TITLE
DE43392 Assignment name cancel dirty-check race condition

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-detail.js
@@ -240,6 +240,20 @@ class AssignmentEditorDetail extends AsyncContainerMixin(SkeletonMixin(SaveStatu
 		await assignment.save();
 	}
 
+	_debounce(debounceJobs, fn, interval) {
+		const isFirstChange = !debounceJobs;
+
+		debounceJobs = Debouncer.debounce(
+			debounceJobs,
+			timeOut.after(interval),
+			() => fn()
+		);
+
+		if (isFirstChange) {
+			debounceJobs.flush();
+		}
+	}
+
 	_onRequestProvider(e) {
 		// Provides orgUnitId for d2l-labs-attachment
 		// https://github.com/Brightspace/attachment/blob/74a66e85f03790aa9f4e6ec5025cd3c62cfb5264/mixins/attachment-mixin.js#L19
@@ -263,25 +277,26 @@ class AssignmentEditorDetail extends AsyncContainerMixin(SkeletonMixin(SaveStatu
 
 	_saveInstructionsOnChange(e) {
 		const instructions = e.detail.content;
-
-		this._debounceJobs.instructions = Debouncer.debounce(
+		this._debounce(
 			this._debounceJobs.instructions,
-			timeOut.after(500),
-			() => this._saveInstructions(instructions)
+			() => this._saveInstructions(instructions),
+			500
 		);
 	}
+
 	_saveName(value) {
 		store.get(this.href).setName(value);
 	}
+
 	_saveNameOnInput(e) {
 		const name = e.target.value;
-
-		this._debounceJobs.name = Debouncer.debounce(
+		this._debounce(
 			this._debounceJobs.name,
-			timeOut.after(500),
-			() => this._saveName(name)
+			() => this._saveName(name),
+			500
 		);
 	}
+
 	_saveOnChange(jobName) {
 		this._debounceJobs[jobName] && this._debounceJobs[jobName].flush();
 	}


### PR DESCRIPTION
Debouncing the name input changes means that the state update could happen _after_ hitting "Cancel" - if the user is fast enough. Fix is to flush the debouncer after the first change.

https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fdefect%2F602484583664