### PR TITLE
Fix ending dialog tag typo

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -102,7 +102,7 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 					type="rubrics"
 					skipSave
 				></d2l-add-associations>
-			</d2l-dialog-fullscreen>
+			</d2l-dialog>
 		`;
 	}
 	_attachRubric() {


### PR DESCRIPTION
The ending tag should be closing the d2l-dialog tag, not d2l-dialog-fullscreen. This was auto-fixed by the HTML, so it wasn't actually causing any errors or rendering problems.