### PR TITLE
US125507 - clean up all the hrefs!

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
@@ -19,7 +19,6 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 
 	static get properties() {
 		return {
-			baseActivityUsageHref: { type: String, attribute: 'base-activity-usage-href' },
 			_createNewRadioChecked: { type: Boolean },
 			_canLinkNewGrade: { type: Boolean },
 			_hasGradeCandidates: { type: Boolean },
@@ -81,8 +80,6 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 	connectedCallback() {
 		super.connectedCallback();
 
-		this.checkedOutHref = this.href;
-
 		const event = new CustomEvent('d2l-request-provider', {
 			detail: { key: 'd2l-provider-create-selectbox-grade-item-enabled' },
 			bubbles: true,
@@ -92,6 +89,10 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 		this.dispatchEvent(event);
 
 		this._createSelectboxGradeItemEnabled = event.detail.provider;
+		if (!this._createSelectboxGradeItemEnabled) {
+			this.checkoutOnLoad = false;
+			this.checkedOutHref = this.href;
+		}
 	}
 
 	render() {
@@ -116,10 +117,7 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 
 	async openGradesDialog() {
 		if (this._createSelectboxGradeItemEnabled) {
-			this.openDialog(null, true);
-			const entity = store.get(this.href);
-			if (!entity) return;
-			this.dialogHref = await entity.checkout(store, true);
+			await this.openDialog();
 		}
 
 		const href = this.dialogHref || this.href;
@@ -167,7 +165,7 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 	}
 
 	async _associateGradeSetGradebookStatus(gradebookStatus) {
-		const scoreAndGrade = store.get(this.baseActivityUsageHref).scoreAndGrade;
+		const scoreAndGrade = store.get(this.dialogHref).scoreAndGrade;
 
 		const associateGrade = associateGradeStore.get(this._associateGradeHref);
 		if (!scoreAndGrade || !associateGrade) return;
@@ -239,7 +237,7 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 			return html``;
 		}
 
-		const scoreAndGrade = store.get(this.baseActivityUsageHref).scoreAndGrade;
+		const scoreAndGrade = store.get(this.href).scoreAndGrade;
 		const {
 			scoreOutOf,
 			scoreOutOfError,

--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
@@ -164,11 +164,17 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 	}
 
 	async _associateGradeSetGradebookStatus(gradebookStatus) {
-		const scoreAndGrade = store.get(this.dialogHref).scoreAndGrade;
+		const dialogEntity = store.get(this.dialogHref);
+		const scoreAndGradeDialog = dialogEntity && dialogEntity.scoreAndGrade;
 
 		const associateGrade = associateGradeStore.get(this._associateGradeHref);
-		if (!scoreAndGrade || !associateGrade) return;
-		await associateGrade.setGradebookStatus(gradebookStatus, scoreAndGrade.newGradeName, scoreAndGrade.scoreOutOf);
+
+		const baseEntity = store.get(this.href);
+		const scoreAndGradeBase = baseEntity && baseEntity.scoreAndGrade;
+
+		if (!scoreAndGradeDialog || !associateGrade || !scoreAndGradeBase) return;
+
+		await associateGrade.setGradebookStatus(gradebookStatus, scoreAndGradeBase.newGradeName, scoreAndGradeBase.scoreOutOf);
 	}
 
 	_cancel(e) {

--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
@@ -164,15 +164,12 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 	}
 
 	async _associateGradeSetGradebookStatus(gradebookStatus) {
-		const dialogEntity = store.get(this.dialogHref);
-		const scoreAndGradeDialog = dialogEntity && dialogEntity.scoreAndGrade;
-
-		const associateGrade = associateGradeStore.get(this._associateGradeHref);
-
 		const baseEntity = store.get(this.href);
 		const scoreAndGradeBase = baseEntity && baseEntity.scoreAndGrade;
 
-		if (!scoreAndGradeDialog || !associateGrade || !scoreAndGradeBase) return;
+		const associateGrade = associateGradeStore.get(this._associateGradeHref);
+
+		if (!scoreAndGradeBase || !associateGrade) return;
 
 		await associateGrade.setGradebookStatus(gradebookStatus, scoreAndGradeBase.newGradeName, scoreAndGradeBase.scoreOutOf);
 	}

--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
@@ -91,7 +91,6 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 		this._createSelectboxGradeItemEnabled = event.detail.provider;
 		if (!this._createSelectboxGradeItemEnabled) {
 			this.checkoutOnLoad = false;
-			this.checkedOutHref = this.href;
 		}
 	}
 
@@ -160,7 +159,7 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 		}
 
 		if (!this._createSelectboxGradeItemEnabled) {
-			this.openDialog(null, true);
+			this.openDialog();
 		}
 	}
 
@@ -305,13 +304,9 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 			const entity = store.get(this.dialogHref);
 			if (!entity) return;
 
-			await entity.saving; // Wait for timing entity PATCH requests to complete before checking in
+			await entity.saving; // Wait for activity usage entity PATCH requests to complete before checking in
 
 			await this.checkinDialog(e);
-
-			if (!this.opened) { // Dialog successfully checked in
-				// do something
-			}
 		} else {
 			const scoreAndGrade = store.get(this.href).scoreAndGrade;
 

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -178,7 +178,7 @@ class ActivityScoreEditor extends ActivityEditorMixin(SkeletonMixin(LocalizeActi
 		this.dispatchEvent(event);
 
 		this._createSelectboxGradeItemEnabled = event.detail.provider;
-		this.checkoutOnLoad = event.detail.provider;
+		this.checkoutOnLoad = this._createSelectboxGradeItemEnabled;
 	}
 
 	render() {
@@ -197,8 +197,6 @@ class ActivityScoreEditor extends ActivityEditorMixin(SkeletonMixin(LocalizeActi
 
 		const inGradesTerm = this._createSelectboxGradeItemEnabled ? this.localize('editor.inGradebook') : this.localize('editor.inGrades');
 		const notInGradesTerm = this._createSelectboxGradeItemEnabled ? this.localize('editor.notInGradebook') : this.localize('editor.notInGrades');
-
-		const workingCopyHref = this.checkedOutHref || this.href;
 
 		return isUngraded || this.skeleton ? html`
 			<div id="ungraded-button-container" class="d2l-skeletize">
@@ -262,8 +260,7 @@ class ActivityScoreEditor extends ActivityEditorMixin(SkeletonMixin(LocalizeActi
 							</d2l-dropdown-menu>
 						</d2l-dropdown>
 						<d2l-activity-grades-dialog
-							href="${workingCopyHref}"
-							base-activity-usage-href="${this.href}"
+							href="${this.href}"
 							.token="${this.token}"></d2l-activity-grades-dialog>
 					</div>
 				` : null}

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-working-copy-dialog-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-working-copy-dialog-mixin.js
@@ -75,19 +75,16 @@ export const ActivityEditorWorkingCopyDialogMixin = superclass => class extends 
 		this.handleClose(e);
 	}
 
-	async openDialog(e, skipCheckout) {
+	async openDialog(e) {
 		const dialog = this.shadowRoot.querySelector('d2l-dialog');
 		dialog && dialog.resetAsyncState();
 		this._resetProps();
 
-		const entity = this.store.get(this.checkedOutHref);
-		if (!entity) return;
-
 		this.open(e);
 
-		if (!skipCheckout) {
-			this.dialogHref = await entity.checkout(this.store, true);
-		}
+		const entity = this.store.get(this.checkedOutHref);
+		if (!entity) return;
+		this.dialogHref = await entity.checkout(this.store, true);
 	}
 
 	async _focusOnInvalid() {


### PR DESCRIPTION
It's magic.

https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F505562087036&expandApp=486232622048&fdp=true?fdp=true

We are only passing in the base activity usage as the `href` to the `grades-dialog`, and no other `href`s. The working copy will be checked out in the `score-editor` which is the parent of the `grades-dialog`. This 1st working copy `href` is stored as a property in the MobX object of the base activity usage.

With the selectbox flag on, aka using working copy, the `grades-dialog` component will mostly be making references to the `dialogHref`. The `dialogHref` which is a string set in the `workingCopyDialogMixin` via a checkout action off the first working copy. It knows the `href` of the first working copy because it can retrieve it from a property in the MobX object of the base activity usage.

With the selectbox flag off, aka not using working copy, the `grades-dialog` component will only be using the `href`. It will not use the `checkoutHref` or the `dialogHref`.

The `grades-dialog` component can still get the "Grade Out Of" and activity "Name" by using the `href` that is passed in and getting the values from the `scoreAndGrade` object of that activityUsage MobX object.

It's basically magic.