### PR TITLE
Fix loading skeleton on the HTML file type page

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -1,4 +1,5 @@
 import '../shared-components/d2l-activity-content-editor-title.js';
+import './d2l-activity-content-file-loading.js';
 import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
 import { ContentFileEntity, FILE_TYPES } from 'siren-sdk/src/activities/content/ContentFileEntity.js';
 import { activityContentEditorStyles } from '../shared-components/d2l-activity-content-editor-styles.js';
@@ -20,7 +21,7 @@ import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingMixin(LocalizeActivityEditorMixin(EntityMixinLit(RtlMixin(ActivityEditorMixin(MobxLitElement))))))) {
 
 	static get styles() {
-		return  [
+		return [
 			super.styles,
 			labelStyles,
 			activityContentEditorStyles,
@@ -55,6 +56,8 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 					pageRenderer = this._renderHtmlEditor(pageContent);
 					break;
 			}
+		} else {
+			pageRenderer = this._renderUnknownLoadingFileType();
 		}
 
 		return html`
@@ -172,6 +175,15 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 				>
 				</d2l-activity-text-editor>
 			</div>`;
+	}
+
+	_renderUnknownLoadingFileType() {
+		return html`
+			<d2l-activity-content-file-loading
+				.href="${this.href}"
+				.token="${this.token}"
+			></d2l-activity-content-file-loading>
+		`;
 	}
 
 	_saveOnChange(jobName) {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-loading.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-loading.js
@@ -1,0 +1,49 @@
+import '../shared-components/d2l-activity-content-editor-title.js';
+import { css, html } from 'lit-element/lit-element.js';
+import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
+import { MobxLitElement } from '@adobe/lit-mobx';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
+
+class ContentFileLoading extends SkeletonMixin(MobxLitElement) {
+
+	static get styles() {
+		return [
+			super.styles,
+			labelStyles,
+			css`
+			:host {
+				display: flex;
+				flex: 1;
+				flex-direction: column;
+
+			}
+			.d2l-activity-label-container {
+				margin-bottom: 7px;
+			}
+			.d2l-file-content-load {
+				display: flex;
+				flex: 1;
+			}
+			`
+		];
+	}
+
+	constructor() {
+		super();
+		/*
+		This skeleton boolean value will always be true.
+		The purpose of this component is to show a generic looking skeleton
+		view before we actually know what elements we need to render and skeletize.
+		 */
+		this.skeleton = true;
+	}
+
+	render() {
+		return html`
+			<div class="d2l-activity-label-container d2l-label-text d2l-skeletize">&nbsp;</div>
+			<div class="d2l-file-content-load d2l-skeletize">&nbsp;</div>
+		`;
+	}
+}
+
+customElements.define('d2l-activity-content-file-loading', ContentFileLoading);


### PR DESCRIPTION
This pr creates a new component which just consists of a label and a full height div that will perpetually be in a loading state. On our file page, we use info from the entity to determine which elements to render as this page will eventually have multiple options based on the file type. As a result, before we got the entity the view would be blank so no loading skeletons would show. Now, before we receive and examine our entity we will default to this loading view.

Note: the loading state on the due date is not in sync with the other elements as we slot that in for some reason I can't remember. It's unrelated to this change, it happened before as well.

![loading](https://user-images.githubusercontent.com/14796305/121736139-c86a3c80-cabc-11eb-93b5-a3a41f730073.gif)
