### PR TITLE
US125507 - Fix cannot re-open dialog after an 'x' click to close dialog

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
@@ -106,10 +106,11 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 				width="${width}"
 				?opened="${this.opened}"
 				@d2l-dialog-open="${this._onDialogOpen}"
+				@d2l-dialog-close="${this._onDialogClose}"
 				?async="${showSpinnerWhenLoading}">
 				${this._renderDialogEditor()}
-				<d2l-button slot="footer" primary @click=${this._saveAssociateGrade} ?disabled="${this.isSaving}">${this.localize('editor.ok')}</d2l-button>
-				<d2l-button slot="footer" @click=${this._cancel} ?disabled="${this.isSaving}">${this.localize('editor.cancel')}</d2l-button>
+				<d2l-button slot="footer" primary @click=${this._saveAssociateGrade} ?disabled="${this.isSaving}" dialog-action="done">${this.localize('editor.ok')}</d2l-button>
+				<d2l-button slot="footer" @click=${this._cancel} ?disabled="${this.isSaving}" data-dialog-action>${this.localize('editor.cancel')}</d2l-button>
 			</d2l-dialog>
 		`;
 	}
@@ -174,8 +175,8 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 		await associateGrade.setGradebookStatus(gradebookStatus, scoreAndGrade.newGradeName, scoreAndGrade.scoreOutOf);
 	}
 
-	_cancel(e) {
-		if (!this._createSelectboxGradeItemEnabled) {
+	_onDialogClose(e) {
+		if (!this._createSelectboxGradeItemEnabled && e.detail.action !== "done") {
 			const scoreAndGrade = store.get(this.href).scoreAndGrade;
 
 			const {
@@ -191,8 +192,7 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 			}
 			newGradeCandidatesCollection.setSelected(prevSelectedCategoryHref);
 		}
-
-		this.closeDialog(e);
+		this.handleClose(e);
 	}
 
 	async _dialogRadioChanged(e) {
@@ -323,7 +323,7 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 				scoreAndGrade.linkToExistingGrade();
 			}
 
-			this.closeDialog(e);
+			this.closeDialog();
 		}
 	}
 }

--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
@@ -110,7 +110,7 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 				?async="${showSpinnerWhenLoading}">
 				${this._renderDialogEditor()}
 				<d2l-button slot="footer" primary @click=${this._saveAssociateGrade} ?disabled="${this.isSaving}" dialog-action="done">${this.localize('editor.ok')}</d2l-button>
-				<d2l-button slot="footer" @click=${this._cancel} ?disabled="${this.isSaving}" dialog-action="cancel">${this.localize('editor.cancel')}</d2l-button>
+				<d2l-button slot="footer" ?disabled="${this.isSaving}" dialog-action="cancel">${this.localize('editor.cancel')}</d2l-button>
 			</d2l-dialog>
 		`;
 	}

--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
@@ -110,7 +110,7 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 				?async="${showSpinnerWhenLoading}">
 				${this._renderDialogEditor()}
 				<d2l-button slot="footer" primary @click=${this._saveAssociateGrade} ?disabled="${this.isSaving}" dialog-action="done">${this.localize('editor.ok')}</d2l-button>
-				<d2l-button slot="footer" @click=${this._cancel} ?disabled="${this.isSaving}" data-dialog-action>${this.localize('editor.cancel')}</d2l-button>
+				<d2l-button slot="footer" @click=${this._cancel} ?disabled="${this.isSaving}" dialog-action="cancel">${this.localize('editor.cancel')}</d2l-button>
 			</d2l-dialog>
 		`;
 	}
@@ -175,26 +175,6 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 		await associateGrade.setGradebookStatus(gradebookStatus, scoreAndGradeBase.newGradeName, scoreAndGradeBase.scoreOutOf);
 	}
 
-	_onDialogClose(e) {
-		if (!this._createSelectboxGradeItemEnabled && e.detail.action !== "done") {
-			const scoreAndGrade = store.get(this.href).scoreAndGrade;
-
-			const {
-				gradeCandidateCollection,
-				newGradeCandidatesCollection
-			} = scoreAndGrade;
-
-			const prevSelectedHref = gradeCandidateCollection && gradeCandidateCollection.selected ? gradeCandidateCollection.selected.href : null;
-			const prevSelectedCategoryHref = newGradeCandidatesCollection.selected.href;
-
-			if (prevSelectedHref) {
-				gradeCandidateCollection.setSelected(prevSelectedHref);
-			}
-			newGradeCandidatesCollection.setSelected(prevSelectedCategoryHref);
-		}
-		this.handleClose(e);
-	}
-
 	async _dialogRadioChanged(e) {
 		const currentTarget = e.currentTarget;
 		const associateGrade = associateGradeStore.get(this._associateGradeHref);
@@ -221,6 +201,26 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 
 		const dialog = this.shadowRoot.querySelector('d2l-dialog');
 		dialog.resize();
+	}
+
+	_onDialogClose(e) {
+		if (!this._createSelectboxGradeItemEnabled && e.detail.action !== 'done') {
+			const scoreAndGrade = store.get(this.href).scoreAndGrade;
+
+			const {
+				gradeCandidateCollection,
+				newGradeCandidatesCollection
+			} = scoreAndGrade;
+
+			const prevSelectedHref = gradeCandidateCollection && gradeCandidateCollection.selected ? gradeCandidateCollection.selected.href : null;
+			const prevSelectedCategoryHref = newGradeCandidatesCollection.selected.href;
+
+			if (prevSelectedHref) {
+				gradeCandidateCollection.setSelected(prevSelectedHref);
+			}
+			newGradeCandidatesCollection.setSelected(prevSelectedCategoryHref);
+		}
+		this.handleClose(e);
 	}
 
 	_onDialogOpen(e) {

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-dialog-mixin.js
@@ -13,7 +13,7 @@ export const ActivityEditorDialogMixin = superclass => class extends superclass 
 
 	handleClose(e) {
 		this.opened = false;
-		e && e.stopPropagation();
+		e && e.stopPropagation(); //https://github.com/BrightspaceHypermediaComponents/activities/pull/1476#pullrequestreview-585651698
 	}
 
 	open(event) {

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-working-copy-dialog-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-working-copy-dialog-mixin.js
@@ -41,7 +41,7 @@ export const ActivityEditorWorkingCopyDialogMixin = superclass => class extends 
 		this.isSaving = false;
 	}
 
-	async checkinDialog(e) {
+	async checkinDialog() {
 		const entity = this.store.get(this.dialogHref);
 		if (!entity) return;
 

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-working-copy-dialog-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-working-copy-dialog-mixin.js
@@ -68,7 +68,7 @@ export const ActivityEditorWorkingCopyDialogMixin = superclass => class extends 
 			return;
 		}
 
-		this.closeDialog(e);
+		this.closeDialog();
 	}
 
 	async closeDialog(e) {


### PR DESCRIPTION
This is due to it initially only calling `_cancel` on cancel button click. But that function also needs to be called if the dialog is closed via the 'x' or 'esc'. The only way to catch this is to listen to the `d2l-dialog-close` event. The change to not pass the event to our dialog mixin is because the mixin is doing `event.stopPropagation` which was preventing the `done` action in `ok` dialog button presses from being present in the `d2l-dialog-close` event.

https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F505562087036&expandApp=486232622048&fdp=true?fdp=true