### PR TITLE
US118647 - Replaced simple-overlay with d2l-dialog-fullscreen component in rubrics list

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -78,6 +78,7 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 
 			<d2l-dialog-fullscreen
 				id="create-new-association-dialog"
+				title-text = ${this.localize('rubrics.hdrCreateRubric')}
 				@d2l-dialog-close="${this._clearNewRubricHref}">
 				${this._renderRubricEditor()}
 				<d2l-button slot="footer" primary  @click="${this._attachRubric}">
@@ -232,7 +233,8 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 				<d2l-rubric-editor
 					.href="${this._newlyCreatedPotentialAssociationHref}"
 					.token="${this.token}"
-					title-dropdown-hidden>
+					title-dropdown-hidden
+					title-hidden>
 				</d2l-rubric-editor>`;
 		} else {
 			return html``;

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -3,7 +3,7 @@ import 'd2l-associations/add-associations.js';
 import 'd2l-rubric/d2l-rubric';
 import 'd2l-rubric/d2l-rubric-title';
 import 'd2l-rubric/editor/d2l-rubric-editor.js';
-import 'd2l-simple-overlay/d2l-simple-overlay.js';
+import '@brightspace-ui/core/components/dialog/dialog-fullscreen.js';
 import '@brightspace-ui/core/components/dropdown/dropdown.js';
 import '@brightspace-ui/core/components/dropdown/dropdown-content.js';
 import '@brightspace-ui/core/components/menu/menu.js';
@@ -76,13 +76,10 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 
 			${this._renderDefaultScoringRubric(entity)}
 
-			<d2l-simple-overlay
+			<d2l-dialog-fullscreen
 				id="create-new-association-dialog"
-				close-simple-overlay-alt-text="${this.localize('rubrics.btnClose')}"
 				no-cancel-on-outside-click
-				@d2l-simple-overlay-close-button-clicked="${this._clearNewRubricHref}"
-				@d2l-simple-overlay-canceled="${this._clearNewRubricHref}"
-			>
+				@d2l-dialog-close="${this._clearNewRubricHref}">
 				${this._renderRubricEditor()}
 				<d2l-floating-buttons always-float>
 					<d2l-button primary @click="${this._attachRubric}">
@@ -92,7 +89,7 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 						${this.localize('rubrics.btnCancel')}
 					</d2l-button>
 				</d2l-floating-buttons>
-			</d2l-simple-overlay>
+			</d2l-dialog-fullscreen>
 
 			<d2l-dialog
 				id="attach-rubric-dialog"
@@ -107,7 +104,7 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 					type="rubrics"
 					skipSave
 				></d2l-add-associations>
-			</d2l-dialog>
+			</d2l-dialog-fullscreen>
 		`;
 	}
 	_attachRubric() {
@@ -140,7 +137,7 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 			this.shadowRoot.querySelector('#create-new-association-dialog');
 		if (editNewAssociationOverlay) {
 			this._clearNewRubricHref();
-			editNewAssociationOverlay.close();
+			editNewAssociationOverlay.opened = false;
 		}
 	}
 	async _createNewAssociation() {
@@ -165,7 +162,7 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 
 		const editNewAssociationOverlay = this.shadowRoot.querySelector('#create-new-association-dialog');
 		if (editNewAssociationOverlay) {
-			editNewAssociationOverlay.open();
+			editNewAssociationOverlay.opened = true;
 		}
 
 	}

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -78,7 +78,6 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 
 			<d2l-dialog-fullscreen
 				id="create-new-association-dialog"
-				no-cancel-on-outside-click
 				@d2l-dialog-close="${this._clearNewRubricHref}">
 				${this._renderRubricEditor()}
 				<d2l-button slot="footer" primary  @click="${this._attachRubric}">

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -81,14 +81,12 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 				no-cancel-on-outside-click
 				@d2l-dialog-close="${this._clearNewRubricHref}">
 				${this._renderRubricEditor()}
