### PR TITLE
Add dialog to confirm detaching rubrics in FACE

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-controller.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-controller.js
@@ -1,0 +1,18 @@
+import 'd2l-fetch/d2l-fetch.js';
+import 'd2l-polymer-siren-behaviors/store/entity-store.js';
+
+const evalStatusRel = 'https://activities.api.brightspace.com/rels/evaluation-status';
+
+async function fetch(href, token) {
+	return (await window.D2L.Siren.EntityStore.fetch(href, token)).entity;
+}
+
+export async function fetchEvaluationCount(activityUsageEntity, token) {
+
+	const evalStatusLink = activityUsageEntity.getLink(evalStatusRel);
+
+	const evaluationStatusEntity = await fetch(evalStatusLink, token);
+
+	const evaluations = evaluationStatusEntity.properties.evaluated;
+	return evaluations || 0;
+}

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
@@ -139,6 +139,9 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 		if (shouldShowRubric) {
 			const canDeleteAssociation = (association.entity.canDeleteAssociation() || association.isAssociating) && !association.isDeleting;
 
+			const deleteButtonClickedFunc = (e) => this._onDeleteAssociationButtonClicked(e, association);
+			const deleteConfirmDialogClosedFunc = (e) => this._handleConfirmDetachDialogClose(e, association.rubricHref);
+
 			return html`
 			<div class="d2l-association-container">
 				<d2l-rubric
@@ -153,22 +156,17 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 					class="d2l-delete-association-button"
 					icon="tier1:close-default"
 					data-id="${association.rubricHref}"
-					@click="${(e) => { this._onDeleteAssociationButtonClicked(e, association); }}"
+					@click="${deleteButtonClickedFunc}"
 					text=${this.localize('rubrics.txtDeleteRubric')}
 				></d2l-button-icon>
 			</div>
 
-			<d2l-dialog
+			<d2l-dialog-confirm
 				?opened="${this._confirmDetachDialogOpen}"
+				text="${this.localize('rubrics.txtConfirmDetachRubric')}"
 				@d2l-dialog-open="${this._handleConfirmDetachDialogOpen}}"
-				@d2l-dialog-close="${(e) => { this._handleConfirmDetachDialogClose(e, association.rubricHref); }}"
+				@d2l-dialog-close="${deleteConfirmDialogClosedFunc}"
 			>
-				<div class="d2l-detach-rubric-dialog-text">
-					${this.localize('rubrics.txtConfirmDetachRubric')}
-				</div>
-				<div class="d2l-detach-rubric-dialog-text-2">
-					${this.localize('rubrics.txtConfirmDetachRubric2')}
-				</div>
 				<d2l-button
 					slot="footer"
 					primary data-dialog-action="${DELETE_ASSOCIATION_ACTION}"
@@ -182,7 +180,7 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 				>
 					${this.localize('rubrics.btnCancel')}
 				</d2l-button>
-			</d2l-dialog>
+			</d2l-dialog-confirm>
 			`;
 		} else {
 			return html``;

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
@@ -144,7 +144,7 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 				<d2l-rubric
 					class="d2l-association-box"
 					force-compact
-					?detached="${association.isDeleting}"
+					?detached-view="${association.isDeleting}"
 					.href="${association.rubricHref}"
 					.token="${this.token}">
 				</d2l-rubric>

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
@@ -108,6 +108,17 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 		this._confirmDetachDialogOpen = false;
 	}
 
