### PR TITLE
Enable fr-on

### DIFF
--- a/components/d2l-activity-card/ActivityCardLocalize.js
+++ b/components/d2l-activity-card/ActivityCardLocalize.js
@@ -8,6 +8,7 @@ import es from './lang/es.js';
 import eses from './lang/es-es.js';
 import fr from './lang/fr.js';
 import frfr from './lang/fr-fr.js';
+import fron from './lang/fr-on.js';
 import ja from './lang/ja.js';
 import ko from './lang/ko.js';
 import nl from './lang/nl.js';
@@ -38,6 +39,7 @@ const ActivityCardImpl = (superClass) => {
 							'es-es': eses,
 							'fr': fr,
 							'fr-fr': frfr,
+							'fr-on': fron,
 							'ja': ja,
 							'ko': ko,
 							'nl': nl,

--- a/components/d2l-activity-collection-editor/localization.js
+++ b/components/d2l-activity-collection-editor/localization.js
@@ -21,6 +21,9 @@ export const LocalizeActivityCollectionEditor = superclass => class extends Loca
 				case 'fr':
 					translations = await import('./lang/fr.js');
 					break;
+				case 'fr-on':
+					translations = await import('./lang/fr-on.js');
+					break;
 				case 'ja':
 					translations = await import('./lang/ja.js');
 					break;

--- a/components/d2l-activity-evaluation-icon/ActivityEvaluationIconBaseLocalize.js
+++ b/components/d2l-activity-evaluation-icon/ActivityEvaluationIconBaseLocalize.js
@@ -8,6 +8,7 @@ import es from './lang/es.js';
 import eses from './lang/es-es.js';
 import fr from './lang/fr.js';
 import frfr from './lang/fr-fr.js';
+import fron from './lang/fr-on.js';
 import ja from './lang/ja.js';
 import ko from './lang/ko.js';
 import nl from './lang/nl.js';
@@ -38,6 +39,7 @@ const ActivityEvaluationIconBaseLocalizeImpl = (superClass) => {
 							'es-es': eses,
 							'fr': fr,
 							'fr-fr': frfr,
+							'fr-on': fron,
 							'ja': ja,
 							'ko': ko,
 							'nl': nl,

--- a/components/d2l-activity-list-item/ActivityListItemLocalize.js
+++ b/components/d2l-activity-list-item/ActivityListItemLocalize.js
@@ -8,6 +8,7 @@ import es from './lang/es.js';
 import eses from './lang/es-es.js';
 import fr from './lang/fr.js';
 import frfr from './lang/fr-fr.js';
+import fron from './lang/fr-on.js';
 import ja from './lang/ja.js';
 import ko from './lang/ko.js';
 import nl from './lang/nl.js';
@@ -38,6 +39,7 @@ const ActivityListItemLocalizeImpl = (superClass) => {
 							'es-es': eses,
 							'fr': fr,
 							'fr-fr': frfr,
+							'fr-on': fron,
 							'ja': ja,
 							'ko': ko,
 							'nl': nl,

--- a/components/d2l-quick-eval-widget/lang/localize-quick-eval-widget.js
+++ b/components/d2l-quick-eval-widget/lang/localize-quick-eval-widget.js
@@ -27,11 +27,14 @@ export const LocalizeQuickEvalWidget = superclass => class extends LocalizeMixin
 				case 'es':
 					translations = await import('./es.js');
 					break;
+				case 'fr':
+					translations = await import('./fr.js');
+					break;
 				case 'fr-fr':
 					translations = await import('./fr-fr.js');
 					break;
-				case 'fr':
-					translations = await import('./fr.js');
+				case 'fr-on':
+					translations = await import('./fr-on.js');
 					break;
 				case 'ja':
 					translations = await import('./ja.js');

--- a/components/d2l-quick-eval/QuickEvalLocalize.js
+++ b/components/d2l-quick-eval/QuickEvalLocalize.js
@@ -8,6 +8,7 @@ import es from './lang/es.js';
 import eses from './lang/es-es.js';
 import fr from './lang/fr.js';
 import frfr from './lang/fr-fr.js';
+import fron from './lang/fr-on.js';
 import ja from './lang/ja.js';
 import ko from './lang/ko.js';
 import nl from './lang/nl.js';
@@ -39,6 +40,7 @@ const QuickEvalLocalizeImpl = (superClass) => {
 							'es-es': eses,
 							'fr': fr,
 							'fr-fr': frfr,
+							'fr-on': fron,
 							'ja': ja,
 							'ko': ko,
 							'nl': nl,
@@ -97,6 +99,9 @@ export const LitQuickEvalLocalize = superclass => class extends LocalizeMixin(su
 					break;
 				case 'fr-fr':
 					translations = frfr;
+					break;
+				case 'fr-on':
+					translations = fron;
 					break;
 				case 'ja':
 					translations = ja;


### PR DESCRIPTION
In https://github.com/BrightspaceHypermediaComponents/activities/pull/1612 I added `fr-on` files for all components in this repo, but I left enabling it up to the teams responsible for each component. I don't think I was very clear about that, so for any components not using the dynamic localization mixin I've manually enabled `fr-on` here. Though I have done a cursory check to make sure the files exist and the correct patterns were followed, 🚨  _I have not tested these_.

Please test these components if your team is responsible for them, or tag someone you know is.

I have no reason to believe any of the affected components required `fr-on` in the May release, or even had any differences from `fr-ca` yet, so I don't see why a hotfix would be necessary, but if you believe it is please let me know.