### PR TITLE
FACE HTML file - Add HTML field via new HTML editor

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -1,10 +1,11 @@
 import '../shared-components/d2l-activity-content-editor-title.js';
 import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
 import { ContentFileEntity, FILE_TYPES } from 'siren-sdk/src/activities/content/ContentFileEntity.js';
-import { html, css } from 'lit-element/lit-element.js';
+import { css, html } from 'lit-element/lit-element.js';
 import { activityContentEditorStyles } from '../shared-components/d2l-activity-content-editor-styles.js';
 import { ActivityEditorMixin } from '../../mixins/d2l-activity-editor-mixin.js';
 import { ContentEditorConstants } from '../constants';
+import { shared as contentFileStore } from './state/content-file-store.js';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { ErrorHandlingMixin } from '../../error-handling-mixin.js';
@@ -12,7 +13,6 @@ import { labelStyles } from '@brightspace-ui/core/components/typography/styles.j
 import { LocalizeActivityEditorMixin } from '../../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
-import { shared as contentFileStore } from './state/content-file-store.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingMixin(LocalizeActivityEditorMixin(EntityMixinLit(RtlMixin(ActivityEditorMixin(MobxLitElement))))))) {
@@ -60,9 +60,9 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 		if (contentFileEntity) {
 			this.skeleton = false;
 			pageContent = contentFileEntity.fileContent;
-		
-			if (contentFileEntity.fileType == FILE_TYPES.html) {
-				pageRenderer = this._renderHtmlEditor( pageContent )
+
+			if (contentFileEntity.fileType === FILE_TYPES.html) {
+				pageRenderer = this._renderHtmlEditor(pageContent);
 			}
 		}
 
@@ -143,19 +143,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 		);
 	}
 
