### PR TITLE
DE43731 - rich text editor saves undefined if no content saved

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
@@ -69,7 +69,7 @@ export class ContentFile {
 
 		if (this._contentFileEntity.getFileType() === FILE_TYPES.html) {
 			const htmlEntity = new ContentHtmlFileEntity(this._contentFileEntity, this.token, { remove: () => { } });
-			await htmlEntity.setHtmlFileHtmlContent(this.htmlContent);
+			await htmlEntity.setHtmlFileHtmlContent(this.fileContent);
 		}
 
 		const committedContentFileEntity = await this._commit(this._contentFileEntity);
@@ -79,7 +79,7 @@ export class ContentFile {
 	}
 
 	setPageContent(pageContent) {
-		this.htmlContent = pageContent;
+		this.fileContent = pageContent;
 	}
 
 	setTitle(value) {


### PR DESCRIPTION
## Relevant Rally Links 

- [DE43731](https://rally1.rallydev.com/#/289692574792d/dashboard?detail=%2Fdefect%2F600345601867&fdp=true?fdp=true): [cert] FACE HTML > HTML file content saved as "undefined" when using the rich text editor



## Description

The rich text editor fires its content changed event on input change rather than on save like the wrapper for the new HTML editor. Since in the `content-file` state object we were using `htmlContent` to store HTML content but initializing `fileContent`, with the rich text editor `htmlContent` was never set and so was undefined. This led to undefined being sent as the new content on save, rather than an empty string (or in the new HTML editor's case, an empty HTML doc).



## Goal/Solution

The solution here is to replace all references to `htmlContent` with `fileContent`. There are checks that make sure we only interact with `fileContent` if it's an HTML file, so we're safe there. If we add the ability to edit other file types in FACE in the future, we'd likely want to reuse this `fileContent` variable as well, so I don't think the extra `htmlContent` variable is necessary.



## Video/Screenshots

Before:
![before_rte_undefined_fix](https://user-images.githubusercontent.com/64805612/119734403-f149cb00-be48-11eb-9cf1-3b83bac1735e.gif)


After:
![after_rte_undefined_fix](https://user-images.githubusercontent.com/64805612/119734392-ed1dad80-be48-11eb-8b7f-9fc0d0240732.gif)


## Related PRs

N/A



## Remaining Work

N/A