### PR TITLE
fix: NVDA reads rubric detachment confirmation buttons instead of dialog text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ package-lock.json
 /test/**/screenshots/golden/
 .DS_Store
 debug.log
+.vs
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,3 @@ package-lock.json
 /test/**/screenshots/golden/
 .DS_Store
 debug.log
-.vs
-.vscode

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
@@ -108,10 +108,6 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 		this._confirmDetachDialogOpen = false;
 	}
 
-	_handleConfirmDetachDialogOpen() {
-		// stub (use autofocus from dialog-mixin)
-	}
-
 	_onDeleteAssociationButtonClicked(e, association) {
 		const associationEntity = association.entity._entity;
 		const activityUsageLink = associationEntity.getSubEntityByClass('activity-usage');
@@ -159,7 +155,6 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 			<d2l-dialog-confirm
 				?opened="${this._confirmDetachDialogOpen}"
 				text="${this.localize('rubrics.txtConfirmDetachRubric')}"
-				@d2l-dialog-open="${this._handleConfirmDetachDialogOpen}"
 				@d2l-dialog-close="${deleteConfirmDialogClosedFunc}"
 			>
 				<d2l-button
@@ -170,6 +165,7 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 				</d2l-button>
 				<d2l-button
 					slot="footer"
+					class="detach-rubric-dialog-cancel-button"
 					data-dialog-action
 				>
 					${this.localize('rubrics.btnCancel')}

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
@@ -108,15 +108,6 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 		this._confirmDetachDialogOpen = false;
 	}
 
-	_handleConfirmDetachDialogOpen(e) {
-		//Set default keyboard focus to the cancel button
-		const dialog = e.target;
-		const closeButton = dialog.querySelector('.detach-rubric-dialog-cancel-button');
-		if (closeButton) {
-			closeButton.focus();
-		}
-	}
-
 	_onDeleteAssociationButtonClicked(e, association) {
 		const associationEntity = association.entity._entity;
 		const activityUsageLink = associationEntity.getSubEntityByClass('activity-usage');
@@ -159,28 +150,27 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 					@click="${deleteButtonClickedFunc}"
 					text=${this.localize('rubrics.txtDeleteRubric')}
 				></d2l-button-icon>
-			</div>
 
-			<d2l-dialog-confirm
-				?opened="${this._confirmDetachDialogOpen}"
-				text="${this.localize('rubrics.txtConfirmDetachRubric')}"
-				@d2l-dialog-open="${this._handleConfirmDetachDialogOpen}}"
-				@d2l-dialog-close="${deleteConfirmDialogClosedFunc}"
-			>
-				<d2l-button
-					slot="footer"
-					primary data-dialog-action="${DELETE_ASSOCIATION_ACTION}"
+				<d2l-dialog-confirm
+					text="${this.localize('rubrics.detachRubricQuestion')}"
+					?opened="${this._confirmDetachDialogOpen}"
+					@d2l-dialog-close="${deleteConfirmDialogClosedFunc}"
 				>
-					${this.localize('rubrics.btnDetach')}
-				</d2l-button>
-				<d2l-button
-					slot="footer"
-					class="detach-rubric-dialog-cancel-button"
-					data-dialog-action
-				>
-					${this.localize('rubrics.btnCancel')}
-				</d2l-button>
-			</d2l-dialog-confirm>
+					<d2l-button
+						slot="footer"
+						primary data-dialog-action="${DELETE_ASSOCIATION_ACTION}"
+					>
+						${this.localize('rubrics.btnDetach')}
+					</d2l-button>
+					<d2l-button
+						slot="footer"
+						data-dialog-action
+						autofocus
+					>
+						${this.localize('rubrics.btnCancel')}
+					</d2l-button>
+				</d2l-dialog-confirm>
+			</div>
 			`;
 		} else {
 			return html``;

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
@@ -150,27 +150,26 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 					@click="${deleteButtonClickedFunc}"
 					text=${this.localize('rubrics.txtDeleteRubric')}
 				></d2l-button-icon>
-
-				<d2l-dialog-confirm
-					text="${this.localize('rubrics.detachRubricQuestion')}"
-					?opened="${this._confirmDetachDialogOpen}"
-					@d2l-dialog-close="${deleteConfirmDialogClosedFunc}"
-				>
-					<d2l-button
-						slot="footer"
-						primary data-dialog-action="${DELETE_ASSOCIATION_ACTION}"
-					>
-						${this.localize('rubrics.btnDetach')}
-					</d2l-button>
-					<d2l-button
-						slot="footer"
-						data-dialog-action
-						autofocus
-					>
-						${this.localize('rubrics.btnCancel')}
-					</d2l-button>
-				</d2l-dialog-confirm>
 			</div>
+
+			<d2l-dialog-confirm
+				text="${this.localize('rubrics.detachRubricQuestion')}"
+				?opened="${this._confirmDetachDialogOpen}"
+				@d2l-dialog-close="${deleteConfirmDialogClosedFunc}"
+			>
+				<d2l-button
+					slot="footer"
+					primary data-dialog-action="${DELETE_ASSOCIATION_ACTION}"
+				>
+					${this.localize('rubrics.btnDetach')}
+				</d2l-button>
+				<d2l-button
+					slot="footer"
+					data-dialog-action
+				>
+					${this.localize('rubrics.btnCancel')}
+				</d2l-button>
+			</d2l-dialog-confirm>
 			`;
 		} else {
 			return html``;


### PR DESCRIPTION
Rally: [US125198](https://rally1.rallydev.com/#/57732444928d/dashboard?detail=%2Fuserstory%2F502279656304)

On the FACE page rubric detachment dialog, NVDA consistently reads out "clickable Cancel button" instead of the dialog text.

This behavior is a symptom of a greater issue with the dialog component, which was addressed(?) in [BrightspaceUI/core#1330](https://github.com/BrightspaceUI/core/pull/1330), so this PR just bumps the UI core version to reflect the changes to the focus behavior.