### PR TITLE
Only show due date subtle button for modules, expand to show field for other content types

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
@@ -63,7 +63,7 @@ class ContentEditorDetail extends MobxLitElement {
 					.href="${contentActivityHref}"
 					.token="${this.token}"
 				>
-					${this._renderDueDate()}
+					${this._renderDueDate(true)}
 				</d2l-activity-content-web-link-detail>
 			`;
 		}
@@ -74,7 +74,7 @@ class ContentEditorDetail extends MobxLitElement {
 					.href="${contentActivityHref}"
 					.token="${this.token}"
 				>
-					${this._renderDueDate()}
+					${this._renderDueDate(true)}
 				</d2l-activity-content-lti-link-detail>
 			`;
 		}
@@ -85,7 +85,7 @@ class ContentEditorDetail extends MobxLitElement {
 					.href="${contentActivityHref}"
 					.token="${this.token}"
 				>
-					${this._renderDueDate()}
+					${this._renderDueDate(true)}
 				</d2l-activity-content-file-detail>
 			`;
 		}
@@ -93,12 +93,13 @@ class ContentEditorDetail extends MobxLitElement {
 		return html``;
 	}
 
-	_renderDueDate() {
+	_renderDueDate(expanded) {
 		return html`
 			<div slot="due-date">
 				<d2l-activity-content-editor-due-date
 					.href="${this.href}"
 					.token="${this.token}"
+					.expanded="${expanded}"
 				>
 				</d2l-activity-content-editor-due-date>
 			</div>

--- a/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-due-date.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-due-date.js
@@ -8,8 +8,8 @@ class ContentEditorDueDate extends LocalizeActivityEditorMixin(MobxLitElement) {
 
 	static get properties() {
 		return {
-			_hasDatePermissions: { type: Boolean },
-			_showAddDueDateBtn: { type: Boolean }
+			expanded: { type: Boolean },
+			_hasDatePermissions: { type: Boolean }
 		};
 	}
 
@@ -32,7 +32,6 @@ class ContentEditorDueDate extends LocalizeActivityEditorMixin(MobxLitElement) {
 	constructor() {
 		super();
 		this._hasDatePermissions = false;
-		this._showAddDueDateBtn = true;
 	}
 
 	render() {
@@ -48,14 +47,14 @@ class ContentEditorDueDate extends LocalizeActivityEditorMixin(MobxLitElement) {
 				<d2l-button-subtle
 					text="${this.localize('content.addDueDate')}"
 					@click="${this._showDueDate}"
-					?hidden="${!this._showAddDueDateBtn}"
+					?hidden="${this.expanded}"
 				>
 				</d2l-button-subtle>
 				<d2l-activity-due-date-editor
 					.href="${this.href}"
 					.token="${this.token}"
 					?skeleton="${this.skeleton}"
-					?hidden="${this._showAddDueDateBtn}"
+					?hidden="${!this.expanded}"
 				>
 				</d2l-activity-due-date-editor>
 			</div>
@@ -71,12 +70,12 @@ class ContentEditorDueDate extends LocalizeActivityEditorMixin(MobxLitElement) {
 		this._hasDatePermissions = dates.canEditDates;
 		// if due date exists on the activity, show the field
 		if (dates.dueDate) {
-			this._showAddDueDateBtn = false;
+			this.expanded = true;
 		}
 	}
 
 	_showDueDate() {
-		this._showAddDueDateBtn = false;
+		this.expanded = true;
 	}
 }
 customElements.define('d2l-activity-content-editor-due-date', ContentEditorDueDate);


### PR DESCRIPTION
## Relevant Rally Links 

[US128149](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F604435412380&fdp=true?fdp=true): FACE pages - due dates component - default to expanded state (but not on modules)

## Related PRs
Add skeletons for due dates under expanded or not scenarios: https://github.com/BrightspaceHypermediaComponents/activities/pull/1771

## Description
​
We don't want to hide the due date field by default when creating or editing non-module content items. But for modules we still want to default to the subtle button which needs to be clicked to display the date/time fields.
​
## Goal/Solution
​
I've replaced the internal `_showAddDueDateBtn` with a public `expanded` attribute. It defaults to false but then in the `_renderDueDate` function I'm passing in an override for the types that we want to default to expanded.

## Video/Screenshots
​
Before:
![before-expanded-due-date](https://user-images.githubusercontent.com/2243995/120519175-f4d4d900-c397-11eb-8f43-9627fa0d1a20.gif)

After:
![after-expanded-due-date](https://user-images.githubusercontent.com/2243995/120519250-061de580-c398-11eb-850e-8d532c61e67a.gif)
​
## Remaining Work

US128149 calls for ensuring skeletonization of the due date controls. This change will be posted in a separate PR. UPDATE: #1771 