### PR TITLE
Added a reset to initial category on save

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-categories.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-categories.js
@@ -57,6 +57,8 @@ export class AssignmentCategories {
 		await this._saving;
 		this._saving = null;
 
+		this._resetInitalCategory();
+
 		await this.fetch(true);
 	}
 
@@ -81,6 +83,10 @@ export class AssignmentCategories {
 		}
 
 		return data;
+	}
+
+	_resetInitalCategory() {
+		this.initialCategory = null;
 	}
 }
 


### PR DESCRIPTION
https://trello.com/c/Mbb5PkHC/377-assignment-aligned-to-new-category-even-on-cancel

For this to work correctly we need to reset the initial category on save otherwise it will reset weirdly if a user saves in place followed by a cancel.