### PR TITLE
US128152 embed link in iframe

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
@@ -23,7 +23,7 @@ class ContentEditorDetail extends MobxLitElement {
 				d2l-loading-spinner {
 					width: 100%;
 				}
-				d2l-activity-content-module-detail, d2l-activity-content-file-detail {
+				d2l-activity-content-module-detail, d2l-activity-content-file-detail, d2l-activity-content-lti-link-detail {
 					display: flex;
 					flex-direction: column;
 					height: inherit;

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-detail.js
@@ -2,12 +2,12 @@ import '../shared-components/d2l-activity-content-editor-title.js';
 import './d2l-activity-content-lti-link-options.js';
 import './d2l-activity-content-lti-link-external-activity.js';
 import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
+import { css, html } from 'lit-element/lit-element.js';
 import { activityContentEditorStyles } from '../shared-components/d2l-activity-content-editor-styles.js';
 import { ActivityEditorMixin } from '../../mixins/d2l-activity-editor-mixin.js';
 import { ContentLTILinkEntity } from 'siren-sdk/src/activities/content/ContentLTILinkEntity.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { ErrorHandlingMixin } from '../../error-handling-mixin.js';
-import { html } from 'lit-element/lit-element.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeActivityEditorMixin } from '../../mixins/d2l-activity-editor-lang-mixin.js';
 import { shared as ltiLinkStore } from './state/content-lti-link-store.js';
@@ -21,7 +21,12 @@ class ContentLTILinkDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandli
 		return  [
 			super.styles,
 			labelStyles,
-			activityContentEditorStyles
+			activityContentEditorStyles,
+			css`
+				d2l-activity-content-lti-link-external-activity {
+					height: 100%;
+				}
+			`,
 		];
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-detail.js
@@ -25,6 +25,7 @@ class ContentLTILinkDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandli
 			css`
 				d2l-activity-content-lti-link-external-activity {
 					height: 100%;
+					margin-top: 36px;
 				}
 			`,
 		];

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-external-activity.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-external-activity.js
@@ -23,25 +23,23 @@ class ActivityContentLTILinkExternalActivity extends SkeletonMixin(LocalizeActiv
 		return [
 			super.styles,
 			css`
-			.d2l-external-activity-outer-frame {
-				display: flex;
-				flex-direction: column;
-				height: 100%;
-				justify-content: flex-start;
-			}
-			.d2l-content-link-external-activity {
-				align-items: center;
-				display: flex;
-				justify-content: space-between;
-			}
-			.d2l-external-activity-inner-frame {
-				display: flex;
-				margin-top: 36px;
-				padding-top: 36px;
-			}
-			d2l-activity-content-lti-link-preview {
-				height: 100%;
-			}
+				.d2l-external-activity-outer-frame {
+					display: flex;
+					flex-direction: column;
+					height: 100%;
+					justify-content: flex-start;
+				}
+				.d2l-content-link-external-activity {
+					align-items: center;
+					display: flex;
+					justify-content: space-between;
+				}
+				.d2l-external-activity-inner-frame {
+					margin-top: 6px;
+				}
+				d2l-activity-content-lti-link-preview {
+					height: 100%;
+				}
 			`,
 			labelStyles,
 			bodyStandardStyles
@@ -75,7 +73,12 @@ class ActivityContentLTILinkExternalActivity extends SkeletonMixin(LocalizeActiv
 				</div>
 				<div class="d2l-external-activity-inner-frame">
 					${this.showIsOpened ?
-						html`<d2l-activity-content-lti-link-jump-icon text="${this.localize('content.externalActivityOpened')}"></d2l-activity-content-lti-link-jump-icon>` :
+						html`
+							<d2l-activity-content-lti-link-jump-icon>
+								<p class="d2l-body-standard">
+									${this.localize('content.externalActivityOpened')}
+								</p>
+							</d2l-activity-content-lti-link-jump-icon>` :
 						html`<d2l-activity-content-lti-link-preview .entity=${this.entity}></d2l-activity-content-lti-link-preview>`
 					}
 				</div>

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-external-activity.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-external-activity.js
@@ -24,9 +24,9 @@ class ActivityContentLTILinkExternalActivity extends SkeletonMixin(LocalizeActiv
 			super.styles,
 			css`
 			.d2l-external-activity-outer-frame {
-				height: 100%;
 				display: flex;
 				flex-direction: column;
+				height: 100%;
 				justify-content: flex-start;
 			}
 			.d2l-content-link-external-activity {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-external-activity.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-external-activity.js
@@ -1,6 +1,7 @@
 /* eslint-disable indent */
 import '@brightspace-ui/core/components/button/button-subtle.js';
 import './d2l-activity-content-lti-link-jump-icon.js';
+import './d2l-activity-content-lti-link-preview.js';
 import { bodyStandardStyles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { LocalizeActivityEditorMixin } from '../../mixins/d2l-activity-editor-lang-mixin.js';
@@ -22,18 +23,28 @@ class ActivityContentLTILinkExternalActivity extends SkeletonMixin(LocalizeActiv
 		return [
 			super.styles,
 			css`
-				.d2l-external-activity-outer-frame {
-					flex-direction: column;
-				}
-				.d2l-content-link-external-activity {
-					align-items: center;
-					display: flex;
-					justify-content: space-between;
-				}
-				.d2l-external-activity-inner-frame {
-					margin-top: 36px;
-					padding-top: 36px;
-				}
+			.d2l-external-activity-outer-frame {
+				flex-direction: column;
+			}
+			.d2l-content-link-external-activity {
+				align-items: center;
+				display: flex;
+				justify-content: space-between;
+			}
+			.d2l-external-activity-inner-frame {
+				display: flex;
+				margin-top: 36px;
+				padding-top: 36px;
+			}
+			.flex-container {
+				height: 100%;
+				display: flex;
+				flex-direction: column;
+				justify-content: flex-start;
+			}
+			d2l-activity-content-lti-link-preview {
+				height: 100%;
+			}
 			`,
 			labelStyles,
 			bodyStandardStyles
@@ -67,11 +78,12 @@ class ActivityContentLTILinkExternalActivity extends SkeletonMixin(LocalizeActiv
 				</div>
 				<div class="d2l-external-activity-inner-frame">
 					${this.showIsOpened ?
-						html`<d2l-activity-content-lti-link-jump-icon><p class="d2l-body-standard">${this.localize('content.externalActivityOpened')}</p></d2l-activity-content-lti-link-jump-icon>` :
-						html`<div class="d2l-skeletize">&nbsp;</div>`
+						html`<d2l-activity-content-lti-link-jump-icon text="${this.localize('content.externalActivityOpened')}"></d2l-activity-content-lti-link-jump-icon>` :
+						html`<d2l-activity-content-lti-link-preview .entity=${this.entity}></d2l-activity-content-lti-link-preview>`
 					}
 				</div>
 			</div>
+		</div>
 		`;
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-external-activity.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-external-activity.js
@@ -15,7 +15,6 @@ class ActivityContentLTILinkExternalActivity extends SkeletonMixin(LocalizeActiv
 		return {
 			entity: { type: Object },
 			showIsOpened: { type: Boolean },
-			skeleton: { type: Boolean },
 		};
 	}
 
@@ -67,11 +66,11 @@ class ActivityContentLTILinkExternalActivity extends SkeletonMixin(LocalizeActiv
 						text="${this.localize('content.openInNewWindow')}"
 						icon="tier1:new-window"
 						@click="${this._openPopout}"
-						?skeleton=${this.skeleton}
+						class="d2l-skeletize"
 					>
 					</d2l-button-subtle>
 				</div>
-				<div class="d2l-external-activity-inner-frame">
+				<div class="d2l-external-activity-inner-frame d2l-skeletize">
 					${this.showIsOpened ?
 						html`
 							<d2l-activity-content-lti-link-jump-icon>

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-external-activity.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-external-activity.js
@@ -24,7 +24,10 @@ class ActivityContentLTILinkExternalActivity extends SkeletonMixin(LocalizeActiv
 			super.styles,
 			css`
 			.d2l-external-activity-outer-frame {
+				height: 100%;
+				display: flex;
 				flex-direction: column;
+				justify-content: flex-start;
 			}
 			.d2l-content-link-external-activity {
 				align-items: center;
@@ -35,12 +38,6 @@ class ActivityContentLTILinkExternalActivity extends SkeletonMixin(LocalizeActiv
 				display: flex;
 				margin-top: 36px;
 				padding-top: 36px;
-			}
-			.flex-container {
-				height: 100%;
-				display: flex;
-				flex-direction: column;
-				justify-content: flex-start;
 			}
 			d2l-activity-content-lti-link-preview {
 				height: 100%;

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-external-activity.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-external-activity.js
@@ -14,7 +14,7 @@ class ActivityContentLTILinkExternalActivity extends SkeletonMixin(LocalizeActiv
 	static get properties() {
 		return {
 			entity: { type: Object },
-			showIsOpened: { type: Boolean },
+			showInNewTab: { type: Boolean },
 		};
 	}
 
@@ -48,7 +48,7 @@ class ActivityContentLTILinkExternalActivity extends SkeletonMixin(LocalizeActiv
 	constructor() {
 		super();
 		this.skeleton = true;
-		this.showIsOpened = false;
+		this.showInNewTab = false;
 		this.activityWindowPopout = null;
 	}
 
@@ -71,7 +71,7 @@ class ActivityContentLTILinkExternalActivity extends SkeletonMixin(LocalizeActiv
 					</d2l-button-subtle>
 				</div>
 				<div class="d2l-external-activity-inner-frame d2l-skeletize">
-					${this.showIsOpened ?
+					${this.showInNewTab ?
 						html`
 							<d2l-activity-content-lti-link-jump-icon>
 								<p class="d2l-body-standard">
@@ -82,12 +82,11 @@ class ActivityContentLTILinkExternalActivity extends SkeletonMixin(LocalizeActiv
 					}
 				</div>
 			</div>
-		</div>
 		`;
 	}
 
 	_openPopout() {
-		this.showIsOpened = true;
+		this.showInNewTab = true;
 		if (this.activityWindowPopout && !this.activityWindowPopout.closed) {
 			this.activityWindowPopout.focus();
 			return;

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-options.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-options.js
@@ -1,10 +1,10 @@
 import 'd2l-inputs/d2l-input-text.js';
 import 'd2l-tooltip/d2l-tooltip';
 import '@brightspace-ui/core/components/button/button-subtle.js';
+import { css, html } from 'lit-element/lit-element.js';
 import { activityContentEditorStyles } from '../shared-components/d2l-activity-content-editor-styles.js';
 import { ActivityEditorMixin } from '../../mixins/d2l-activity-editor-mixin.js';
 import { ErrorHandlingMixin } from '../../error-handling-mixin.js';
-import { html } from 'lit-element/lit-element.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeActivityEditorMixin } from '../../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
@@ -26,7 +26,12 @@ class ContentEditorLtiLinkOptions extends SkeletonMixin(ErrorHandlingMixin(Local
 			super.styles,
 			labelStyles,
 			radioStyles,
-			activityContentEditorStyles
+			activityContentEditorStyles,
+			css`
+				:host > div {
+					padding-bottom: 0px; /* undo the activity-content-editor-styles padding */
+				}
+			`,
 		];
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-options.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-options.js
@@ -29,7 +29,7 @@ class ContentEditorLtiLinkOptions extends SkeletonMixin(ErrorHandlingMixin(Local
 			activityContentEditorStyles,
 			css`
 				:host > div {
-					padding-bottom: 0px; /* undo the activity-content-editor-styles padding */
+					padding-bottom: 0; /* undo the activity-content-editor-styles padding */
 				}
 			`,
 		];

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-preview.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-preview.js
@@ -18,7 +18,6 @@ class ContentEditorLtiLinkPreview extends SkeletonMixin(LocalizeActivityEditorMi
 			css`
 				iframe {
 					border: none;
-					flex-grow: 1;
 					height: 100%;
 					overflow: hidden;
 					resize: vertical;
@@ -30,12 +29,9 @@ class ContentEditorLtiLinkPreview extends SkeletonMixin(LocalizeActivityEditorMi
 					iframe height should be 60% of viewport height,
 					otherwise use all the remaining height
 					*/
-					display: flex;
-					flex-direction: column;
 					height: 100%;
 					min-height: 60vh;
 					padding-bottom: 18px;
-					padding-top: 6px;
 				}
 			`,
 		];

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-preview.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-preview.js
@@ -52,7 +52,7 @@ class ContentEditorLtiLinkPreview extends SkeletonMixin(LocalizeActivityEditorMi
 		let preview = html``;
 		if (this.entity) {
 			preview = html`
-				<div class='iframe-container d2l-skeletize-container'>
+				<div class='iframe-container d2l-skeletize'>
 					<iframe src=${this.entity.link} @load=${this._onLoad} class='d2l-skeletize'></iframe>
 				</div>
 			`;

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-preview.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-preview.js
@@ -18,9 +18,10 @@ class ContentEditorLtiLinkPreview extends SkeletonMixin(LocalizeActivityEditorMi
 			css`
 				iframe {
 					border: none;
+					flex-grow: 1;
 					height: 100%;
+					min-height: 60vh;
 					overflow: hidden;
-					resize: vertical;
 					width: 100%;
 				}
 				.d2l-lti-iframe-container {
@@ -29,9 +30,15 @@ class ContentEditorLtiLinkPreview extends SkeletonMixin(LocalizeActivityEditorMi
 					iframe height should be 60% of viewport height,
 					otherwise use all the remaining height
 					*/
+					display: flex;
+					flex-direction: column;
 					height: 100%;
 					min-height: 60vh;
-					padding-bottom: 18px;
+					overflow: hidden;
+					resize: vertical;
+				}
+				.d2l-margined-container {
+					margin-bottom: 18px;
 				}
 			`,
 		];
@@ -51,9 +58,11 @@ class ContentEditorLtiLinkPreview extends SkeletonMixin(LocalizeActivityEditorMi
 		}
 
 		return html`
+		<div class='d2l-margined-container'>
 			<div class='d2l-lti-iframe-container d2l-skeletize'>
 				${preview}
 			</div>
+		</div>
 		`;
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-preview.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-preview.js
@@ -17,27 +17,25 @@ class ContentEditorLtiLinkPreview extends SkeletonMixin(LocalizeActivityEditorMi
 			super.styles,
 			css`
 				iframe {
-						height: 100%;
-						width: 100%;
-						border: none;
-						resize: vertical;
-						overflow: hidden;
-						flex-grow: 1;
+					border: none;
+					flex-grow: 1;
+					height: 100%;
+					overflow: hidden;
+					resize: vertical;
+					width: 100%;
 				}
-				.iframe-container {
-						/*
-						if remaining height in content block is less than 60% of viewport height,
-						iframe height should be 60% of viewport height,
-						otherwise use all the remaining height
-						*/
-						height: 100%;
-						min-height: 60vh;
-
-						display: flex;
-						flex-direction: column;
-
-						padding-top: 6px;
-						padding-bottom: 18px;
+				.d2l-lti-iframe-container {
+					/*
+					if remaining height in content block is less than 60% of viewport height,
+					iframe height should be 60% of viewport height,
+					otherwise use all the remaining height
+					*/
+					display: flex;
+					flex-direction: column;
+					height: 100%;
+					min-height: 60vh;
+					padding-bottom: 18px;
+					padding-top: 6px;
 				}
 			`,
 		];
@@ -52,7 +50,7 @@ class ContentEditorLtiLinkPreview extends SkeletonMixin(LocalizeActivityEditorMi
 		let preview = html``;
 		if (this.entity) {
 			preview = html`
-				<div class='iframe-container d2l-skeletize'>
+				<div class='d2l-lti-iframe-container d2l-skeletize'>
 					<iframe src=${this.entity.link} @load=${this._onLoad} class='d2l-skeletize'></iframe>
 				</div>
 			`;

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-preview.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-preview.js
@@ -1,0 +1,69 @@
+import { css, html } from 'lit-element/lit-element.js';
+import { LocalizeActivityEditorMixin } from '../../mixins/d2l-activity-editor-lang-mixin';
+import { MobxLitElement } from '@adobe/lit-mobx';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin';
+
+class ContentEditorLtiLinkPreview extends SkeletonMixin(LocalizeActivityEditorMixin(RtlMixin(MobxLitElement))) {
+
+	static get properties() {
+		return {
+			entity: { type: Object }
+		};
+	}
+
+	static get styles() {
+		return [
+			super.styles,
+			css`
+				iframe {
+						height: 100%;
+						width: 100%;
+						border: none;
+						resize: vertical;
+						overflow: hidden;
+						flex-grow: 1;
+				}
+				.iframe-container {
+						/*
+						if remaining height in content block is less than 60% of viewport height,
+						iframe height should be 60% of viewport height,
+						otherwise use all the remaining height
+						*/
+						height: 100%;
+						min-height: 60vh;
+
+						display: flex;
+						flex-direction: column;
+
+						padding-top: 6px;
+						padding-bottom: 18px;
+				}
+			`,
+		];
+	}
+
+	constructor() {
+		super();
+		this.skeleton = true;
+	}
+
+	render() {
+		let preview = html``;
+		if (this.entity) {
+			preview = html`
+				<div class='iframe-container d2l-skeletize-container'>
+					<iframe src=${this.entity.link} @load=${this._onLoad} class='d2l-skeletize'></iframe>
+				</div>
+			`;
+		}
+
+		return html`${preview}`;
+	}
+
+	_onLoad() {
+		this.skeleton = false;
+	}
+}
+
+customElements.define('d2l-activity-content-lti-link-preview', ContentEditorLtiLinkPreview);

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-preview.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-preview.js
@@ -46,13 +46,15 @@ class ContentEditorLtiLinkPreview extends SkeletonMixin(LocalizeActivityEditorMi
 		let preview = html``;
 		if (this.entity) {
 			preview = html`
-				<div class='d2l-lti-iframe-container d2l-skeletize'>
-					<iframe src=${this.entity.link} @load=${this._onLoad} class='d2l-skeletize'></iframe>
-				</div>
+				<iframe src=${this.entity.link} @load=${this._onLoad} class='d2l-skeletize'></iframe>
 			`;
 		}
 
-		return html`${preview}`;
+		return html`
+			<div class='d2l-lti-iframe-container d2l-skeletize'>
+				${preview}
+			</div>
+		`;
 	}
 
 	_onLoad() {


### PR DESCRIPTION
## Relevant Rally Links

- [US128152](https://rally1.rallydev.com/#/289692574792d/dashboard?detail=%2Fuserstory%2F604435426512&fdp=true?fdp=true): LTI page - Display link inside embedded display



## Description

We want to display the LTI link embedded in an iframe on the FACE page so that instructors can edit the activity from within the FACE page.


## Goal/Solution

I've added another component that has only the iframe in it. The reason I've done this is because its skeleton is going to behave differently from the rest of the FACE page's skeleton in that it doesn't go away on entity load but rather on iframe load.

## Video/Screenshots
Below is a gif of editing an LTI link that can be embedded in an iframe without error, including showing the delayed skeleton and resizing capabilities:
![good_lti_in_iframe](https://user-images.githubusercontent.com/64805612/121432739-0ba39e80-c949-11eb-9d3d-19149a3768bd.gif)


Below is a gif of editing an LTI link that cannot be embedded in an iframe and showing that the rest of the FACE page is still usable:
![bad_lti_in_iframe](https://user-images.githubusercontent.com/64805612/121432365-91731a00-c948-11eb-9404-da764bf5cb60.gif)

## Remaining Work

- [x] Dev Testing: another developer will test this code on their machine
