### PR TITLE
Default to font families in Content editors

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -159,7 +159,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 					html-editor-height="100%"
 					full-page
 					full-page-font-size="12pt"
-					full-page-font-family="Lato"
+					full-page-font-family="Verdana"
 				>
 				</d2l-activity-text-editor>
 			</div>`;

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -159,6 +159,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 					html-editor-height="100%"
 					full-page
 					full-page-font-size="12pt"
+					full-page-font-family="Lato"
 				>
 				</d2l-activity-text-editor>
 			</div>`;

--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -81,7 +81,7 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 						html-editor-height="100%"
 						full-page
 						full-page-font-size="12pt"
-						full-page-font-family="Verdana"
+						full-page-font-family="Lato"
 					>
 					</d2l-activity-text-editor>
 				</div>

--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -81,6 +81,7 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 						html-editor-height="100%"
 						full-page
 						full-page-font-size="12pt"
+						full-page-font-family="Verdana"
 					>
 					</d2l-activity-text-editor>
 				</div>

--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -15,7 +15,8 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 			_filesToReplace: { type: Object },
 			htmlEditorHeight: { type: String, attribute: 'html-editor-height' },
 			fullPage: { type: Boolean, attribute: 'full-page' },
-			fullPageFontSize: { type: String, attribute: 'full-page-font-size' }
+			fullPageFontSize: { type: String, attribute: 'full-page-font-size' },
+			fullPageFontFamily: { type: String, attribute: 'full-page-font-family' }
 		};
 	}
 
@@ -50,6 +51,7 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 				height=${ifDefined(this.htmlEditorHeight)}
 				?full-page="${this.fullPage}"
 				full-page-font-size="${ifDefined(this.fullPageFontSize)}"
+				full-page-font-family="${ifDefined(this.fullPageFontFamily)}"
 				?paste-local-images="${allowPaste}">
 			</d2l-htmleditor>
 		`;

--- a/components/d2l-activity-editor/d2l-activity-text-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-text-editor.js
@@ -14,7 +14,8 @@ class ActivityTextEditor extends LitElement {
 			key: { type: String },
 			htmlEditorHeight: { type: String, attribute: 'html-editor-height' },
 			fullPage: { type: Boolean, attribute: 'full-page' },
-			fullPageFontSize: { type: String, attribute: 'full-page-font-size' }
+			fullPageFontSize: { type: String, attribute: 'full-page-font-size' },
+			fullPageFontFamily: { type: String, attribute: 'full-page-font-family' }
 		};
 	}
 
@@ -55,7 +56,8 @@ class ActivityTextEditor extends LitElement {
 						@d2l-activity-html-editor-change="${this._onRichtextChange}"
 						html-editor-height=${ifDefined(this.htmlEditorHeight)}
 						?full-page="${this.fullPage}"
-						full-page-font-size="${ifDefined(this.fullPageFontSize)}">
+						full-page-font-size="${ifDefined(this.fullPageFontSize)}"
+						full-page-font-family="${ifDefined(this.fullPageFontFamily)}">
 					</d2l-activity-html-new-editor>
 				`;
 			} else {


### PR DESCRIPTION
This pr will tell the content html editors to use a certain font family. They were not being applied as we set our editor to "fullPage" so we can take advantage of customization.

One unfortunate thing is that manually setting the font family like this does not make it select it from the drop down list, so even though I am typing in Lato by default, I still see a different Lato in the dropdown menu.

![image](https://user-images.githubusercontent.com/14796305/118690108-56f4e200-b7cd-11eb-92cb-a656488dde69.png)


Note: I had the font flipped when I made these screenshots, Modules should be Lato, Files should be Verdana.

MODULE EDITOR:

![image](https://user-images.githubusercontent.com/14796305/118689632-d7671300-b7cc-11eb-92a7-3383fbb6d91c.png)

HTML EDITOR:

![image](https://user-images.githubusercontent.com/14796305/118689821-067d8480-b7cd-11eb-88f9-0821332daad5.png)
