### PR TITLE
DE43500: Use file data endpoint when editing html files

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
@@ -39,7 +39,7 @@ export class ContentFile {
 			if (entity.getFileType() === FILE_TYPES.html && fileEntityHref) {
 				const fileEntityResponse = await fetchEntity(fileEntityHref, this.token);
 				const fileEntity = new FileEntity(fileEntityResponse, this.token, { remove: () => { } });
-				const fileContentFetchResponse = await fetch(fileEntity.getFileLocationHref());
+				const fileContentFetchResponse = await window.d2lfetch.fetch(fileEntity.getFileDataLocationHref());
 				if (fileContentFetchResponse.ok) {
 					fileContent = await fileContentFetchResponse.text();
 				}


### PR DESCRIPTION
## Relevant Rally Links 

[DE43500](https://rally1.rallydev.com/#/289692574792/custom/355050439968?detail=%2Fdefect%2F603973776280&fdp=true): FACE HTML > Head scripts are duplicated when saving html files

## Description

When editing an html file, the endpoint we were using was attaching head scripts to the file, which would show up in the html editor. If a user edited and saved, these scripts would also be saved in the file, resulting in duplicate scripts.

## Goal/Solution

Calling the raw data endpoint will make it so that only the raw html file data will show up in the editor.

## Video/Screenshots
Before:
![beforehtml](https://user-images.githubusercontent.com/52549862/118665834-4423e280-b7b8-11eb-89db-ce40d4c27bb1.gif)

After:
![afterhtml](https://user-images.githubusercontent.com/52549862/118665631-10e15380-b7b8-11eb-9554-71474d54dd80.gif)


## Related PRs

- https://github.com/Brightspace/lms/pull/10645
- https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/324