### PR TITLE
Add required labels to selectable d2l-list-items.

### DIFF
--- a/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
+++ b/components/d2l-activity-collection-editor/d2l-activity-collection-editor.js
@@ -692,7 +692,7 @@ class CollectionEditor extends LocalizeActivityCollectionEditor(EntityMixinLit(L
 
 		const items = repeat(this._candidateItems, (candidate) => candidate.itemSelf, candidate => {
 			return html`
-				<d2l-list-item selectable ?disabled=${candidate.alreadyAdded} ?selected=${candidate.alreadyAdded || this._currentSelection[candidate.item.getActionState()]} key=${candidate.alreadyAdded ? ifDefined(undefined) : candidate.item.getActionState()}>
+				<d2l-list-item selectable label="${candidate.organization.name()}" ?disabled=${candidate.alreadyAdded} ?selected=${candidate.alreadyAdded || this._currentSelection[candidate.item.getActionState()]} key=${candidate.alreadyAdded ? ifDefined(undefined) : candidate.item.getActionState()}>
 					<div slot="illustration" class="d2l-activitiy-collection-list-item-illustration">
 						${this._renderCourseImageSkeleton()}
 						<d2l-organization-image

--- a/components/d2l-quick-eval/dismiss/d2l-quick-eval-dismissed-activities-list.js
+++ b/components/d2l-quick-eval/dismiss/d2l-quick-eval-dismissed-activities-list.js
@@ -18,7 +18,7 @@ class D2LQuickEvalDismissedActivitiesList extends LitQuickEvalLocalize(LitElemen
 	render() {
 		return html`
 			<d2l-list separators="all">${this.dismissedActivities && this.dismissedActivities.length ? this.dismissedActivities.map((act, index) => html`
-				<d2l-list-item selectable key="${index}" @d2l-list-item-selected=${this._handleItemSelected}>
+				<d2l-list-item selectable key="${index}" label="${act.name}" @d2l-list-item-selected=${this._handleItemSelected}>
 					<d2l-icon slot="illustration" icon="${this._computeIcon(act.type)}" aria-label="${this.localize(act.type)}"></d2l-icon>
 					<d2l-list-item-content>
 						${act.name}


### PR DESCRIPTION
This PR adds labels to selectable d2l-list-items that will be required in the near future in order to support changes that are being made to lists for selection, multi-selection, and multi-actions.