### PR TITLE
DE43733: Clicking back or cancel with changes in editor does not trigger discard changes popup

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -127,8 +127,13 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 
 	_onPageContentChange(e) {
 		const pageContent = e.detail.content;
-		this._debounceJobs.htmlContent = Debouncer.debounce(
-			this._debounceJobs.htmlContent,
+		this._savePageContent(pageContent);
+	}
+
+	_onPageContentChangeDebounced(e) {
+		const pageContent = e.detail.content;
+		this._debounceJobs.description = Debouncer.debounce(
+			this._debounceJobs.description,
 			timeOut.after(ContentEditorConstants.DEBOUNCE_TIMEOUT),
 			() => this._savePageContent(pageContent)
 		);
@@ -145,6 +150,10 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 		this.dispatchEvent(newEditorEvent);
 		const htmlNewEditorEnabled = newEditorEvent.detail.provider;
 
+		//@d2l-activity-text-editor-change for the new editor is on blur, while the old editor is on change
+		//we don't want the debouncer on the new editor in case the user clicks directly onto a button from the editor
+		const activityTextEditorChange = htmlNewEditorEnabled ? this._onPageContentChange : this._onPageContentChangeDebounced;
+
 		return html`
 			<div class="d2l-activity-label-container d2l-label-text d2l-skeletize">
 				${this.localize('content.pageContent')}
@@ -154,7 +163,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 					.ariaLabel="${this.localize('content.pageContent')}"
 					.key="content-page-content"
 					.value="${pageContent}"
-					@d2l-activity-text-editor-change="${this._onPageContentChange}"
+					@d2l-activity-text-editor-change="${activityTextEditorChange}"
 					.richtextEditorConfig="${{}}"
 					html-editor-height="100%"
 					full-page

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
@@ -15,6 +15,7 @@ export class ContentFile {
 		this.token = token;
 		this.title = '';
 		this.activityUsageHref = '';
+		this.persistedFileContent = '';
 		this.fileContent = '';
 		this.fileType = null;
 	}
@@ -24,7 +25,7 @@ export class ContentFile {
 	}
 
 	get dirty() {
-		return !this._contentFileEntity.equals(this._makeContentFileData());
+		return !(this._contentFileEntity.equals(this._makeContentFileData()) && this.persistedFileContent === this.fileContent);
 	}
 
 	async fetch() {
@@ -55,6 +56,7 @@ export class ContentFile {
 		this.href = contentFileEntity.self();
 		this.activityUsageHref = contentFileEntity.getActivityUsageHref();
 		this.title = contentFileEntity.title();
+		this.persistedFileContent = fileContent;
 		this.fileContent = fileContent;
 		this.fileType = contentFileEntity.getFileType();
 		this.fileHref = contentFileEntity.getFileHref();
@@ -66,15 +68,17 @@ export class ContentFile {
 		}
 
 		await this._contentFileEntity.setFileTitle(this.title);
+		let fileContent = '';
 
 		if (this._contentFileEntity.getFileType() === FILE_TYPES.html) {
 			const htmlEntity = new ContentHtmlFileEntity(this._contentFileEntity, this.token, { remove: () => { } });
 			await htmlEntity.setHtmlFileHtmlContent(this.fileContent);
+			fileContent = this.fileContent;
 		}
 
 		const committedContentFileEntity = await this._commit(this._contentFileEntity);
 		const editableContentFileEntity = await this._checkout(committedContentFileEntity);
-		this.load(editableContentFileEntity);
+		this.load(editableContentFileEntity, fileContent);
 		return this._contentFileEntity;
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -61,6 +61,10 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 		this.dispatchEvent(newEditorEvent);
 		const htmlNewEditorEnabled = newEditorEvent.detail.provider;
 
+		//@d2l-activity-text-editor-change for the new editor is on blur, while the old editor is on change
+		//we don't want the debouncer on the new editor in case the user clicks directly onto a button from the editor
+		const activityTextEditorChange = htmlNewEditorEnabled ? this._onRichtextChange : this._onRichtextChangeDebounced;
+
 		return html`
 			<d2l-activity-content-editor-title
 				.entity=${moduleEntity}
@@ -76,7 +80,7 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 						.ariaLabel="${this.localize('content.description')}"
 						.key="content-description"
 						.value="${descriptionRichText}"
-						@d2l-activity-text-editor-change="${this._onRichtextChange}"
+						@d2l-activity-text-editor-change="${activityTextEditorChange}"
 						.richtextEditorConfig="${{}}"
 						html-editor-height="100%"
 						full-page
@@ -131,6 +135,11 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 	}
 
 	_onRichtextChange(e) {
+		const descriptionRichText = e.detail.content;
+		this._saveDescription(descriptionRichText);
+	}
+
+	_onRichtextChangeDebounced(e) {
 		const descriptionRichText = e.detail.content;
 		this._debounceJobs.description = Debouncer.debounce(
 			this._debounceJobs.description,


### PR DESCRIPTION
## Relevant Rally Links 

[DE43733:](https://rally1.rallydev.com/#/289692574792/custom/355050439968?detail=%2Fdefect%2F600359414369&fdp=true) FACE HTML > clicking 'back' with changes in editor does not trigger discard changes popup

## Description

Clicking back or cancel with changes in editor was not triggering the 'Discard changes? Are you sure you want to discard your changes?'. This was happening for two reasons:

1. The current `dirty()` method was only comparing the `ContentFileEntity` values, which is the title and the description of the file activity, not the actual file content in the html editor.
2. The html editor triggers the save event on `blur` rather than on `change`, which is being debounced. If the user is working on the html editor then immediately presses 'Cancel' or 'Back', the changes in the editor won't be detected since it is being debounced.

## Goal/Solution

These two issues were addressed accordingly:

1. Added `persistedFileContent` to `content-file` which holds the most recent saved content on disk (or in working copy). This was then added to the` dirty() `method to compare to what's in the actual html editor. The comparison is done separately from the `contentFileEntity` since the `contentFileEntity` does not contain the actual file data.
2. A separate `onChange` method without the debouncer is used for the new editor, with the original `onChange` method added only to the old editor. This way, there is is no delay for saving the page content on blur (while maintaining a debouncer for the old editor).

## Remaining Work

There is one remaining issue where the discard changes popup window will be incorrectly triggered if a new html document is made. If the user makes a new html document, triggers the blur event on the editor, then hits cancel, the `dirty()` method will compare the persistedFileContent (which is "" since it is new) and what is in the editor (which will now have the head and body tags). Since this issue also affects modules, this will be addressed in a separate defect.