### PR TITLE
DE43805 Fix rubrics behavior on save-in-place

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-rubrics/state/association-collection.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/state/association-collection.js
@@ -111,8 +111,8 @@ export class AssociationCollection {
 
 		return false;
 	}
-	async fetch() {
-		const sirenEntity = await fetchEntity(this.href, this.token);
+	async fetch(bypassCache = false) {
+		const sirenEntity = await fetchEntity(this.href, this.token, bypassCache);
 
 		if (sirenEntity) {
 			const entity = new Associations(sirenEntity, this.token);
@@ -185,11 +185,15 @@ export class AssociationCollection {
 		}
 	}
 
-	async save() {
+	async save(saveInPlace) {
 		const associations = this.associationsMap.values();
 
 		for await (const association of associations) {
 			await this._saveChanges(association);
+		}
+
+		if (saveInPlace) {
+			await this.fetch(true);
 		}
 	}
 


### PR DESCRIPTION
Save-in-place was throwing off the existing rubric state management, so this just re-fetches the associations on save-in-place so the UI reflects the correct state (equivalent to loading the assignment from scratch).

There was also a small bug where the rubric 'X' removal button was relying on the event to provide the rubric id, but if the focus was elsewhere when clicking the target event was an unexpected element and the button wouldn't respond. Since the association is available at the time of the click, this switches it to just use the known association href directly.

https://rally1.rallydev.com/#/29180338367ud/custom/486232622040?detail=%2Fdefect%2F600844552471&fdp=true