### PR TITLE
[cert] DE43500: use file data endpoint when editing html files

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
@@ -39,7 +39,7 @@ export class ContentFile {
 			if (entity.getFileType() === FILE_TYPES.html && fileEntityHref) {
 				const fileEntityResponse = await fetchEntity(fileEntityHref, this.token);
 				const fileEntity = new FileEntity(fileEntityResponse, this.token, { remove: () => { } });
-				const fileContentFetchResponse = await fetch(fileEntity.getFileLocationHref());
+				const fileContentFetchResponse = await window.d2lfetch.fetch(fileEntity.getFileDataLocationHref());
 				if (fileContentFetchResponse.ok) {
 					fileContent = await fileContentFetchResponse.text();
 				}


### PR DESCRIPTION
Cert fix of [this PR](https://github.com/BrightspaceHypermediaComponents/activities/pull/1733).