### PR TITLE
Add display options label and update lang terms

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-options.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-options.js
@@ -4,7 +4,7 @@ import '@brightspace-ui/core/components/button/button-subtle.js';
 import { activityContentEditorStyles } from '../shared-components/d2l-activity-content-editor-styles.js';
 import { ActivityEditorMixin } from '../../mixins/d2l-activity-editor-mixin.js';
 import { ErrorHandlingMixin } from '../../error-handling-mixin.js';
-import { html } from 'lit-element/lit-element.js';
+import { css, html } from 'lit-element/lit-element.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeActivityEditorMixin } from '../../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
@@ -26,7 +26,15 @@ class ContentEditorLtiLinkOptions extends SkeletonMixin(ErrorHandlingMixin(Local
 			super.styles,
 			labelStyles,
 			radioStyles,
-			activityContentEditorStyles
+			activityContentEditorStyles,
+			css`
+				.display-options-text {
+					padding: 0 0 7px 0;
+				}
+				#open-new-tab-help-span {
+					margin-left: 7px;
+				}
+			`
 		];
 	}
 
@@ -47,6 +55,7 @@ class ContentEditorLtiLinkOptions extends SkeletonMixin(ErrorHandlingMixin(Local
 
 		return html`
 		<div id="content-link-options-container" class="d2l-skeletize">
+			<div class="d2l-label-text display-options-text">${this.localize('content.displayOptions')}</div>
 			<label class="d2l-input-radio-label">
 				<input
 					id="embed-on-page"
@@ -66,6 +75,15 @@ class ContentEditorLtiLinkOptions extends SkeletonMixin(ErrorHandlingMixin(Local
                     ?checked="${isExternalResource}"
                     @change="${this._saveLinkOptions}">
 					${this.localize('content.openNewTab')}
+					<span id="open-new-tab-help-span" tabindex="0">
+						<d2l-icon
+							icon="d2l-tier1:help">
+						</d2l-icon>
+						<d2l-tooltip
+							for="open-new-tab-help-span">
+							${this.localize('content.openNewTabHelp')}
+						</d2l-tooltip>
+					</span>
 			</label>
 		</div>
 		`;

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-editor-link.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-editor-link.js
@@ -40,6 +40,12 @@ class ContentEditorLink extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 				:host > div {
 					padding-bottom: 20px;
 				}
+				.display-options-text {
+					padding: 0 0 7px 0;
+				}
+				#open-new-tab-help-span {
+					margin-left: 7px;
+				}
 			`
 		];
 	}
@@ -79,6 +85,7 @@ class ContentEditorLink extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 				${this._renderLinkTooltip()}
 			</div>
 			<div id="content-link-options-container" class="d2l-skeletize">
+				<div class="d2l-label-text display-options-text">${this.localize('content.displayOptions')}</div>
 				<label class="d2l-input-radio-label">
 					<input
 						id="embed-on-page"
@@ -98,6 +105,15 @@ class ContentEditorLink extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 						?checked="${isExternalResource}"
 						@change="${this._saveLink}">
 						${this.localize('content.openNewTab')}
+						<span id="open-new-tab-help-span" tabindex="0">
+							<d2l-icon
+								icon="d2l-tier1:help">
+							</d2l-icon>
+							<d2l-tooltip
+								for="open-new-tab-help-span">
+								${this.localize('content.openNewTabHelp')}
+							</d2l-tooltip>
+						</span>
 				</label>
 			</div>
 		`;

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -130,9 +130,11 @@ export default {
 	"content.pageContent": "Page Content", // Text label for page content input field (HTML files)
 	"content.availabilityHeader": "Availability Dates", // availability header
 	"content.saveError": "Your content item wasn't saved. Please correct the fields outlined in red.", // Error message to inform the user that there was a problem saving the content item, instructing them to correct invalid fields
+	"content.displayOptions": "Display Options", // Text label for display options
 	"content.addDueDate": "Add Due Date", // Text label for name input field
-	"content.embedOnPage": "Embed on the page (iframe)", // Text label for link radio button
-	"content.openNewTab": "Open in a new tab", // Text label for link radio button
+	"content.embedOnPage": "Embed on the page", // Text label for link radio button
+	"content.openNewTab": "Open in a new tab (recommended)", // Text label for link radio button
+	"content.openNewTabHelp": "Time on page is not tracked", // ARIA label for the help icon next to link radio button
 	"content.link": "Link", //Text label for link input field
 	"content.emptyLinkField": "Link is required.", //Error message shown on link tooltip when the link is empty
 	"content.invalidLink": "Please enter a valid URL.", //Error message shown on link tooltip when the link is not formatted correctly


### PR DESCRIPTION
## Relevant Rally Links

https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F604435423216

## Description

There are new designs that affect LTI (and Weblink) pages for FACE work (link to designs in the Rally ticket linked above).

## Goal/Solution

As per the new design, the langterms on LTI/Weblink FACE pages have been updated, and a 'Display Options` header label added. Furthermore, a help focusable icon has been added, upon hovering/focusing on which, the required tooltip is displayed. 

## Screenshots

*Note: Changes to default/local langterms don't reflect at the time of this PR unfortunately, so while the langterms themselves have been updated, the screenshot with the changes taken of my local LMS doesn't reflect that. See: https://d2l.slack.com/archives/C0PHG3QB0/p1622736515166100

Before:
![image](https://user-images.githubusercontent.com/29843252/120752672-b2161c80-c4cf-11eb-9410-8e05621b6e40.png)

After:
![image](https://user-images.githubusercontent.com/29843252/120752533-7d09ca00-c4cf-11eb-9f08-108a66fb5c54.png)

