### PR TITLE
US125507 - Fix dialog height and async

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
@@ -107,81 +107,10 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 				?opened="${this.opened}"
 				@d2l-dialog-open="${this._onDialogOpen}"
 				?async="${showSpinnerWhenLoading}">
-				${this.renderDialogEditor()}
+				${this._renderDialogEditor()}
 				<d2l-button slot="footer" primary @click=${this._saveAssociateGrade} ?disabled="${this.isSaving}">${this.localize('editor.ok')}</d2l-button>
 				<d2l-button slot="footer" @click=${this._cancel} ?disabled="${this.isSaving}">${this.localize('editor.cancel')}</d2l-button>
 			</d2l-dialog>
-		`;
-	}
-
-	renderDialogEditor() {
-		const href = this._createSelectboxGradeItemEnabled ? this.dialogHref : this.href;
-
-		const activity = store.get(href);
-		if (!activity) {
-			return html``;
-		}
-
-		const scoreAndGrade = store.get(this.baseActivityUsageHref).scoreAndGrade;
-		const {
-			scoreOutOf,
-			scoreOutOfError,
-			newGradeName
-		} = scoreAndGrade;
-
-		return html`
-			<div class="d2l-activity-grades-dialog-editor">
-				<label class="d2l-input-radio-label ${!this._canLinkNewGrade ? 'd2l-input-radio-label-disabled' : ''}">
-					<input
-						type="radio"
-						name="chooseFromGrades"
-						value="createNew"
-						?disabled="${!this._canLinkNewGrade}"
-						.checked="${this._createNewRadioChecked}"
-						@change="${this._dialogRadioChanged}">
-					${this.localize('editor.createAndLinkToNewGradeItem')}
-				</label>
-				<d2l-input-radio-spacer ?hidden="${!this._createNewRadioChecked && this._canLinkNewGrade}">
-					${this._canLinkNewGrade ? html`
-						<div class="d2l-activity-grades-dialog-create-new-container">
-							<div class="d2l-activity-grades-dialog-create-new-icon"><d2l-icon class="d2l-activity-grades-dialog-grade-icon" icon="tier1:grade"></d2l-icon></div>
-							<div>
-								<div class="d2l-activity-grades-dialog-create-new-activity-name">${newGradeName}</div>
-								<div class="d2l-body-small">${scoreOutOf && !scoreOutOfError ? html`
-									${this.localize('editor.points', { points: formatNumber(scoreOutOf, { maximumFractionDigits: 2 }) })}
-								` : null }
-								</div>
-							</div>
-						</div>
-						<d2l-activity-grade-category-selector
-							.href="${href}"
-							.token="${this.token}">
-						</d2l-activity-grade-category-selector>
-					` : html`
-						<div class="d2l-body-small">
-							${this.localize('editor.noGradeCreatePermission')}
-						</div>
-					`}
-				</d2l-input-radio-spacer>
-				<label id="linkToExistingGradeItemRadioButton" class="d2l-input-radio-label ${!this._hasGradeCandidates ? 'd2l-input-radio-label-disabled' : ''}">
-					<input
-						type="radio"
-						name="chooseFromGrades"
-						value="linkExisting"
-						?disabled="${!this._hasGradeCandidates}"
-						.checked="${!this._createNewRadioChecked && this._hasGradeCandidates}"
-						@change="${this._dialogRadioChanged}">
-					${this.localize('editor.linkToExistingGradeItem')}
-				</label>
-				<d2l-input-radio-spacer ?hidden="${this._createNewRadioChecked && this._hasGradeCandidates}" ?disabled="${!this._hasGradeCandidates}">
-					${this._hasGradeCandidates ? html`<d2l-activity-grade-candidate-selector
-						.href="${href}"
-						.token="${this.token}">
-					</d2l-activity-grade-candidate-selector>` : html`<div class="d2l-body-small">
-						${this.localize('editor.noGradeItems')}
-					</div>`}
-				</d2l-input-radio-spacer>
-			</div>
 		`;
 	}
 
@@ -300,6 +229,77 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 			gradeCategorySelector && gradeCategorySelector.resetShowCategoriesProperty();
 			e.target.resize();
 		}
+	}
+
+	_renderDialogEditor() {
+		const href = this._createSelectboxGradeItemEnabled ? this.dialogHref : this.href;
+
+		const activity = store.get(href);
+		if (!activity) {
+			return html``;
+		}
+
+		const scoreAndGrade = store.get(this.baseActivityUsageHref).scoreAndGrade;
+		const {
+			scoreOutOf,
+			scoreOutOfError,
+			newGradeName
+		} = scoreAndGrade;
+
+		return html`
+			<div class="d2l-activity-grades-dialog-editor">
+				<label class="d2l-input-radio-label ${!this._canLinkNewGrade ? 'd2l-input-radio-label-disabled' : ''}">
+					<input
+						type="radio"
+						name="chooseFromGrades"
+						value="createNew"
+						?disabled="${!this._canLinkNewGrade}"
+						.checked="${this._createNewRadioChecked}"
+						@change="${this._dialogRadioChanged}">
+					${this.localize('editor.createAndLinkToNewGradeItem')}
+				</label>
+				<d2l-input-radio-spacer ?hidden="${!this._createNewRadioChecked && this._canLinkNewGrade}">
+					${this._canLinkNewGrade ? html`
+						<div class="d2l-activity-grades-dialog-create-new-container">
+							<div class="d2l-activity-grades-dialog-create-new-icon"><d2l-icon class="d2l-activity-grades-dialog-grade-icon" icon="tier1:grade"></d2l-icon></div>
+							<div>
+								<div class="d2l-activity-grades-dialog-create-new-activity-name">${newGradeName}</div>
+								<div class="d2l-body-small">${scoreOutOf && !scoreOutOfError ? html`
+									${this.localize('editor.points', { points: formatNumber(scoreOutOf, { maximumFractionDigits: 2 }) })}
+								` : null }
+								</div>
+							</div>
+						</div>
+						<d2l-activity-grade-category-selector
+							.href="${href}"
+							.token="${this.token}">
+						</d2l-activity-grade-category-selector>
+					` : html`
+						<div class="d2l-body-small">
+							${this.localize('editor.noGradeCreatePermission')}
+						</div>
+					`}
+				</d2l-input-radio-spacer>
+				<label id="linkToExistingGradeItemRadioButton" class="d2l-input-radio-label ${!this._hasGradeCandidates ? 'd2l-input-radio-label-disabled' : ''}">
+					<input
+						type="radio"
+						name="chooseFromGrades"
+						value="linkExisting"
+						?disabled="${!this._hasGradeCandidates}"
+						.checked="${!this._createNewRadioChecked && this._hasGradeCandidates}"
+						@change="${this._dialogRadioChanged}">
+					${this.localize('editor.linkToExistingGradeItem')}
+				</label>
+				<d2l-input-radio-spacer ?hidden="${this._createNewRadioChecked && this._hasGradeCandidates}" ?disabled="${!this._hasGradeCandidates}">
+					${this._hasGradeCandidates ? html`<d2l-activity-grade-candidate-selector
+						.href="${href}"
+						.token="${this.token}">
+					</d2l-activity-grade-candidate-selector>` : html`<div class="d2l-body-small">
+						${this.localize('editor.noGradeItems')}
+					</div>`}
+				</d2l-input-radio-spacer>
+			</div>
+		`;
 	}
 
 	async _saveAssociateGrade(e) {

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-working-copy-dialog-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-working-copy-dialog-mixin.js
@@ -75,7 +75,7 @@ export const ActivityEditorWorkingCopyDialogMixin = superclass => class extends 
 		this.handleClose(e);
 	}
 
-	async openDialog(e) {
+	async openDialog(e, skipCheckout) {
 		const dialog = this.shadowRoot.querySelector('d2l-dialog');
 		dialog && dialog.resetAsyncState();
 		this._resetProps();
@@ -84,7 +84,10 @@ export const ActivityEditorWorkingCopyDialogMixin = superclass => class extends 
 		if (!entity) return;
 
 		this.open(e);
-		this.dialogHref = await entity.checkout(this.store, true);
+
+		if (!skipCheckout) {
+			this.dialogHref = await entity.checkout(this.store, true);
+		}
 	}
 
 	async _focusOnInvalid() {


### PR DESCRIPTION
Non working copy (i.e. `createSelectboxGradeItemEnabled` is `false`) will not be using the loading spinner in the dialog. It will open when it is ready just like the existing behavior.

Working copy (i.e. `createSelectboxGradeItemEnabled` is `true`) will be using the loading spinner in the dialog. The loading spinner still acts a bit funny and might disappear too soon before everything is loaded. I'll like to see how it performs on quad.

https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F505562087036&expandApp=486232622048&fdp=true?fdp=true