### PR TITLE
DE43452 Content files incorrectly marked as dirty

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
@@ -35,6 +35,7 @@ export class ContentFile {
 	load(contentFileEntity) {
 		this._contentFile = contentFileEntity;
 		this.title = contentFileEntity.title();
+		this.fileHref = contentFileEntity.getFileHref();
 	}
 
 	async save() {
@@ -82,6 +83,7 @@ export class ContentFile {
 		*/
 		return {
 			title: this.title,
+			fileHref: this.fileHref,
 		};
 	}
 }

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
@@ -91,6 +91,7 @@ export class ContentFile {
 decorate(ContentFile, {
 	// props
 	title: observable,
+	fileHref: observable,
 	// actions
 	load: action,
 	setTitle: action,


### PR DESCRIPTION
## Relevant Rally Links 

- [DE43452](https://rally1.rallydev.com/#/289692574792d/dashboard?detail=%2Fdefect%2F603408374512&fdp=true?fdp=true): FACE HTML/Files > Clicking Back/Cancel on unmodified files causes "Discard changes?" warning to popup



## Description

The Siren SDK `equals` implementation checks title and file href currently, but here we only include the title when making the object for comparison. The file href should never change for now, but eventually we will implement replace file functionality in which it will change. This is not HTML file specific.



## Goal/Solution

The solution was to add the file href to the object being built for comparison. I chose this solution over the alternative of removing it from the equals check in the Siren SDK because eventually we will add the ability to replace the file (for all non-HTML file types) and this will lead to there being a different file href.

I'm definitely open to going with the alternative solution where we modify the `equals` implementation in the Siren SDK if the rest of the team prefers it, but I think it makes sense that we make this change since the file href is a changeable property that we'd ideally want to keep track of, even if we're not changing it yet.



## Video/Screenshots
Before:
![popup_not_working](https://user-images.githubusercontent.com/64805612/117885336-bc038180-b27b-11eb-9fdb-165081d83f84.gif)

After:
![popup_working](https://user-images.githubusercontent.com/64805612/117885148-7b0b6d00-b27b-11eb-8d9d-8851c166ab02.gif)


## Related PRs

N/A



## Remaining Work

N/A