### PR TITLE
US128128 Add created questions to quiz via add-existing workflow

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-action-bar.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-action-bar.js
@@ -54,7 +54,7 @@ class ActivityQuizEditorActionBar extends ActivityEditorMixin(SkeletonMixin(RtlM
 		return html`
 			<div class='d2l-action-bar-container d2l-skeletize'>
 				<d2l-activity-quiz-add-activity-menu
-					href="${this.quizHref}"
+					href="${this.href}"
 					.token="${this.token}"
 				></d2l-activity-quiz-add-activity-menu>
 				${scoreOutOf ? html`<div class='d2l-body-standard d2l-quiz-score-out-of'>${this.localize('totalPoints', { scoreOutOf })}</div>` : null }

--- a/test/d2l-activity-editor/state/activity-usage.spec.js
+++ b/test/d2l-activity-editor/state/activity-usage.spec.js
@@ -54,7 +54,8 @@ describe('Activity Usage', function() {
 			specialAccessHref: () => null,
 			specializationHref: () => null,
 			fetchLinkedScoreOutOfEntity: () => null,
-			associateGradeHref: () => null
+			associateGradeHref: () => null,
+			activityCollectionHref: () => undefined
 		};
 	}
 


### PR DESCRIPTION
When the QED dialog is closed, this calls the start-add-existing actions and then the action on each candidate for the returned question hrefs.

Relies on changes in the siren-sdk: https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/327