### PR TITLE
DE43589 - flush the correct debouncer on content file save

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -100,7 +100,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 			return;
 		}
 
-		this._saveOnChange('pageContent');
+		this._saveOnChange('htmlContent');
 
 		const originalActivityUsageHref = contentFileActivity.activityUsageHref;
 		const updatedEntity = await contentFileActivity.save();
@@ -127,8 +127,8 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 
 	_onPageContentChange(e) {
 		const pageContent = e.detail.content;
-		this._debounceJobs.description = Debouncer.debounce(
-			this._debounceJobs.description,
+		this._debounceJobs.htmlContent = Debouncer.debounce(
+			this._debounceJobs.htmlContent,
 			timeOut.after(ContentEditorConstants.DEBOUNCE_TIMEOUT),
 			() => this._savePageContent(pageContent)
 		);


### PR DESCRIPTION
## Relevant Rally Links 

- [DE43589](https://rally1.rallydev.com/#/289692574792d/dashboard?detail=%2Fdefect%2F605074749528%2Fconnections&fdp=true?fdp=true): [cert] FACE HTML > HTML file content saved as "undefined"



## Description

In our debouncer map, we were storing the content debouncer at "description" and then flushing the debouncer at "pageContent". Since these don't match, the debouncer wasn't actually being flushed on save.



## Goal/Solution

Renaming the debouncer to be consistently "htmlContent".



## Video/Screenshots

N/A


## Related PRs

- https://github.com/BrightspaceHypermediaComponents/activities/pull/1738 lessened a lot of the reasons for a race condition, but because of the debouncer not being flushed, we were still "racing" against the debouncer when saving.



## Remaining Work

N/A

