### PR TITLE
US128071 - don't load file entity if there's no link

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
@@ -35,10 +35,10 @@ export class ContentFile {
 
 			entity = await this._checkout(entity);
 
-			// TODO: This will have to change once the BE changes (US128070)
-			if (!this._isNewFile(entity) && entity.getFileType() === FILE_TYPES.html) {
-				const fileEntityHref = await fetchEntity(entity.getFileHref(), this.token);
-				const fileEntity = new FileEntity(fileEntityHref, this.token, { remove: () => { } });
+			const fileEntityHref = entity.getFileHref();
+			if (entity.getFileType() === FILE_TYPES.html && fileEntityHref) {
+				const fileEntityResponse = await fetchEntity(fileEntityHref, this.token);
+				const fileEntity = new FileEntity(fileEntityResponse, this.token, { remove: () => { } });
 				const fileContentFetchResponse = await fetch(fileEntity.getFileLocationHref());
 				if (fileContentFetchResponse.ok) {
 					fileContent = await fileContentFetchResponse.text();
@@ -110,11 +110,6 @@ export class ContentFile {
 		}
 
 		return new ContentFileEntity(sirenEntity, this.token, { remove: () => { } });
-	}
-
-	_isNewFile(entity) {
-		const url = new URL(entity.self());
-		return url.pathname.includes('-1');
 	}
 
 	_makeContentFileData() {


### PR DESCRIPTION
## Relevant Rally Links 

- [US128071](https://rally1.rallydev.com/#/289692574792d/dashboard?detail=%2Fuserstory%2F604152072952&fdp=true?fdp=true): (FE) FACE HTML file - Don't load file usage link if not present, change where to check for type



## Description

To handle the fact that we don't want to have a file entity usage link when the file activity is new, we have removed the link from the entity response when it's a new entity. The goal is to update FACE to check if there is a file entity usage link before trying to load it, rather than checking the URL to determine if it's a new activity.



## Goal/Solution

The solution here is just to get the `fileEntityHref` and check if it has a value before proceeding to load its content.



## Video/Screenshots

N/A



## Related PRs

- https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/323 the SDK PR needs to be merged first



## Remaining Work

- In the future we will want to factor out this HTML specific stuff from the generic component. We have a story for that [here in US128197](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F604631601020)