### PR TITLE
fix: hide dropdown pointer to work with start-alignment

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-add-activity-menu.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-add-activity-menu.js
@@ -120,7 +120,7 @@ class ActivityQuizAddActivityMenu extends ActivityEditorMixin(SkeletonMixin(Loca
 				?primary="${primary}"
 				?disabled="${disabled}">
 				${disabled ? null : html`
-					<d2l-dropdown-menu align="start" min-width="260">
+					<d2l-dropdown-menu align="start" no-pointer min-width="260">
 						<d2l-menu label="${label}" @d2l-menu-item-select="${this._onSelect}">
 							${content}
 						</d2l-menu>


### PR DESCRIPTION
https://trello.com/c/kjd4oLi9/383-create-new-button-dropdown-shows-arrow-off-to-the-left-too-much