+	_handleConfirmDetachDialogOpen(e) {
+		//Set default keyboard focus to the cancel button
+		const dialog = e.target;
+		console.log(dialog);
+		const closeButton = dialog.querySelector('.detach-rubric-dialog-cancel-button');
+		console.log(closeButton);
+		if(closeButton) {
+			closeButton.focus();
+		}
+	}
+
 	_onDeleteAssociationButtonClicked(e, association) {
 		const associationEntity = association.entity._entity;
 		const activityUsageLink = associationEntity.getSubEntityByClass('activity-usage');
@@ -151,6 +162,7 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 
 			<d2l-dialog
 				?opened="${this._confirmDetachDialogOpen}"
+				@d2l-dialog-open="${this._handleConfirmDetachDialogOpen}}"
 				@d2l-dialog-close="${(e) => { this._handleConfirmDetachDialogClose(e, association.rubricHref); }}"
 			>
 				<div class="detach-rubric-dialog-text">
@@ -159,8 +171,19 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 				<div class="detach-rubric-dialog-text-2">
 					${this.localize('rubrics.txtConfirmDetachRubric2')}
 				</div>
-				<d2l-button slot="footer" primary data-dialog-action="${DELETE_ASSOCIATION_ACTION}">${this.localize('rubrics.btnDetach')}</d2l-button>
-				<d2l-button slot="footer" data-dialog-action>${this.localize('rubrics.btnCancel')}</d2l-button>
+				<d2l-button
+					slot="footer"
+					primary data-dialog-action="${DELETE_ASSOCIATION_ACTION}"
+				>
+					${this.localize('rubrics.btnDetach')}
+				</d2l-button>
+				<d2l-button
+					slot="footer"
+					class="detach-rubric-dialog-cancel-button"
+					data-dialog-action
+				>
+					${this.localize('rubrics.btnCancel')}
+				</d2l-button>
 			</d2l-dialog>
 			`;
 		} else {

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
@@ -1,6 +1,5 @@
 import 'd2l-rubric/d2l-rubric';
 import '@brightspace-ui/core/components/dialog/dialog';
-import '@brightspace-ui/core/components/dialog/dialog-confirm';
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { shared as activityStore } from '../state/activity-store';
@@ -47,6 +46,10 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 				}
 				.d2l-association-box {
 					flex-grow: 1;
+				}
+
+				.detach-rubric-dialog-text {
+					margin-bottom: 1rem;
 				}
 			`
 		];
@@ -128,7 +131,6 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 		if (shouldShowRubric) {
 			const canDeleteAssociation = association.entity.canDeleteAssociation() || association.isAssociating;
 
-			//Add langterm to confirm dialog!
 			return html`
 			<div class="d2l-association-container">
 				<d2l-rubric
@@ -147,14 +149,19 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 				></d2l-button-icon>
 			</div>
 
-			<d2l-dialog-confirm
+			<d2l-dialog
 				?opened="${this._confirmDetachDialogOpen}"
-				text="${this.localize('rubrics.txtConfirmDetachRubric')}"
 				@d2l-dialog-close="${(e) => { this._handleConfirmDetachDialogClose(e, association.rubricHref); }}"
 			>
+				<div class="detach-rubric-dialog-text">
+					${this.localize('rubrics.txtConfirmDetachRubric')}
+				</div>
+				<div class="detach-rubric-dialog-text-2">
+					${this.localize('rubrics.txtConfirmDetachRubric2')}
+				</div>
 				<d2l-button slot="footer" primary data-dialog-action="${DELETE_ASSOCIATION_ACTION}">${this.localize('rubrics.btnDetach')}</d2l-button>
 				<d2l-button slot="footer" data-dialog-action>${this.localize('rubrics.btnCancel')}</d2l-button>
-			</d2l-dialog-confirm>
+			</d2l-dialog>
 			`;
 		} else {
 			return html``;

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
@@ -48,7 +48,7 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 					flex-grow: 1;
 				}
 