-	_savePageContent(pageContent) {
-		const contentFileEntity = contentFileStore.getContentFileActivity(this.href);
-		if (!contentFileEntity) {
-			return;
-		}
-		contentFileEntity.setPageContent(pageContent);
-	}
-
-	_saveOnChange(jobName) {
-		this._debounceJobs[jobName] && this._debounceJobs[jobName].flush();
-	}
-
-	_renderHtmlEditor( pageContent ) {
+	_renderHtmlEditor(pageContent) {
 		const newEditorEvent = new CustomEvent('d2l-request-provider', {
 			detail: { key: 'd2l-provider-html-new-editor-enabled' },
 			bubbles: true,
@@ -182,7 +170,19 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 					full-page-font-size="12pt"
 				>
 				</d2l-activity-text-editor>
-			</div>`
+			</div>`;
+	}
+
+	_saveOnChange(jobName) {
+		this._debounceJobs[jobName] && this._debounceJobs[jobName].flush();
+	}
+
+	_savePageContent(pageContent) {
+		const contentFileEntity = contentFileStore.getContentFileActivity(this.href);
+		if (!contentFileEntity) {
+			return;
+		}
+		contentFileEntity.setPageContent(pageContent);
 	}
 }
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -104,7 +104,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 
 		const originalActivityUsageHref = contentFileActivity.activityUsageHref;
 		const updatedEntity = await contentFileActivity.save();
-		const event = new CustomEvent('d2l-content-activity-update', {
+		const event = new CustomEvent('d2l-content-working-copy-committed', {
 			detail: {
 				originalActivityUsageHref: originalActivityUsageHref,
 				updatedActivityUsageHref: updatedEntity.getActivityUsageHref()

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -50,8 +50,10 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 			this.skeleton = false;
 			pageContent = contentFileEntity.fileContent;
 
-			if (contentFileEntity.fileType === FILE_TYPES.html) {
-				pageRenderer = this._renderHtmlEditor(pageContent);
+			switch (contentFileEntity.fileType) {
+				case FILE_TYPES.html:
+					pageRenderer = this._renderHtmlEditor(pageContent);
+					break;
 			}
 		}
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -1,18 +1,18 @@
 import '../shared-components/d2l-activity-content-editor-title.js';
-import { AsyncContainerMixin } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
+import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
+import { ContentFileEntity, FILE_TYPES } from 'siren-sdk/src/activities/content/ContentFileEntity.js';
+import { html, css } from 'lit-element/lit-element.js';
 import { activityContentEditorStyles } from '../shared-components/d2l-activity-content-editor-styles.js';
 import { ActivityEditorMixin } from '../../mixins/d2l-activity-editor-mixin.js';
 import { ContentEditorConstants } from '../constants';
-import { ContentFileEntity, FILE_TYPES } from 'siren-sdk/src/activities/content/ContentFileEntity.js';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
-import { shared as contentFileStore } from './state/content-file-store.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { ErrorHandlingMixin } from '../../error-handling-mixin.js';
-import { html, css } from 'lit-element/lit-element.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeActivityEditorMixin } from '../../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
+import { shared as contentFileStore } from './state/content-file-store.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingMixin(LocalizeActivityEditorMixin(EntityMixinLit(RtlMixin(ActivityEditorMixin(MobxLitElement))))))) {
@@ -60,7 +60,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 		if (contentFileEntity) {
 			this.skeleton = false;
 			pageContent = contentFileEntity.fileContent;
-			
+		
 			if (contentFileEntity.fileType == FILE_TYPES.html) {
 				pageRenderer = this._renderHtmlEditor( pageContent )
 			}
@@ -77,6 +77,12 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 				${pageRenderer}
 			</div>
 		`;
+	}
+
+	updated(changedProperties) {
+		if (changedProperties.has('asyncState')) {
+			this.skeleton = this.asyncState !== asyncStates.complete;
+		}
 	}
 
 	async cancelCreate() {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -16,6 +16,7 @@ import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
+
 class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingMixin(LocalizeActivityEditorMixin(EntityMixinLit(RtlMixin(ActivityEditorMixin(MobxLitElement))))))) {
 
 	static get styles() {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -1,5 +1,5 @@
 import '../shared-components/d2l-activity-content-editor-title.js';
-import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
+import { AsyncContainerMixin } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
 import { activityContentEditorStyles } from '../shared-components/d2l-activity-content-editor-styles.js';
 import { ActivityEditorMixin } from '../../mixins/d2l-activity-editor-mixin.js';
 import { ContentEditorConstants } from '../constants';

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -1,14 +1,15 @@
 import '../shared-components/d2l-activity-content-editor-title.js';
 import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
 import { ContentFileEntity, FILE_TYPES } from 'siren-sdk/src/activities/content/ContentFileEntity.js';
-import { css, html } from 'lit-element/lit-element.js';
 import { activityContentEditorStyles } from '../shared-components/d2l-activity-content-editor-styles.js';
 import { ActivityEditorMixin } from '../../mixins/d2l-activity-editor-mixin.js';
+import { activityHtmlEditorStyles } from '../shared-components/d2l-activity-html-editor-styles.js';
 import { ContentEditorConstants } from '../constants';
 import { shared as contentFileStore } from './state/content-file-store.js';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { ErrorHandlingMixin } from '../../error-handling-mixin.js';
+import { html } from 'lit-element/lit-element.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeActivityEditorMixin } from '../../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
@@ -22,20 +23,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 			super.styles,
 			labelStyles,
 			activityContentEditorStyles,
-			css`
-				.d2l-activity-label-container {
-					margin-bottom: 7px;
-				}
-				.d2l-new-html-editor-container {
-					flex: 1;
-					min-height: 300px;
-				}
-				#content-page-content-container {
-					display: flex;
-					flex-direction: column;
-					height: inherit;
-				}
-			`
+			activityHtmlEditorStyles
 		];
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
@@ -15,7 +15,7 @@ export class ContentFile {
 		this.token = token;
 		this.title = '';
 		this.activityUsageHref = '';
-		this.fileContent = null;
+		this.fileContent = '';
 		this.fileType = null;
 	}
 
@@ -35,11 +35,13 @@ export class ContentFile {
 
 			entity = await this._checkout(entity);
 
-			if(!this._isNewFile(entity)) {
+			if(!this._isNewFile(entity) && entity.getFileType() === FILE_TYPES.html) {
 				const fileEntityHref = await fetchEntity(entity.getFileHref(), this.token);
 				const fileEntity = new FileEntity(fileEntityHref, this.token, { remove: () => { } });
 				const fileContentFetchResponse = await fetch(fileEntity.getFileLocationHref()); 
-				fileContent = await fileContentFetchResponse.text();
+				if (fileContentFetchResponse.ok) {
+					fileContent = await fileContentFetchResponse.text();
+				}
 			}
 
 			this.load(entity, fileContent);
@@ -47,7 +49,7 @@ export class ContentFile {
 		return this;
 	}
 
-	load(contentFileEntity, fileContent = null) {
+	load(contentFileEntity, fileContent) {
 		this._contentFile = contentFileEntity;
 		this.href = contentFileEntity.self();
 		this.activityUsageHref = contentFileEntity.getActivityUsageHref();

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
@@ -20,11 +20,11 @@ export class ContentFile {
 	}
 
 	async cancelCreate() {
-		await this._contentFile.deleteFile();
+		await this._contentFileEntity.deleteFile();
 	}
 
 	get dirty() {
-		return !this._contentFile.equals(this._makeContentFileData());
+		return !this._contentFileEntity.equals(this._makeContentFileData());
 	}
 
 	async fetch() {
@@ -35,6 +35,7 @@ export class ContentFile {
 
 			entity = await this._checkout(entity);
 
+			// TODO: This will have to change once the BE changes (US128070)
 			if (!this._isNewFile(entity) && entity.getFileType() === FILE_TYPES.html) {
 				const fileEntityHref = await fetchEntity(entity.getFileHref(), this.token);
 				const fileEntity = new FileEntity(fileEntityHref, this.token, { remove: () => { } });
@@ -50,7 +51,7 @@ export class ContentFile {
 	}
 
 	load(contentFileEntity, fileContent) {
-		this._contentFile = contentFileEntity;
+		this._contentFileEntity = contentFileEntity;
 		this.href = contentFileEntity.self();
 		this.activityUsageHref = contentFileEntity.getActivityUsageHref();
 		this.title = contentFileEntity.title();
@@ -60,21 +61,21 @@ export class ContentFile {
 	}
 
 	async save() {
-		if (!this._contentFile) {
+		if (!this._contentFileEntity) {
 			return;
 		}
 
-		await this._contentFile.setFileTitle(this.title);
+		await this._contentFileEntity.setFileTitle(this.title);
 
-		if (this._contentFile.getFileType() === FILE_TYPES.html) {
-			const htmlEntity = new ContentHtmlFileEntity(this._contentFile, this.token, { remove: () => { } });
+		if (this._contentFileEntity.getFileType() === FILE_TYPES.html) {
+			const htmlEntity = new ContentHtmlFileEntity(this._contentFileEntity, this.token, { remove: () => { } });
 			await htmlEntity.setHtmlFileHtmlContent(this.htmlContent);
 		}
 
-		const committedContentFileEntity = await this._commit(this._contentFile);
+		const committedContentFileEntity = await this._commit(this._contentFileEntity);
 		const editableContentFileEntity = await this._checkout(committedContentFileEntity);
 		this.load(editableContentFileEntity);
-		return this._contentFile;
+		return this._contentFileEntity;
 	}
 
 	setPageContent(pageContent) {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
@@ -1,8 +1,8 @@
 import { action, configure as configureMobx, decorate, observable } from 'mobx';
 import { ContentFileEntity, FILE_TYPES } from 'siren-sdk/src/activities/content/ContentFileEntity.js';
 import { ContentHtmlFileEntity } from 'siren-sdk/src/activities/content/ContentHtmlFileEntity.js';
-import { FileEntity } from 'siren-sdk/src/files/FileEntity.js';
 import { fetchEntity } from '../../../state/fetch-entity.js';
+import { FileEntity } from 'siren-sdk/src/files/FileEntity.js';
 // TODO: Explore idea of using this shared WorkingCopy
 // import { WorkingCopy } from '../../../state/working-copy.js';
 
@@ -35,10 +35,10 @@ export class ContentFile {
 
 			entity = await this._checkout(entity);
 
-			if(!this._isNewFile(entity) && entity.getFileType() === FILE_TYPES.html) {
+			if (!this._isNewFile(entity) && entity.getFileType() === FILE_TYPES.html) {
 				const fileEntityHref = await fetchEntity(entity.getFileHref(), this.token);
 				const fileEntity = new FileEntity(fileEntityHref, this.token, { remove: () => { } });
-				const fileContentFetchResponse = await fetch(fileEntity.getFileLocationHref()); 
+				const fileContentFetchResponse = await fetch(fileEntity.getFileLocationHref());
 				if (fileContentFetchResponse.ok) {
 					fileContent = await fileContentFetchResponse.text();
 				}
@@ -64,9 +64,9 @@ export class ContentFile {
 		}
 
 		await this._contentFile.setFileTitle(this.title);
-		
+
 		if (this._contentFile.getFileType() === FILE_TYPES.html) {
-			let htmlEntity = new ContentHtmlFileEntity(this._contentFile, this.token, { remove: () => { } });
+			const htmlEntity = new ContentHtmlFileEntity(this._contentFile, this.token, { remove: () => { } });
 			await htmlEntity.setHtmlFileHtmlContent(this.htmlContent);
 		}
 
@@ -76,19 +76,14 @@ export class ContentFile {
 		return this._contentFile;
 	}
 
-	setTitle(value) {
-		this.title = value;
-	}
-
 	setPageContent(pageContent) {
 		this.htmlContent = pageContent;
 	}
 
-	_isNewFile(entity) {
-		let url = new URL(entity.self());
-		return url.pathname.includes('-1');
+	setTitle(value) {
+		this.title = value;
 	}
-	
+
 	async _checkout(contentFileEntity) {
 		if (!contentFileEntity) {
 			return;
@@ -98,7 +93,7 @@ export class ContentFile {
 		if (!sirenEntity) {
 			return contentFileEntity;
 		}
-		
+
 		return new ContentFileEntity(sirenEntity, this.token, { remove: () => { } });
 	}
 
@@ -111,8 +106,13 @@ export class ContentFile {
 		if (!sirenEntity) {
 			return contentFileEntity;
 		}
-		
+
 		return new ContentFileEntity(sirenEntity, this.token, { remove: () => { } });
+	}
+
+	_isNewFile(entity) {
+		const url = new URL(entity.self());
+		return url.pathname.includes('-1');
 	}
 
 	_makeContentFileData() {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
@@ -23,7 +23,7 @@ class ContentEditorDetail extends MobxLitElement {
 				d2l-loading-spinner {
 					width: 100%;
 				}
-				d2l-activity-content-module-detail {
+				d2l-activity-content-module-detail, d2l-activity-content-file-detail {
 					display: flex;
 					flex-direction: column;
 					height: inherit;

--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -1,14 +1,15 @@
 import '../shared-components/d2l-activity-content-editor-title.js';
 import '../../d2l-activity-text-editor.js';
 import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
-import { css, html } from 'lit-element/lit-element.js';
 import { activityContentEditorStyles } from '../shared-components/d2l-activity-content-editor-styles.js';
 import { ActivityEditorMixin } from '../../mixins/d2l-activity-editor-mixin.js';
+import { activityHtmlEditorStyles } from '../shared-components/d2l-activity-html-editor-styles.js';
 import { ContentEditorConstants } from '../constants';
 import { ContentModuleEntity } from 'siren-sdk/src/activities/content/ContentModuleEntity.js';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { ErrorHandlingMixin } from '../../error-handling-mixin.js';
+import { html } from 'lit-element/lit-element.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeActivityEditorMixin } from '../../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
@@ -24,20 +25,7 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 			super.styles,
 			labelStyles,
 			activityContentEditorStyles,
-			css`
-				.d2l-activity-label-container {
-					margin-bottom: 7px;
-				}
-				.d2l-new-html-editor-container {
-					flex: 1;
-					min-height: 300px;
-				}
-				#content-description-container {
-					display: flex;
-					flex-direction: column;
-					height: inherit;
-				}
-			`
+			activityHtmlEditorStyles
 		];
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-html-editor-styles.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-html-editor-styles.js
@@ -1,0 +1,16 @@
+import { css } from 'lit-element/lit-element.js';
+
+export const activityHtmlEditorStyles = css`
+	.d2l-activity-label-container {
+		margin-bottom: 7px;
+	}
+	.d2l-new-html-editor-container {
+		flex: 1;
+		min-height: 300px;
+	}
+	#content-page-content-container {
+		display: flex;
+		flex-direction: column;
+		height: inherit;
+	}
+`;

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -127,6 +127,7 @@ export default {
 	"content.name": "Name", // Text label for name input field
 	"content.emptyNameField": "Name is required.", // Error text that appears below name field when it is left empty
 	"content.description": "Description", // Text label for description input field
+	"content.pageContent": "Page Content", // Text label for page content input field (HTML files)
 	"content.availabilityHeader": "Availability Dates", // availability header
 	"content.saveError": "Your content item wasn't saved. Please correct the fields outlined in red.", // Error message to inform the user that there was a problem saving the content item, instructing them to correct invalid fields
 	"content.addDueDate": "Add Due Date", // Text label for name input field


### PR DESCRIPTION
Co-authored-by: @brissons

## Relevant Rally Links 

- https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F393033401500

## Description

The FACE HTML File Create/Edit pages are required to have an HTML Editor for the user to edit content.

## Goal/Solution

This PR adds and hooks up the HTML Editor (Whether old editor vs. new/TinyMCE one is rendered is determined based on WYISWYG.NewEditor Config Variable). The hookup part of the code ensures loading of HTML content, Saving as well as Save and Close function properly.

## Video/Screenshots

![Demo](https://user-images.githubusercontent.com/29843252/117696411-e3c4ed80-b186-11eb-9732-c6fbc620d354.gif)

## Related PRs

- https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/320

