### PR TITLE
Remove unnecessary savehref logic from content editor

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
@@ -157,18 +157,9 @@ class ContentEditor extends LocalizeActivityEditorMixin(RtlMixin(ActivityEditorM
 	}
 
 	_redirectOnSaveComplete() {
-		let redirectLocation = this.saveHref;
-		store.fetchContentActivity(this.href, this.token)
-			.then((contentActivity) => {
-				if (contentActivity && contentActivity.lessonViewPageHref) {
-					redirectLocation = contentActivity.lessonViewPageHref;
-				}
-			})
-			.finally(() => {
-				if (redirectLocation) {
-					window.location.href = redirectLocation;
-				}
-			});
+		if (this.saveHref) {
+			window.location.href = this.saveHref;
+		}
 	}
 
 	_updateUsageHrefPostCommit() {


### PR DESCRIPTION
## Description
​
When saving and closing a new weblink the actvities repo navigates you to a 404 page in lessons
​
## Goal/Solution

So we originally tried to solve this one way by including the updated `lessonViewPageHref` on the activity-usage which gets fetched after committing the weblink, therefore having a 'proper' lessons URL with the newly saved topic id. Unfortunately do to async timing things that isn't super reliable. However in the meantime we also added in a bunch of logic in the LMS to track the persisted topic id against the original 'fake' activity usage, and so we were able to solve this LMS side via [this commit](https://github.com/Brightspace/lms/pull/10084/commits/cf2414010c141add93003294023145bd8e24d4ee#diff-997906e087c0689fbc237e3c896114462d24bea5e982ea408d75da08c68a78a9R227).
​
Anywho, that makes this code actually problematic due to the timing issues, and unnecessary, so we can fix the 404 by just removing the unnecessary logic and navigating to the originally provided `saveHref`.

## Video/Screenshots
​
Before:
![404-before-fix](https://user-images.githubusercontent.com/2243995/118286684-53452080-b498-11eb-9eff-c6a2f797f1d3.gif)

After:
![404-after-fix](https://user-images.githubusercontent.com/2243995/118287272-ea11dd00-b498-11eb-8ec4-60e8f12645ad.gif)

​
## Remaining Work

n/a
​​
## Relevant Rally Links 

[DE43566](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F604759636596&fdp=true?fdp=true): Lessons FACE working copy > saving a new weblink/HTML topic results in a 404