-				.detach-rubric-dialog-text {
+				.d2l-detach-rubric-dialog-text {
 					margin-bottom: 1rem;
 				}
 			`
@@ -111,10 +111,8 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 	_handleConfirmDetachDialogOpen(e) {
 		//Set default keyboard focus to the cancel button
 		const dialog = e.target;
-		console.log(dialog);
 		const closeButton = dialog.querySelector('.detach-rubric-dialog-cancel-button');
-		console.log(closeButton);
-		if(closeButton) {
+		if (closeButton) {
 			closeButton.focus();
 		}
 	}
@@ -137,16 +135,16 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 	}
 
 	_renderAssociation(association) {
-		const shouldShowRubric = (association.isAssociated || association.isAssociating)
-			&& !association.isDeleting;
+		const shouldShowRubric = (association.isAssociated || association.isAssociating);
 		if (shouldShowRubric) {
-			const canDeleteAssociation = association.entity.canDeleteAssociation() || association.isAssociating;
+			const canDeleteAssociation = (association.entity.canDeleteAssociation() || association.isAssociating) && !association.isDeleting;
 
 			return html`
 			<div class="d2l-association-container">
 				<d2l-rubric
 					class="d2l-association-box"
 					force-compact
+					?detached="${association.isDeleting}"
 					.href="${association.rubricHref}"
 					.token="${this.token}">
 				</d2l-rubric>
@@ -165,10 +163,10 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 				@d2l-dialog-open="${this._handleConfirmDetachDialogOpen}}"
 				@d2l-dialog-close="${(e) => { this._handleConfirmDetachDialogClose(e, association.rubricHref); }}"
 			>
-				<div class="detach-rubric-dialog-text">
+				<div class="d2l-detach-rubric-dialog-text">
 					${this.localize('rubrics.txtConfirmDetachRubric')}
 				</div>
-				<div class="detach-rubric-dialog-text-2">
+				<div class="d2l-detach-rubric-dialog-text-2">
 					${this.localize('rubrics.txtConfirmDetachRubric2')}
 				</div>
 				<d2l-button

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
@@ -3,18 +3,23 @@ import '@brightspace-ui/core/components/dialog/dialog';
 import '@brightspace-ui/core/components/dialog/dialog-confirm';
 import { css, html } from 'lit-element/lit-element.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
+import { shared as activityStore } from '../state/activity-store';
 import { announce } from '@brightspace-ui/core/helpers/announce.js';
 import { shared as assignmentStore } from '../../d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-store.js';
+import { fetchEvaluationCount } from './d2l-activity-rubrics-list-controller.js';
 import { LocalizeActivityEditorMixin } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import store from './state/association-collection-store';
 
+const DELETE_ASSOCIATION_ACTION = 'delete-association';
+
 class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEditorMixin(RtlMixin((MobxLitElement)))) {
 
 	static get properties() {
 		return {
-			assignmentHref: { type: String }
+			assignmentHref: { type: String },
+			_confirmDetachDialogOpen: { type: Boolean }
 		};
 	}
 
@@ -49,6 +54,7 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 
 	constructor() {
 		super(store);
+		this._confirmDetachDialogOpen = false;
 	}
 
 	render() {
@@ -74,15 +80,46 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 		}
 		await entity.save();
 	}
