### PR TITLE
fix: switching quiz IP table and Quick Eval to use Lit tables

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restrictions-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-ip-restrictions-editor.js
@@ -1,21 +1,16 @@
 import '@brightspace-ui/core/components/dialog/dialog.js';
-import 'd2l-table/d2l-table';
-import 'd2l-table/d2l-tr';
-import 'd2l-table/d2l-th';
-import 'd2l-table/d2l-table-style.js';
-import 'd2l-table/d2l-tbody';
-import 'd2l-table/d2l-thead';
 import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorContainerMixin } from '../mixins/d2l-activity-editor-container-mixin';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin';
 import { LocalizeActivityQuizEditorMixin } from './mixins/d2l-activity-quiz-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { sharedIpRestrictions as store } from './state/quiz-store.js';
+import { tableStyles } from '@brightspace-ui/core/components/table/table-wrapper.js';
 
 class ActivityQuizIpRestrictionsEditor extends ActivityEditorMixin(ActivityEditorContainerMixin(LocalizeActivityQuizEditorMixin(MobxLitElement))) {
 
 	static get styles() {
-		return css`
+		return [tableStyles, css`
 				:host {
 					display: block;
 				}
@@ -25,13 +20,10 @@ class ActivityQuizIpRestrictionsEditor extends ActivityEditorMixin(ActivityEdito
 				d2l-button-subtle {
 					margin-top: 0.5rem;
 				}
-				d2l-thead {
-					font-weight: 700;
-				}
 				d2l-button {
 					margin: 1rem 0;
 				}
-			`;
+			`];
 	}
 
 	constructor() {
@@ -106,29 +98,18 @@ class ActivityQuizIpRestrictionsEditor extends ActivityEditorMixin(ActivityEdito
 
 	_renderIpRestrictionTable() {
 		return html`
-			<custom-style>
-				<style include="d2l-table-style">
-					:host {
-						display: block;
-					}
-				</style>
-			</custom-style>
-
-			<d2l-table id="ip-restrictions-table">
-			 	<d2l-thead>
-			 		<d2l-tr>
-			 			<d2l-th class="title">${this.localize('ipRestrictionsTableStartRangeHdr')}</d2l-th>
-			 			<d2l-th>${this.localize('ipRestrictionsTableEndRangeHdr')}</d2l-th>
-			 			<d2l-th>${this.localize('ipRestrictionsTableDeleteRangeHdr')}</d2l-th>
-			 		</d2l-tr>
-				</d2l-thead>
-				<d2l-tbody>
-
-					${this._renderRestrictionRows()}
-
-				</d2l-tbody>
-
-			</d2l-table>
+			<d2l-table-wrapper>
+				<table class="d2l-table">
+					<thead>
+			 			<tr>
+							<th>${this.localize('ipRestrictionsTableStartRangeHdr')}</th>
+							<th>${this.localize('ipRestrictionsTableEndRangeHdr')}</th>
+							<th>${this.localize('ipRestrictionsTableDeleteRangeHdr')}</th>
+						</tr>
+					</thead>
+					<tbody>${this._renderRestrictionRows()}</tbody>
+				</table>
+			</d2l-table-wrapper>
 		`;
 	}
 
@@ -142,35 +123,31 @@ class ActivityQuizIpRestrictionsEditor extends ActivityEditorMixin(ActivityEdito
 			const { start, end } = restriction;
 
 			return html`
-				<d2l-tr>
-					<d2l-th>
-
+				<tr>
+					<td>
 						<d2l-input-text
 							class="d2l-ip-input"
 							@input="${this._generateHandler(this._handleChange, index)}"
 							value="${start || ''}"
 							name="start">
 						</d2l-input-text>
-
-					</d2l-th>
-					<d2l-th>
-
+					</td>
+					<td>
 						<d2l-input-text
 							class="d2l-ip-input"
 							@input="${this._generateHandler(this._handleChange, index)}"
 							value="${end || ''}"
 							name="end">
 						</d2l-input-text>
-
-					</d2l-th>
-					<d2l-th>
+					</td>
+					<td>
 						<d2l-button-icon
-						icon="d2l-tier1:delete"
-						aria-label="delete"
-						@click="${this._generateHandler(this._deleteIp, index)}">
+							icon="d2l-tier1:delete"
+							aria-label="delete"
+							@click="${this._generateHandler(this._deleteIp, index)}">
 						</d2l-button-icon>
-					</d2l-th>
-				</d2l-tr>
+					</td>
+				</tr>
 			`;
 		});
 	}

--- a/components/d2l-quick-eval/d2l-quick-eval-submissions-table.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions-table.js
@@ -3,7 +3,7 @@ import { QuickEvalLocalize } from './QuickEvalLocalize.js';
 import { QuickEvalLogging } from './QuickEvalLogging.js';
 import 'd2l-alert/d2l-alert.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
-import 'd2l-table/d2l-table.js';
+import 'd2l-table/d2l-table-wrapper.js';
 import 'd2l-button/d2l-button.js';
 import 'd2l-offscreen/d2l-offscreen.js';
 import 'd2l-polymer-behaviors/d2l-dom-focus.js';
@@ -30,11 +30,10 @@ class D2LQuickEvalSubmissionsTable extends QuickEvalLogging(QuickEvalLocalize(Po
 				:host {
 					display: block;
 				}
-				d2l-td {
+				td:not(.d2l-username-column) {
 					font-size: 0.7rem;
 				}
-				d2l-td.d2l-username-column {
-					font-size: 0.8rem;
+				td.d2l-username-column {
 					overflow: hidden;
 					text-overflow: ellipsis;
 				}
@@ -46,10 +45,6 @@ class D2LQuickEvalSubmissionsTable extends QuickEvalLogging(QuickEvalLocalize(Po
 				:host(:dir(rtl)) .d2l-user-badge-image {
 					padding-right: 0;
 					padding-left: 0.6rem;
-				}
-				/* Needed for Edge */
-				d2l-table-col-sort-button span {
-					color: var(--d2l-color-ferrite);
 				}
 				d2l-alert {
 					margin: auto;
@@ -148,87 +143,81 @@ class D2LQuickEvalSubmissionsTable extends QuickEvalLogging(QuickEvalLocalize(Po
 			<template is="dom-if" if="[[courseLevel]]">
 				<h2 title="[[courseLevelName]]" class="d2l-quick-eval-submissions-course-name-heading">[[courseLevelName]]</h2>
 			</template>
-			<d2l-table type="light" hidden$="[[showLoadingSkeleton]]" aria-describedby$="[[_tableDescriptionId]]" aria-colcount$="[[headerColumns.length]]" aria-rowcount$="[[_data.length]]">
-				<d2l-thead>
-					<d2l-tr>
-						<dom-repeat items="[[headerColumns]]" as="headerColumn">
-							<template>
-								<d2l-th class$=[[_getWidthCssClass(headerColumn.widthOverride)]]>
-									<dom-repeat items="[[headerColumn.headers]]" as="header">
-										<template>
-											<template is="dom-if" if="[[header.canSort]]">
-												<d2l-table-col-sort-button
-													nosort$="[[!header.sorted]]"
-													desc$="[[header.desc]]"
-													on-click="_dispatchSortRequestedEvent"
-													id="[[header.key]]"
-													title="[[_localizeSortText(header.key)]]"
-													aria-label$="[[_localizeSortText(header.key)]]"
-													aria-live="assertive"
-												>
-													<span hidden="true" aria-hidden="[[!header.nameColumn]]">[[_localizeSortText(header.key)]]</span>
-													<span aria-hidden="true">[[localize(header.key)]]</span>
-												</d2l-table-col-sort-button>
-												<template is="dom-if" if="[[header.suffix]]">
-													<span>[[header.suffix]]&nbsp;</span>
-												</template>
-											</template>
-											<template is="dom-if" if="[[!header.canSort]]">
-												<span>[[localize(header.key)]]</span>
-												<template is="dom-if" if="[[header.suffix]]">
-													<span>[[header.suffix]]&nbsp;</span>
-												</template>
+			<d2l-table-wrapper type="light" hidden$="[[showLoadingSkeleton]]">
+				<table class="d2l-table" aria-describedby$="[[_tableDescriptionId]]">
+					<thead>
+						<tr>
+							<template is="dom-repeat" items="[[headerColumns]]" as="headerColumn">
+								<th class$=[[_getWidthCssClass(headerColumn.widthOverride)]]>
+									<template is="dom-repeat" items="[[headerColumn.headers]]" as="header">
+										<template is="dom-if" if="[[header.canSort]]">
+											<d2l-table-col-sort-button
+												nosort$="[[!header.sorted]]"
+												desc$="[[header.desc]]"
+												on-click="_dispatchSortRequestedEvent"
+												id="[[header.key]]"
+												title="[[_localizeSortText(header.key)]]"
+												aria-label$="[[_localizeSortText(header.key)]]"
+												aria-live="assertive"
+											>
+												<span hidden="true" aria-hidden="[[!header.nameColumn]]">[[_localizeSortText(header.key)]]</span>
+												<span aria-hidden="true">[[localize(header.key)]]</span>
+											</d2l-table-col-sort-button>
+											<template is="dom-if" if="[[header.suffix]]">
+												<span>[[header.suffix]]&nbsp;</span>
 											</template>
 										</template>
-									</dom-repeat>
-								</d2l-th>
-							</template>
-						</dom-repeat>
-					</d2l-tr>
-				</d2l-thead>
-				<d2l-tbody>
-					<dom-repeat items="[[_data]]" as="s">
-						<template>
-							<d2l-tr>
-								<dom-repeat items="[[headerColumns]]" as="c">
-									<template>
-										<template is="dom-if" if="[[_isColumn(c, 'user')]]">
-											<d2l-td class="d2l-quick-eval-truncated-column d2l-username-column">
-												<template is="dom-if" if="[[s.userHref]]">
-													<d2l-profile-image
-														class="d2l-user-badge-image"
-														href="[[s.userHref]]"
-														token="[[token]]"
-														small
-														aria-hidden="true">
-													</d2l-profile-image>
-												</template>
-												<d2l-link
-													title="[[_localizeEvaluationText(s, c.meta.firstThenLast)]]"
-													href="[[s.activityLink]]"
-													aria-label$="[[_localizeEvaluationText(s, c.meta.firstThenLast)]]"
-													class="d2l-quick-eval-submissions-table-name-link"
-												>[[_formatDisplayName(s, c.meta.firstThenLast)]]</d2l-link>
-												<d2l-activity-evaluation-icon-base draft$="[[s.isDraft]]"></d2l-activity-evaluation-icon-base>
-											</d2l-td>
-										</template>
-										<template is="dom-if" if="[[_isColumn(c, 'activity-name')]]">
-											<d2l-td  class$="[[_computeTruncateClass(c.truncated)]]">
-												<d2l-activity-name href="[[s.activityNameHref]]" token="[[token]]"></d2l-activity-name>
-											</d2l-td>
-										</template>
-										<template is="dom-if" if="[[_isColumn(c, 'none')]]">
-											<d2l-td class$="[[_computeTruncateClass(c.truncated)]] d2l-quick-eval-submissions-overflow-hidden">
-												<span title="[[_computeColumnText(s, c)]]">[[_computeColumnText(s, c)]]</span>
-											</d2l-td>
+										<template is="dom-if" if="[[!header.canSort]]">
+											<span>[[localize(header.key)]]</span>
+											<template is="dom-if" if="[[header.suffix]]">
+												<span>[[header.suffix]]&nbsp;</span>
+											</template>
 										</template>
 									</template>
-								<dom-repeat>
-							</d2l-tr>
+								</th>
+							</template>
+						</tr>
+					</thead>
+					<tbody>
+						<template is="dom-repeat" items="[[_data]]" as="s">
+							<tr>
+								<template is="dom-repeat" items="[[headerColumns]]" as="c">
+									<template is="dom-if" if="[[_isColumn(c, 'user')]]">
+										<td class="d2l-quick-eval-truncated-column d2l-username-column">
+											<template is="dom-if" if="[[s.userHref]]">
+												<d2l-profile-image
+													class="d2l-user-badge-image"
+													href="[[s.userHref]]"
+													token="[[token]]"
+													small
+													aria-hidden="true">
+												</d2l-profile-image>
+											</template>
+											<d2l-link
+												title="[[_localizeEvaluationText(s, c.meta.firstThenLast)]]"
+												href="[[s.activityLink]]"
+												aria-label$="[[_localizeEvaluationText(s, c.meta.firstThenLast)]]"
+												class="d2l-quick-eval-submissions-table-name-link"
+											>[[_formatDisplayName(s, c.meta.firstThenLast)]]</d2l-link>
+											<d2l-activity-evaluation-icon-base draft$="[[s.isDraft]]"></d2l-activity-evaluation-icon-base>
+										</td>
+									</template>
+									<template is="dom-if" if="[[_isColumn(c, 'activity-name')]]">
+										<td  class$="[[_computeTruncateClass(c.truncated)]]">
+											<d2l-activity-name href="[[s.activityNameHref]]" token="[[token]]"></d2l-activity-name>
+										</td>
+									</template>
+									<template is="dom-if" if="[[_isColumn(c, 'none')]]">
+										<td class$="[[_computeTruncateClass(c.truncated)]] d2l-quick-eval-submissions-overflow-hidden">
+											<span title="[[_computeColumnText(s, c)]]">[[_computeColumnText(s, c)]]</span>
+										</td>
+									</template>
+								</template>
+							</tr>
 						</template>
-					</dom-repeat>
-				</d2l-tbody>
-			</d2l-table>
+					</tbody>
+				</table>
+			</d2l-table-wrapper>
 			<d2l-alert class="list-alert" type="critical" hidden$="[[_health.isHealthy]]">
 				[[localize(_health.errorMessage)]]
 			</d2l-alert>


### PR DESCRIPTION
The new Lit version of tables is ready! That, combined with no longer supporting IE11 means we can just use normal table/tr/td elements instead of the crazy d2l-table/d2l-tr/d2l-td ones. 🙌 

These two solutions look slightly different because the way styles get shared is different in Lit (where it uses CSS literals that you apply to your Lit element) vs. Polymer (where it uses shared <dom-module>s). So Quizzing can just reference the new Lit table directly whereas Quick Eval because it's still a Polymer element needs to reference `d2l-table`'s wrapper that has the style module.