### PR TITLE
add skeletons for due dates under expanded or not scenarios

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-due-date.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-due-date.js
@@ -26,7 +26,7 @@ class ContentEditorDueDate extends SkeletonMixin(LocalizeActivityEditorMixin(Rtl
 					display: none;
 				}
 				#duedate-container {
-					padding-bottom: 20px;
+					margin-bottom: 20px;
 				}
 			`
 		];
@@ -53,7 +53,7 @@ class ContentEditorDueDate extends SkeletonMixin(LocalizeActivityEditorMixin(Rtl
 
 		return html `
 			<div id="duedate-container">
-				<d2l-button-subtle class="d2l-skeletize"
+				<d2l-button-subtle
 					text="${this.localize('content.addDueDate')}"
 					@click="${this._showDueDate}"
 					?hidden="${this.expanded}"

--- a/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-due-date.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-due-date.js
@@ -3,8 +3,10 @@ import { css, html } from 'lit-element/lit-element.js';
 import { shared as activityStore } from '../../state/activity-store.js';
 import { LocalizeActivityEditorMixin } from '../../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
-class ContentEditorDueDate extends LocalizeActivityEditorMixin(MobxLitElement) {
+class ContentEditorDueDate extends SkeletonMixin(LocalizeActivityEditorMixin(RtlMixin(MobxLitElement))) {
 
 	static get properties() {
 		return {
@@ -15,6 +17,7 @@ class ContentEditorDueDate extends LocalizeActivityEditorMixin(MobxLitElement) {
 
 	static get styles() {
 		return  [
+			super.styles,
 			css`
 				:host {
 					display: block;
@@ -32,11 +35,17 @@ class ContentEditorDueDate extends LocalizeActivityEditorMixin(MobxLitElement) {
 	constructor() {
 		super();
 		this._hasDatePermissions = false;
+		this.skeleton = true;
 	}
 
 	render() {
 		// TODO - replace with shared component from UI/core when one is created
 		this._getDueDateAndPermission();
+
+		if (this.skeleton)
+		{
+			return html `<div id="duedate-container" class="d2l-skeletize d2l-skeletize-20">&nbsp;</div>`;
+		}
 
 		if (!this._hasDatePermissions) {
 			return html ``;
@@ -44,7 +53,7 @@ class ContentEditorDueDate extends LocalizeActivityEditorMixin(MobxLitElement) {
 
 		return html `
 			<div id="duedate-container">
-				<d2l-button-subtle
+				<d2l-button-subtle class="d2l-skeletize"
 					text="${this.localize('content.addDueDate')}"
 					@click="${this._showDueDate}"
 					?hidden="${this.expanded}"
@@ -63,6 +72,11 @@ class ContentEditorDueDate extends LocalizeActivityEditorMixin(MobxLitElement) {
 
 	_getDueDateAndPermission() {
 		const entity = activityStore.get(this.href);
+
+		if (entity) {
+			this.skeleton = false;
+		}
+
 		if (!entity || !entity.dates) {
 			return;
 		}


### PR DESCRIPTION
## Relevant Rally Links 

[US128149](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F604435412380&fdp=true?fdp=true): FACE pages - due dates component - default to expanded state (but not on modules)

## Related PRs

Only show due date subtle button for modules, expand to show field for other content types: https://github.com/BrightspaceHypermediaComponents/activities/pull/1770

## Description
​
Skeletons were not appearing on the due date control when it displayed the subtle button. This PR aims to fix that.
​
## Goal/Solution
​
`d2l-subtle-button` does not natively support skeletons. To provide them I've added the `SkeletonMixin` to the `ContentEditorDueDate` web component and applied the `d2l-skeletize` class to the button.

This did not completely solve the problem, however, as there is a period of time between loading this component and when it gets the due date information loaded. During this time the component rendered empty html, which led to a 'pop-in' effect. I've added some logic to show an empty skeleton div during this period.

Unfortunately there is a little bit of movement as things render because the component doesn't know if it will be showing the date controls or the subtle button and so the in-between skeleton doesn't exactly match the size. It seems pretty decent, though, and I am not sure of a way to avoid this.

## Video/Screenshots
​
### Before
loading a module with no dates:
![load-module-no-date-skeletons-before](https://user-images.githubusercontent.com/2243995/120524937-35832100-c39d-11eb-81d3-75a85b870b33.gif)

loading a module with dates:
![load-module-with-date-skeletons-before](https://user-images.githubusercontent.com/2243995/120525020-49c71e00-c39d-11eb-8b36-a5c7411142c1.gif)

creating a weblink:
![create-weblink-skeletons-before](https://user-images.githubusercontent.com/2243995/120525046-50ee2c00-c39d-11eb-9e7c-fb79ae355387.gif)

### After
loading a module with no dates:
![load-module-no-date-skeletons-after](https://user-images.githubusercontent.com/2243995/120525082-5e0b1b00-c39d-11eb-8ded-4fd0ce66a3e9.gif)

loading a module with dates:
![load-module-with-date-skeletons-after](https://user-images.githubusercontent.com/2243995/120525109-65cabf80-c39d-11eb-8482-4beed5761d8c.gif)

creating a weblink:
![create-weblink-skeletons-after](https://user-images.githubusercontent.com/2243995/120525147-6e22fa80-c39d-11eb-8b95-4d168a700ce7.gif)
​
## Remaining Work

none