-	_deleteAssociation(e) {
+
+	_deleteAssociation(e, rubricHref = null) {
 		const entity = store.get(this.href);
 		const assignment = assignmentStore.get(this.assignmentHref);
 
 		if (!entity || !assignment) {
 			return;
 		}
-		entity.deleteAssociation(e.target.dataset.id, assignment);
+
+		rubricHref = rubricHref || e.target.dataset.id;
+		if (!rubricHref) {
+			return;
+		}
+
+		entity.deleteAssociation(rubricHref, assignment);
 		announce(this.localize('rubrics.txtRubricRemoved'));
+	}
+
+	_handleConfirmDetachDialogClose(e, rubricHref) {
+		if (e.detail.action === DELETE_ASSOCIATION_ACTION) {
+			this._deleteAssociation(e, rubricHref);
+		}
+		this._confirmDetachDialogOpen = false;
+	}
+
+	_onDeleteAssociationButtonClicked(e, association) {
+		const associationEntity = association.entity._entity;
+		const activityUsageLink = associationEntity.getSubEntityByClass('activity-usage');
+		const activityUsage = activityStore.get(activityUsageLink.href);
+		const activityUsageEntity = activityUsage._entity._entity;
+
+		fetchEvaluationCount(activityUsageEntity, activityUsageEntity.token).then((evaluationCount) => {
+			const hasAssessments = (evaluationCount > 0);
+			if (!hasAssessments) {
+				this._deleteAssociation(e);
+			}
+			else {
+				this._confirmDetachDialogOpen = true;
+			}
+		});
 	}
 
 	_renderAssociation(association) {
@@ -91,6 +128,7 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 		if (shouldShowRubric) {
 			const canDeleteAssociation = association.entity.canDeleteAssociation() || association.isAssociating;
 
+			//Add langterm to confirm dialog!
 			return html`
 			<div class="d2l-association-container">
 				<d2l-rubric
@@ -104,10 +142,19 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 					class="d2l-delete-association-button"
 					icon="tier1:close-default"
 					data-id="${association.rubricHref}"
-					@click="${this._deleteAssociation}"
+					@click="${(e) => { this._onDeleteAssociationButtonClicked(e, association); }}"
 					text=${this.localize('rubrics.txtDeleteRubric')}
 				></d2l-button-icon>
 			</div>
+
+			<d2l-dialog-confirm
+				?opened="${this._confirmDetachDialogOpen}"
+				text="${this.localize('rubrics.txtConfirmDetachRubric')}"
+				@d2l-dialog-close="${(e) => { this._handleConfirmDetachDialogClose(e, association.rubricHref); }}"
+			>
+				<d2l-button slot="footer" primary data-dialog-action="${DELETE_ASSOCIATION_ACTION}">${this.localize('rubrics.btnDetach')}</d2l-button>
+				<d2l-button slot="footer" data-dialog-action>${this.localize('rubrics.btnCancel')}</d2l-button>
+			</d2l-dialog-confirm>
 			`;
 		} else {
 			return html``;

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -97,8 +97,7 @@ export default {
 	"rubrics.btnClose": "Close", // X button for exiting the create new rubric overlay
 	"rubrics.txtRubricAdded": "Rubric added", // Text for notifying screenreader rubric was added
 	"rubrics.txtRubricRemoved": "Rubric removed", // Text for notifying screenreader rubric was removed
-	"rubrics.txtConfirmDetachRubric": "Once the rubric is detached, all previous assessments of the rubric in this activity will be deleted.", //Text for the dialog to confirm detaching a rubric from an evaluated activity
-	"rubrics.txtConfirmDetachRubric2": "Confirm detaching the rubric?", // Second half of the text for the dialog to confirm detaching an evaluated rubric
+	"rubrics.txtConfirmDetachRubric": "Once the rubric is detached, all previous assessments of the rubric in this activity will be deleted. Confirm detaching the rubric?", //Text for the dialog to confirm detaching a rubric from an evaluated activity
 	"rubrics.defaultScoringRubric": "Default Scoring Rubric", // Sub heading for the default scoring rubric select dropdown
 	"rubrics.noDefaultScoringRubricSelected": "No default selected", // option in default scoring rubric when no default scoring rubric selected
 

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -85,6 +85,7 @@ export default {
 
 	"rubrics.btnAddRubric": "Add rubric", //text for add rubric button
 	"rubrics.btnCreateNew": "Create New", //Text for create new dropdown
+	"rubrics.btnDetach": "Detach", //Text for the button to confirm detaching a rubric
 	"rubrics.btnAddExisting": "Add Existing", //Text for Add Existing dropdown
 	"rubrics.hdrRubrics": "Rubrics", //Header for the rubrics section
 	"rubrics.btnAttachRubric": "Attach Rubric", //Button for the attach new rubric overlay
@@ -96,6 +97,8 @@ export default {
 	"rubrics.btnClose": "Close", // X button for exiting the create new rubric overlay
 	"rubrics.txtRubricAdded": "Rubric added", // Text for notifying screenreader rubric was added
 	"rubrics.txtRubricRemoved": "Rubric removed", // Text for notifying screenreader rubric was removed
+	"rubrics.txtConfirmDetachRubric": "Once the rubric is detached, all previous assessments of the rubric in this activity will be deleted.", //Text for the dialog to confirm detaching a rubric from an evaluated activity
+	"rubrics.txtConfirmDetachRubric2": "Confirm detaching the rubric?", // Second half of the text for the dialog to confirm detaching an evaluated rubric
 	"rubrics.defaultScoringRubric": "Default Scoring Rubric", // Sub heading for the default scoring rubric select dropdown
 	"rubrics.noDefaultScoringRubricSelected": "No default selected", // option in default scoring rubric when no default scoring rubric selected
 


### PR DESCRIPTION
Rally: [US125198](https://rally1.rallydev.com/#/57732444928d/dashboard?detail=%2Fuserstory%2F5022

We want to warn users of FACE using a confirmation dialog if they are about to detach a rubric which has evaluated assessments for the activity, since these assessments will be deleted along with the association.