### PR TITLE
DE43913: FACE rubric preview tabulation

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-editor.js
@@ -150,6 +150,7 @@ class ActivityRubricsListEditor extends ActivityEditorMixin(LocalizeActivityEdit
 				<d2l-rubric
 					class="d2l-association-box"
 					force-compact
+					read-only
 					.href="${association.rubricHref}"
 					.token="${this.token}">
 				</d2l-rubric>


### PR DESCRIPTION
Rally: [DE43913](https://rally1.rallydev.com/#/57732444928d/custom/373260458992?detail=%2Fdefect%2F601487122367)

Tiny fix to ensure that rubrics being previewed in the assignment editor are read-only as per the design spec