### PR TITLE
Content module editor: Description field text defaults to "undefined" for new modules

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -56,7 +56,7 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 
 	render() {
 		const moduleEntity = moduleStore.getContentModuleActivity(this.href);
-		let descriptionRichText = undefined;
+		let descriptionRichText = '';
 
 		if (moduleEntity) {
 			this.skeleton = false;

--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -56,7 +56,7 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 
 	render() {
 		const moduleEntity = moduleStore.getContentModuleActivity(this.href);
-		let descriptionRichText = '';
+		let descriptionRichText = undefined;
 
 		if (moduleEntity) {
 			this.skeleton = false;

--- a/components/d2l-activity-editor/d2l-activity-text-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-text-editor.js
@@ -49,7 +49,7 @@ class ActivityTextEditor extends LitElement {
 				import('./d2l-activity-html-new-editor');
 				return html`
 					<d2l-activity-html-new-editor
-						value="${live(this.value)}"
+						.value="${live(this.value)}"
 						ariaLabel="${this.ariaLabel}"
 						?disabled="${this.disabled}"
 						@d2l-activity-html-editor-change="${this._onRichtextChange}"


### PR DESCRIPTION
~~Because of the recent addition of the `live()` [directive on the new-html-editor component in this repo](https://lit-html.polymer-project.org/guide/release-notes/1.2.0.html#live-directive), the initial text was not getting updated from it's initial state of `undefined` to `""`. I'll be honest, I don't understand why not as `live` claims it does a strict equality check to update and so it should be updating. I suspect something is not setup quite right for how some other editors want to update (or not update) their content. This is also only happening for new content which makes this lifecycle all the more confusing.~~

~~This is a bit of a band-aid fix, as we should still be respecting `moduleEntity.descriptionRichText` (which is empty string) but for whatever reason the initial render is passing down that `undefined` and then when we get `""` and pass that down, `live` is rejecting the update.~~

Binding `value` as a property (as it is done for the other editors) seems to make `live` respect these changes.