### PR TITLE
DE43589 - fixing new editor content race condition

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -34,7 +34,7 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 		super();
 		this._context = JSON.parse(document.documentElement.getAttribute('data-he-context'));
 		this._filesToReplace = {};
-		this.saveOrder = 500;
+		this.saveOrder = 400;
 		this.fullPage = false;
 		this.htmlEditorHeight = '10rem';
 	}
@@ -52,7 +52,8 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 				?full-page="${this.fullPage}"
 				full-page-font-size="${ifDefined(this.fullPageFontSize)}"
 				full-page-font-family="${ifDefined(this.fullPageFontFamily)}"
-				?paste-local-images="${allowPaste}">
+				?paste-local-images="${allowPaste}"
+				@d2l-htmleditor-blur="${this._onBlur}">
 			</d2l-htmleditor>
 		`;
 	}
@@ -108,6 +109,11 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 					}
 				});
 		});
+	}
+
+	_onBlur() {
+		const editor = this.shadowRoot.querySelector('d2l-htmleditor');
+		this._dispatchChangeEvent(editor.html);
 	}
 
 	_parseHtml() {


### PR DESCRIPTION
## Relevant Rally Links 

- [DE43589](https://rally1.rallydev.com/#/289692574792d/dashboard?detail=%2Fdefect%2F605074749528&fdp=true?fdp=true): [cert] FACE HTML > HTML file content saved as "undefined"



## Description

HTML file content is occasionally saved as "undefined". This is happening because the new HTML editor fires the `d2l-activity-html-editor-change` event only on save and the new editor's save order is 500, which is the same order as our content editors that use working copy. Due to this, these two saves happen in the same `Promise.all`, and so there's a chance that the content hasn't been retrieved from the HTML editor when we are saving the content file activity. This doesn't affect content modules because the save order for that editor is the default (1000).



## Goal/Solution

This change implements 2 solutions:

1. Change the new HTML editor wrapper's save order to 400, so that it comes before our content editor save orders of 500. This should have no impact on other users of the new HTML editor wrapper because if it was working at save order 500 it should continue to work at save order 400. There are also no other editors in this repo with save order 400.
2. Update the new HTML editor wrapper to fire the `d2l-activity-html-editor-change` event on blur so that it's more consistent with the wrapper for the old HTML editor, which fires the event on handling `input` and `change` events. This could have more of a wide-reaching impact, as it requires the users of this wrapper to be able to handle this event happening more often. The 2 content users of the `d2l-activity-text-editor` and `d2l-activity-assignment-editor-detail` all debounce updating their state from this event because they are intended to work with the old editor too. However, `d2l-activity-quiz-editor-detail` and `d2l-activity-quiz-manage-header-footer-editor` do not have debouncing (the latter doesn't handle the event), so there could be issues with these editors. I'll reach out to the people who added the editors to check with them.





## Video/Screenshots

N/A



## Related PRs

N/A



## Remaining Work

N/A