### PR TITLE
Added logic to clear category on cancel

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-categories-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-categories-editor.js
@@ -91,6 +91,13 @@ class AssignmentCategoriesEditor extends ActivityEditorMixin(ActivityEditorDialo
 		`;
 	}
 
+	cancelChanges() {
+		const categoriesStore = store.get(this.href);
+		if (!categoriesStore) return;
+
+		categoriesStore.reset();
+	}
+
 	hasPendingChanges() {
 		const categoriesStore = store.get(this.href);
 		if (!categoriesStore) return;
@@ -125,10 +132,12 @@ class AssignmentCategoriesEditor extends ActivityEditorMixin(ActivityEditorDialo
 		if (!categoriesStore) return;
 
 		if (e && e.detail && e.detail.action === 'save') {
+
+			categoriesStore.setSelectedCategory(null); // explicitly set to null in case it was previously set
 			await categoriesStore.save();
+
 		} else {
-			// reset category to prevent it from saving
-			categoriesStore.setNewCategoryName('');
+			categoriesStore.setNewCategoryName(''); // reset category to prevent it from saving
 		}
 
 		this.handleClose();

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-categories.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-categories.js
@@ -30,9 +30,18 @@ export class AssignmentCategories {
 		this.canEditCategories = entity.canEditCategories();
 		this.canAddCategories = entity.canAddCategories();
 		this.selectedCategory = entity.getSelectedCategory();
+		this.initialCategory = this.initialCategory || this.selectedCategory;
 		this.selectedCategoryName = this.selectedCategory && this.selectedCategory.properties.name;
 		this.selectedCategoryId = this.selectedCategory && this.selectedCategory.properties.categoryId;
 		this.newCategoryName = '';
+	}
+
+	async reset() {
+		if (!this._entity) {
+			return;
+		}
+
+		this.initialCategory && await this._entity.save({ categoryId: this.initialCategory.properties.categoryId });
 	}
 
 	async save() {


### PR DESCRIPTION
https://trello.com/c/Mbb5PkHC/377-assignment-aligned-to-new-category-even-on-cancel

Joseph requested a change to categories behaviour so that when a new category is created it will not be aligned to an assignment if a user then cancels the assignment. Instead it will just live in an orphan state in the db.