-				<d2l-floating-buttons always-float>
-					<d2l-button primary @click="${this._attachRubric}">
-						${this.localize('rubrics.btnAttachRubric')}
-					</d2l-button>
-					<d2l-button @click="${this._closeEditNewAssociationOverlay}">
-						${this.localize('rubrics.btnCancel')}
-					</d2l-button>
-				</d2l-floating-buttons>
+				<d2l-button slot="footer" primary  @click="${this._attachRubric}">
+					${this.localize('rubrics.btnAttachRubric')}
+				</d2l-button>
+				<d2l-button slot="footer" @click="${this._closeEditNewAssociationOverlay}">
+					${this.localize('rubrics.btnCancel')}
+				</d2l-button>
 			</d2l-dialog-fullscreen>
 
 			<d2l-dialog

--- a/components/d2l-activity-editor/lang/ar.js
+++ b/components/d2l-activity-editor/lang/ar.js
@@ -94,7 +94,6 @@ export default {
 	"rubrics.txtNoRubricAdded": "لم تتم إضافة آلية تقييم", // rubric summary for no rubrics
 	"rubrics.txtRubricsAdded": "{count, plural, =1 {آلية تقييم واحدة مضافة} other {{count} من آليات التقييم المضافة}}", // count of asoociated rubrics
 	"rubrics.txtDeleteRubric": "حذف آلية التقييم", // Text for deleting rubric icon
-	"rubrics.btnClose": "إغلاق", // X button for exiting the create new rubric overlay
 	"rubrics.txtRubricAdded": "تمت إضافة آلية تقييم", // Text for notifying screenreader rubric was added
 	"rubrics.txtRubricRemoved": "تمت إزالة آلية تقييم", // Text for notifying screenreader rubric was removed
 	"rubrics.txtConfirmDetachRubric": "بعد فصل آلية التقييم، سيتم حذف كل التقييمات السابقة لآلية التقييم في هذا النشاط. هل تريد تأكيد فصل آلية التقييم؟", //Text for the dialog to confirm detaching a rubric from an evaluated activity

--- a/components/d2l-activity-editor/lang/cy.js
+++ b/components/d2l-activity-editor/lang/cy.js
@@ -94,7 +94,6 @@ export default {
 	"rubrics.txtNoRubricAdded": "Dim cyfeireb wedi’i hychwanegu", // rubric summary for no rubrics
 	"rubrics.txtRubricsAdded": "{count, plural, =1 {1 rubric added} other {{count} rubrics added}}", // count of asoociated rubrics
 	"rubrics.txtDeleteRubric": "Dileu Cyfeireb", // Text for deleting rubric icon
-	"rubrics.btnClose": "Cau", // X button for exiting the create new rubric overlay
 	"rubrics.txtRubricAdded": "Wedi ychwanegu cyfeireb", // Text for notifying screenreader rubric was added
 	"rubrics.txtRubricRemoved": "Wedi tynnu cyfeireb", // Text for notifying screenreader rubric was removed
 	"rubrics.txtConfirmDetachRubric": "Unwaith y bydd y gyfeireb wedi’i datgysylltu, bydd yr holl asesiadau blaenorol o'r gyfeireb yn y gweithgaredd hwn yn cael eu dileu. Cadarnhau datgysylltu'r gyfeireb?", //Text for the dialog to confirm detaching a rubric from an evaluated activity

--- a/components/d2l-activity-editor/lang/da.js
+++ b/components/d2l-activity-editor/lang/da.js
@@ -94,7 +94,6 @@ export default {
 	"rubrics.txtNoRubricAdded": "Ingen rubrik tilføjet", // rubric summary for no rubrics
 	"rubrics.txtRubricsAdded": "{count, plural, =1 {1 rubrik tilføjet} other {{count} rubrikker tilføjet}}", // count of asoociated rubrics
 	"rubrics.txtDeleteRubric": "Slet rubrik", // Text for deleting rubric icon
-	"rubrics.btnClose": "Luk", // X button for exiting the create new rubric overlay
 	"rubrics.txtRubricAdded": "Rubrik tilføjet", // Text for notifying screenreader rubric was added
 	"rubrics.txtRubricRemoved": "Rubrik fjernet", // Text for notifying screenreader rubric was removed
 	"rubrics.txtConfirmDetachRubric": "Når rubrikken er fjernet, slettes alle tidligere vurderinger af rubrikken i denne aktivitet. Bekræft fjernelse af rubrikken?", //Text for the dialog to confirm detaching a rubric from an evaluated activity

--- a/components/d2l-activity-editor/lang/de.js
+++ b/components/d2l-activity-editor/lang/de.js
@@ -94,7 +94,6 @@ export default {
 	"rubrics.txtNoRubricAdded": "Kein Bewertungsschema hinzugefügt", // rubric summary for no rubrics
 	"rubrics.txtRubricsAdded": "{count, plural, =1 {1 Rubrik hinzugefügt} other {{count} Rubriken hinzugefügt}}", // count of asoociated rubrics
 	"rubrics.txtDeleteRubric": "Bewertungsschema löschen", // Text for deleting rubric icon
-	"rubrics.btnClose": "Schließen", // X button for exiting the create new rubric overlay
 	"rubrics.txtRubricAdded": "Bewertungsschema hinzugefügt", // Text for notifying screenreader rubric was added
 	"rubrics.txtRubricRemoved": "Bewertungsschema entfernt", // Text for notifying screenreader rubric was removed
 	"rubrics.txtConfirmDetachRubric": "Sobald die Rubrik getrennt ist, werden alle vorherigen Bewertungen der Rubrik in dieser Aktivität gelöscht. Trennen der Rubrik bestätigen?", //Text for the dialog to confirm detaching a rubric from an evaluated activity

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -94,7 +94,6 @@ export default {
 	"rubrics.txtNoRubricAdded": "No rubric added", // rubric summary for no rubrics
 	"rubrics.txtRubricsAdded": "{count, plural, =1 {1 rubric added} other {{count} rubrics added}}", // count of asoociated rubrics
 	"rubrics.txtDeleteRubric": "Delete Rubric", // Text for deleting rubric icon
-	"rubrics.btnClose": "Close", // X button for exiting the create new rubric overlay
 	"rubrics.txtRubricAdded": "Rubric added", // Text for notifying screenreader rubric was added
 	"rubrics.txtRubricRemoved": "Rubric removed", // Text for notifying screenreader rubric was removed
 	"rubrics.txtConfirmDetachRubric": "Once the rubric is detached, all previous assessments of the rubric in this activity will be deleted. Confirm detaching the rubric?", //Text for the dialog to confirm detaching a rubric from an evaluated activity

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -85,6 +85,7 @@ export default {
 
 	"rubrics.btnAddRubric": "Add rubric", //text for add rubric button
 	"rubrics.btnCreateNew": "Create New", //Text for create new dropdown
+	"rubrics.hdrCreateRubric": "Create Rubric", // Header for creating a new rubric
 	"rubrics.btnDetach": "Detach", //Text for the button to confirm detaching a rubric
 	"rubrics.btnAddExisting": "Add Existing", //Text for Add Existing dropdown
 	"rubrics.hdrRubrics": "Rubrics", //Header for the rubrics section

--- a/components/d2l-activity-editor/lang/es-es.js
+++ b/components/d2l-activity-editor/lang/es-es.js
@@ -94,7 +94,6 @@ export default {
 	"rubrics.txtNoRubricAdded": "No se ha añadido ninguna rúbrica", // rubric summary for no rubrics
 	"rubrics.txtRubricsAdded": "{count, plural, =1 {1 rúbrica añadida} other {{count} rúbricas añadidas}}", // count of asoociated rubrics
 	"rubrics.txtDeleteRubric": "Eliminar rúbrica", // Text for deleting rubric icon
-	"rubrics.btnClose": "Cerrar", // X button for exiting the create new rubric overlay
 	"rubrics.txtRubricAdded": "Rúbrica añadida", // Text for notifying screenreader rubric was added
 	"rubrics.txtRubricRemoved": "Rúbrica eliminada", // Text for notifying screenreader rubric was removed
 	"rubrics.txtConfirmDetachRubric": "Cuando se haya separado la rúbrica, se eliminarán todas las evaluaciones previas de la rúbrica en esta actividad. ¿Confirmar la separación de la rúbrica?", //Text for the dialog to confirm detaching a rubric from an evaluated activity

--- a/components/d2l-activity-editor/lang/es.js
+++ b/components/d2l-activity-editor/lang/es.js
@@ -94,7 +94,6 @@ export default {
 	"rubrics.txtNoRubricAdded": "No se agregó ninguna rúbrica", // rubric summary for no rubrics
 	"rubrics.txtRubricsAdded": "{count, plural, =1 {1 rúbrica agregada} other {{count} rúbricas agregadas}}", // count of asoociated rubrics
 	"rubrics.txtDeleteRubric": "Eliminar rúbrica", // Text for deleting rubric icon
-	"rubrics.btnClose": "Cerrar", // X button for exiting the create new rubric overlay
 	"rubrics.txtRubricAdded": "Rúbrica agregada", // Text for notifying screenreader rubric was added
 	"rubrics.txtRubricRemoved": "Rúbrica eliminada", // Text for notifying screenreader rubric was removed
 	"rubrics.txtConfirmDetachRubric": "Una vez que la rúbrica esté separada, se eliminarán todas las evaluaciones anteriores de la rúbrica en esta actividad. ¿Desea confirmar la separación de la rúbrica?", //Text for the dialog to confirm detaching a rubric from an evaluated activity

--- a/components/d2l-activity-editor/lang/fr-fr.js
+++ b/components/d2l-activity-editor/lang/fr-fr.js
@@ -94,7 +94,6 @@ export default {
 	"rubrics.txtNoRubricAdded": "Aucune grille d’évaluation ajoutée", // rubric summary for no rubrics
 	"rubrics.txtRubricsAdded": "{count, plural, =1 {1 grille d’évaluation ajoutée} other {{count} grilles d’évaluation ajoutées}}", // count of asoociated rubrics
 	"rubrics.txtDeleteRubric": "Supprimer la grille d’évaluation", // Text for deleting rubric icon
-	"rubrics.btnClose": "Fermer", // X button for exiting the create new rubric overlay
 	"rubrics.txtRubricAdded": "Grille d’évaluation ajoutée", // Text for notifying screenreader rubric was added
 	"rubrics.txtRubricRemoved": "Grille d’évaluation supprimée", // Text for notifying screenreader rubric was removed
 	"rubrics.txtConfirmDetachRubric": "Une fois la grille d’évaluation détachée, toutes les évaluations précédentes de la rubrique dans cette activité seront supprimées. Confirmer le détachement de la grille d’évaluation ?", //Text for the dialog to confirm detaching a rubric from an evaluated activity

--- a/components/d2l-activity-editor/lang/fr-on.js
+++ b/components/d2l-activity-editor/lang/fr-on.js
@@ -94,7 +94,6 @@ export default {
 	"rubrics.txtNoRubricAdded": "Aucune grille d'évaluation n’a été ajoutée", // rubric summary for no rubrics
 	"rubrics.txtRubricsAdded": "{count, plural, =1 {1 grille d'évaluation ajoutée} other {{count} grilles d'évaluation ajoutées}}", // count of asoociated rubrics
 	"rubrics.txtDeleteRubric": "Supprimer la grille d'évaluation", // Text for deleting rubric icon
-	"rubrics.btnClose": "Fermer", // X button for exiting the create new rubric overlay
 	"rubrics.txtRubricAdded": "Grille d'évaluation ajoutée", // Text for notifying screenreader rubric was added
 	"rubrics.txtRubricRemoved": "Grille d'évaluation supprimée", // Text for notifying screenreader rubric was removed
 	"rubrics.txtConfirmDetachRubric": "Once the rubric is detached, all previous assessments of the rubric in this activity will be deleted. Confirm detaching the rubric?", //Text for the dialog to confirm detaching a rubric from an evaluated activity

--- a/components/d2l-activity-editor/lang/fr.js
+++ b/components/d2l-activity-editor/lang/fr.js
@@ -94,7 +94,6 @@ export default {
 	"rubrics.txtNoRubricAdded": "Aucune rubrique n’a été ajoutée", // rubric summary for no rubrics
 	"rubrics.txtRubricsAdded": "{count, plural, =1 {1 rubrique ajoutée} other {{count} rubriques ajoutées}}", // count of asoociated rubrics
 	"rubrics.txtDeleteRubric": "Supprimer la rubrique", // Text for deleting rubric icon
-	"rubrics.btnClose": "Fermer", // X button for exiting the create new rubric overlay
 	"rubrics.txtRubricAdded": "Rubrique ajoutée", // Text for notifying screenreader rubric was added
 	"rubrics.txtRubricRemoved": "Rubrique supprimée", // Text for notifying screenreader rubric was removed
 	"rubrics.txtConfirmDetachRubric": "Quand la rubrique sera retirée, toutes les évaluations précédentes de la rubrique dans cette activité seront supprimées. Confirmer le retrait de la rubrique?", //Text for the dialog to confirm detaching a rubric from an evaluated activity

--- a/components/d2l-activity-editor/lang/ja.js
+++ b/components/d2l-activity-editor/lang/ja.js
@@ -94,7 +94,6 @@ export default {
 	"rubrics.txtNoRubricAdded": "追加された注釈がありません", // rubric summary for no rubrics
 	"rubrics.txtRubricsAdded": "{count, plural, =1 {1 つの注釈が追加されました} other {{count} 個の注釈が追加されました}}", // count of asoociated rubrics
 	"rubrics.txtDeleteRubric": "注釈の削除", // Text for deleting rubric icon
-	"rubrics.btnClose": "閉じる", // X button for exiting the create new rubric overlay
 	"rubrics.txtRubricAdded": "注釈が追加されました", // Text for notifying screenreader rubric was added
 	"rubrics.txtRubricRemoved": "注釈が削除されました", // Text for notifying screenreader rubric was removed
 	"rubrics.txtConfirmDetachRubric": "注釈を取り外すと、このアクティビティの注釈の以前の評価はすべて削除されます。注釈を取り外しますか？", //Text for the dialog to confirm detaching a rubric from an evaluated activity

--- a/components/d2l-activity-editor/lang/ko.js
+++ b/components/d2l-activity-editor/lang/ko.js
@@ -94,7 +94,6 @@ export default {
 	"rubrics.txtNoRubricAdded": "추가된 루브릭 없음", // rubric summary for no rubrics
 	"rubrics.txtRubricsAdded": "{count, plural, =1 {루브릭 1개 추가} other {{count}개 루브릭 추가}}", // count of asoociated rubrics
 	"rubrics.txtDeleteRubric": "루브릭 삭제", // Text for deleting rubric icon
-	"rubrics.btnClose": "닫기", // X button for exiting the create new rubric overlay
 	"rubrics.txtRubricAdded": "루브릭 추가됨", // Text for notifying screenreader rubric was added
 	"rubrics.txtRubricRemoved": "루브릭 제거됨", // Text for notifying screenreader rubric was removed
 	"rubrics.txtConfirmDetachRubric": "루브릭이 분리되면 이 활동에서 루브릭에 대한 이전의 모든 평가가 삭제됩니다. 루브릭을 분리하시겠습니까?", //Text for the dialog to confirm detaching a rubric from an evaluated activity

--- a/components/d2l-activity-editor/lang/nl.js
+++ b/components/d2l-activity-editor/lang/nl.js
@@ -94,7 +94,6 @@ export default {
 	"rubrics.txtNoRubricAdded": "Geen rubric toegevoegd", // rubric summary for no rubrics
 	"rubrics.txtRubricsAdded": "{count, plural, =1 {1 rubric toegevoegd} other {{count} rubrics toegevoegd}}", // count of asoociated rubrics
 	"rubrics.txtDeleteRubric": "Rubric verwijderen", // Text for deleting rubric icon
-	"rubrics.btnClose": "Sluiten", // X button for exiting the create new rubric overlay
 	"rubrics.txtRubricAdded": "Rubric toegevoegd", // Text for notifying screenreader rubric was added
 	"rubrics.txtRubricRemoved": "Rubric verwijderd", // Text for notifying screenreader rubric was removed
 	"rubrics.txtConfirmDetachRubric": "Zodra de rubric is losgekoppeld, worden alle eerdere evaluaties van de rubric in deze activiteit verwijderd. Wilt u het loskoppelen van de rubric bevestigen?", //Text for the dialog to confirm detaching a rubric from an evaluated activity

--- a/components/d2l-activity-editor/lang/pt.js
+++ b/components/d2l-activity-editor/lang/pt.js
@@ -94,7 +94,6 @@ export default {
 	"rubrics.txtNoRubricAdded": "Nenhuma rubrica adicionada", // rubric summary for no rubrics
 	"rubrics.txtRubricsAdded": "{count, plural, =1 {1 rubrica adicionada} other {{count} rubricas adicionadas}}", // count of asoociated rubrics
 	"rubrics.txtDeleteRubric": "Excluir rubrica", // Text for deleting rubric icon
-	"rubrics.btnClose": "Fechar", // X button for exiting the create new rubric overlay
 	"rubrics.txtRubricAdded": "Rubrica adicionada", // Text for notifying screenreader rubric was added
 	"rubrics.txtRubricRemoved": "Rubrica removida", // Text for notifying screenreader rubric was removed
 	"rubrics.txtConfirmDetachRubric": "Depois que a rubrica for desanexada, todas as avaliações anteriores da rubrica na atividade serão excluídas. Confirmar a exclusão da rubrica?", //Text for the dialog to confirm detaching a rubric from an evaluated activity

--- a/components/d2l-activity-editor/lang/sv.js
+++ b/components/d2l-activity-editor/lang/sv.js
@@ -94,7 +94,6 @@ export default {
 	"rubrics.txtNoRubricAdded": "Du har inte lagt till någon rubrik", // rubric summary for no rubrics
 	"rubrics.txtRubricsAdded": "{count, plural, =1 {1 rubrik har lagts till} other {{count} rubriker har lagts till}}", // count of asoociated rubrics
 	"rubrics.txtDeleteRubric": "Ta bort rubricering", // Text for deleting rubric icon
-	"rubrics.btnClose": "Stäng", // X button for exiting the create new rubric overlay
 	"rubrics.txtRubricAdded": "Rubriken har lagts till", // Text for notifying screenreader rubric was added
 	"rubrics.txtRubricRemoved": "Rubriken har tagits bort", // Text for notifying screenreader rubric was removed
 	"rubrics.txtConfirmDetachRubric": "När rubriceringen har tagits bort tas alla tidigare bedömningar av rubriceringen i den här aktiviteten bort. Bekräfta borttagning av rubricering?", //Text for the dialog to confirm detaching a rubric from an evaluated activity

--- a/components/d2l-activity-editor/lang/tr.js
+++ b/components/d2l-activity-editor/lang/tr.js
@@ -94,7 +94,6 @@ export default {
 	"rubrics.txtNoRubricAdded": "Rubrik eklenmedi", // rubric summary for no rubrics
 	"rubrics.txtRubricsAdded": "{count, plural, =1 {1 rubrik eklendi} other {{count} rubrik eklendi}}", // count of asoociated rubrics
 	"rubrics.txtDeleteRubric": "Rubriği Sil", // Text for deleting rubric icon
-	"rubrics.btnClose": "Kapat", // X button for exiting the create new rubric overlay
 	"rubrics.txtRubricAdded": "Rubrik eklendi", // Text for notifying screenreader rubric was added
 	"rubrics.txtRubricRemoved": "Rubrik kaldırıldı", // Text for notifying screenreader rubric was removed
 	"rubrics.txtConfirmDetachRubric": "Rubrik ayrıldıktan sonra, bu etkinlikteki rubrik ile ilgili önceki tüm değerlendirmeler silinecektir. Rubrik sökülmesini onaylıyor musunuz?", //Text for the dialog to confirm detaching a rubric from an evaluated activity

--- a/components/d2l-activity-editor/lang/zh-cn.js
+++ b/components/d2l-activity-editor/lang/zh-cn.js
@@ -94,7 +94,6 @@ export default {
 	"rubrics.txtNoRubricAdded": "未添加量规", // rubric summary for no rubrics
 	"rubrics.txtRubricsAdded": "{count, plural, =1 {添加了 1 个量规} other {添加了 {count} 个量规}}", // count of asoociated rubrics
 	"rubrics.txtDeleteRubric": "删除量规", // Text for deleting rubric icon
-	"rubrics.btnClose": "关闭", // X button for exiting the create new rubric overlay
 	"rubrics.txtRubricAdded": "量规已添加", // Text for notifying screenreader rubric was added
 	"rubrics.txtRubricRemoved": "量规已移除", // Text for notifying screenreader rubric was removed
 	"rubrics.txtConfirmDetachRubric": "一旦分离量规，此活动中所以之前评估的量规都将被删除。是否确认分离量规？", //Text for the dialog to confirm detaching a rubric from an evaluated activity

--- a/components/d2l-activity-editor/lang/zh-tw.js
+++ b/components/d2l-activity-editor/lang/zh-tw.js
@@ -94,7 +94,6 @@ export default {
 	"rubrics.txtNoRubricAdded": "未新增量規", // rubric summary for no rubrics
 	"rubrics.txtRubricsAdded": "{count, plural, =1 {已新增 1 個量規} other {已新增 {count} 個量規}}", // count of asoociated rubrics
 	"rubrics.txtDeleteRubric": "刪除量規", // Text for deleting rubric icon
-	"rubrics.btnClose": "關閉", // X button for exiting the create new rubric overlay
 	"rubrics.txtRubricAdded": "量規已新增", // Text for notifying screenreader rubric was added
 	"rubrics.txtRubricRemoved": "量規已移除", // Text for notifying screenreader rubric was removed
 	"rubrics.txtConfirmDetachRubric": "中斷連結量規後，系統將刪除此活動中所有之前的量規評量。確認中斷連結量規？", //Text for the dialog to confirm detaching a rubric from an evaluated activity

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "d2l-polymer-siren-behaviors": "Brightspace/polymer-siren-behaviors#semver:^1",
     "d2l-rubric": "Brightspace/d2l-rubric#semver:^3",
     "d2l-save-status": "Brightspace/d2l-save-status#semver:^3",
-    "d2l-simple-overlay": "Brightspace/simple-overlay#semver:^3",
     "d2l-table": "BrightspaceUI/table#semver:^2",
     "d2l-telemetry-browser-client": "Brightspace/d2l-telemetry-browser-client#semver:^1",
     "d2l-tooltip": "BrightspaceUI/tooltip#semver:^3",


### PR DESCRIPTION
The d2l-simple-overlay component is being replaced with the d2l-dialog-fullscreen component. The functionality of the page should not be affected. 

Here's a gif of the new look: 
![add_rubric_new](https://user-images.githubusercontent.com/83968927/120670244-3b8d0680-c45e-11eb-8de5-aa36bd54ab6c.gif)

I noticed that the "Edit rubric" title is part of the body, rather than being in the header. We can move that to the header, but I decided to keep it as it was for this PR(the overlay header was also empty). 
