### PR TITLE
US126389/Fix categories dirty check

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-categories-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-categories-editor.js
@@ -128,7 +128,7 @@ class AssignmentCategoriesEditor extends ActivityEditorMixin(ActivityEditorDialo
 			await categoriesStore.save();
 		} else {
 			// reset category to prevent it from saving
-			categoriesStore.setNewCategoryName(null);
+			categoriesStore.setNewCategoryName('');
 		}
 
 		this.handleClose();

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-categories.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-categories.js
@@ -68,12 +68,7 @@ export class AssignmentCategories {
 		}
 
 		if (this.selectedCategoryId) {
-			const initialId = this.selectedCategory && this.selectedCategory.properties.categoryId;
-			const shouldUpdateCategoryId = this.selectedCategoryId !== initialId;
-
-			if (shouldUpdateCategoryId) {
-				data.categoryId = this.selectedCategoryId;
-			}
+			data.categoryId = this.selectedCategoryId;
 		}
 
 		return data;


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F516602039000

Fixed small defect where the modal's input would read "null" if a user reopened the dialog after cancelling also added a small fix for the dirty check logic.