### PR TITLE
Updating the href on save complete, and awaiting the save of the activity usage

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -28,7 +28,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 		this._debounceJobs = {};
 		this._setEntityType(ContentFileEntity);
 		this.skeleton = true;
-		this.saveOrder = 2000;
+		this.saveOrder = 500;
 	}
 
 	connectedCallback() {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
@@ -60,6 +60,7 @@ class ContentEditor extends LocalizeActivityEditorMixin(RtlMixin(ActivityEditorM
 		super.connectedCallback();
 		// storing onSaveComplete handler in property in order to have 'this' work as expected,
 		// see https://lit.dev/docs/components/events/#understanding-this-in-event-listeners and
+		// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this
 		this.onSaveComplete = ({ detail: { saveInPlace } }) =>
 			(saveInPlace ? this._updateUsageHrefPostCommit() : this._redirectOnSaveComplete());
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-detail.js
@@ -97,7 +97,7 @@ class ContentWebLinkDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandli
 
 		const originalActivityUsageHref = webLinkEntity.activityUsageHref;
 		const updatedEntity = await webLinkEntity.save();
-		const event = new CustomEvent('d2l-content-activity-update', {
+		const event = new CustomEvent('d2l-content-working-copy-committed', {
 			detail: {
 				originalActivityUsageHref: originalActivityUsageHref,
 				updatedActivityUsageHref: updatedEntity.getActivityUsageHref()

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -185,7 +185,6 @@ class ActivityEditor extends ActivityEditorContainerMixin(ActivityEditorTelemetr
 	_onSaveComplete(e) {
 		if (e.detail.saveInPlace) {
 			this._saveToastVisible = true;
-			e.stopPropagation();
 		}
 	}
 

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -64,7 +64,7 @@ export class ActivityUsage extends WorkingCopy {
 
 		await this.scoreAndGrade.primeGradeSave();
 
-		super.save();
+		await super.save();
 	}
 	setAlignmentsHref(value) {
 		this.alignmentsHref = value;


### PR DESCRIPTION
## Relevant Rally Links 

- [DE43265](https://rally1.rallydev.com/#/289692574792d/dashboard?detail=%2Fdefect%2F600684803540&fdp=true?fdp=true): Lessons FACE Weblinks >  Saving a new weblink sometimes causes a 500 error
- [DE43284](https://rally1.rallydev.com/#/289692574792d/dashboard?detail=%2Fdefect%2F600899688384&fdp=true?fdp=true): Lessons FACE Weblinks > Visibility status and dates are not saved when creating a new weblink with working copy enabled



## Description

We want to adjust the save flow for content FACE pages so that on saving a new activity we re-fetch the activity usage if we're not navigating away from the FACE page. 



## Goal/Solution

The solution was to stop the editor from stopping the save complete event propagation and updating the `d2l-activity-content-editor` to handle the in place save complete event and set `this.href` to `this.postCommitHref`, which should have been set when the `d2l-content-working-copy-committed` event was fired. Another change was to add an `await` for the activity usage save so that the save complete event didn't fire before the usage was saved. This was necessary for us to ensure that the usage was updated properly before we re-fetched it. Finally, in order to get these fixes working for content files as well, we had to update the `saveOrder` to 500 so that the content file entity was saved prior to the activity usage.

The impact on other FACE pages should be low, since `d2l-activity-content-editor` seems to be the only editor that ever handled the save complete event, and waiting for the usage to finish saving shouldn't cause any issues either.


## Video/Screenshots

N/A



## Related PRs

- https://github.com/Brightspace/lms/pull/10084 This is the draft PR with most of the backend work we need
- https://github.com/Brightspace/lms/pull/9920 The rest of the backend work is in this PR, and the PR above points to the `compare` branch of this PR



## Remaining Work

N/A