### PR TITLE
DE43565 re-add content-description-container rule

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-styles.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-styles.js
@@ -10,4 +10,9 @@ export const activityContentEditorStyles = css`
 	:host > div {
 		padding-bottom: 20px;
 	}
+	#content-description-container {
+		display: flex;
+		flex-direction: column;
+		height: inherit;
+	}
 `;


### PR DESCRIPTION
An oversight in #1716 resulted in [this rule](https://github.com/BrightspaceHypermediaComponents/activities/pull/1716/files#diff-61ede7520d7d792457b26925a2f88e6315341fc1ca5794d271e20b6a127c8ceaL35) being removed, causing the editor to get squished. It's back now.

I can't believe it took me a week to find this