### PR TITLE
US125507 - fix old functionality on dialog cancel

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
@@ -147,7 +147,13 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 				}
 			}
 		} else {
-			const { createNewGrade } = scoreAndGrade || {};
+			const {
+				gradeCandidateCollection,
+				createNewGrade,
+				newGradeCandidatesCollection
+			} = scoreAndGrade || {};
+			this._prevSelectedHref = gradeCandidateCollection && gradeCandidateCollection.selected ? gradeCandidateCollection.selected.href : null;
+			this._prevSelectedCategoryHref = newGradeCandidatesCollection && newGradeCandidatesCollection.selected.href;
 			this._createNewRadioChecked = createNewGrade && this._canCreateNewGrade;
 			this.openDialog();
 		}
@@ -232,13 +238,10 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 				newGradeCandidatesCollection
 			} = scoreAndGrade;
 
-			const prevSelectedHref = gradeCandidateCollection && gradeCandidateCollection.selected ? gradeCandidateCollection.selected.href : null;
-			const prevSelectedCategoryHref = newGradeCandidatesCollection.selected.href;
-
-			if (prevSelectedHref) {
-				gradeCandidateCollection.setSelected(prevSelectedHref);
+			if (this._prevSelectedHref) {
+				gradeCandidateCollection.setSelected(this._prevSelectedHref);
 			}
-			newGradeCandidatesCollection.setSelected(prevSelectedCategoryHref);
+			newGradeCandidatesCollection.setSelected(this._prevSelectedCategoryHref);
 		}
 		this.handleClose(e);
 	}


### PR DESCRIPTION
On dialog cancel, it was not going back to the previous selected grade category or grade candidate

I broke it here: https://github.com/BrightspaceHypermediaComponents/activities/commit/5c51bea4cf7e9ac250908c94e654a36f9ab3ac6e#diff-3d1b7f638f1665079274762423219b3db399cf9d01e94426273861595da0d112L194-L211

https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F505562087036&expandApp=486232622048&fdp=true?fdp=true