### PR TITLE
Always await page.hover

### DIFF
--- a/test/d2l-quick-eval/perceptual/d2l-quick-eval-activity-card.visual-diff.js
+++ b/test/d2l-quick-eval/perceptual/d2l-quick-eval-activity-card.visual-diff.js
@@ -33,13 +33,13 @@ describe('d2l-quick-eval-activity-card', function() {
 
 	it ('dismiss', async function() {
 		// The differences between this and the "regular" card is only in the buttons which only appear on hover.
-		page.hover('#dismiss d2l-quick-eval-activity-card');
+		await page.hover('#dismiss d2l-quick-eval-activity-card');
 		const rect = await visualDiff.getRect(page, '#dismiss');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});
 
 	it('hovered', async function() {
-		page.hover('#hovered');
+		await page.hover('#hovered');
 		const rect = await visualDiff.getRect(page, '#hovered');
 		await visualDiff.screenshotAndCompare(page, this.test.fullTitle(), { clip: rect });
 	});
@@ -70,7 +70,7 @@ describe('d2l-quick-eval-activity-card', function() {
 
 	it('dismiss-dropdown-publish-disabled', async function() {
 		await page.setViewport({ width: 900, height: 1900, deviceScaleFactor: 2 });
-		page.hover('#dismiss d2l-quick-eval-activity-card');
+		await page.hover('#dismiss d2l-quick-eval-activity-card');
 		await page.evaluate(() => {
 			return new Promise(resolve => {
 				const card = document.querySelector('#dismiss d2l-quick-eval-activity-card');
@@ -87,7 +87,7 @@ describe('d2l-quick-eval-activity-card', function() {
 
 	it('dismiss-dropdown-publish-enabled', async function() {
 		await page.setViewport({ width: 900, height: 1900, deviceScaleFactor: 2 });
-		page.hover('#dismiss-with-publish d2l-quick-eval-activity-card');
+		await page.hover('#dismiss-with-publish d2l-quick-eval-activity-card');
 		await page.evaluate(() => {
 			return new Promise(resolve => {
 				const dropdown = document.querySelector('#dismiss-with-publish d2l-quick-eval-activity-card')


### PR DESCRIPTION
Fairly certain this is what caused [this run](https://visual-diff.d2l.dev/screenshots/BrightspaceHypermediaComponents/activities/activity-card/2021-05-05-16.20.28.364-90b39eadd3325003ae766c8fadedcd3cf6b28f8d-report.html) to flake.