### PR TITLE
Prevent bubbling close event from popup dialogs to affect the fullscreen dialog

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -78,6 +78,7 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 
 			<d2l-dialog-fullscreen
 				id="create-new-association-dialog"
+				@d2l-dialog-close="${this._onDialogClose}"
 				title-text = ${this.localize('rubrics.hdrCreateRubric')}>
 				${this._renderRubricEditor()}
 				<d2l-button slot="footer" primary  @click="${this._attachRubric}">
@@ -160,12 +161,13 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 		const editNewAssociationDialog = this.shadowRoot.querySelector('#create-new-association-dialog');
 		if (editNewAssociationDialog) {
 			editNewAssociationDialog.opened = true;
-			editNewAssociationDialog.addEventListener('d2l-dialog-close', (e) => {
-				// only update when the dialog closes, not any nested popups that bubble a close event
-				if(e.target == editNewAssociationDialog) this._clearNewRubricHref();
-			});
 		}
 
+	}
+	_onDialogClose(e) {
+		const editNewAssociationDialog = this.shadowRoot.querySelector('#create-new-association-dialog');
+		// only update when the dialog closes, not any nested popups that bubble a close event
+		if(e.target == editNewAssociationDialog) this._clearNewRubricHref();
 	}
 	_openAttachRubricDialog() {
 		this._toggleDialog(true);

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -78,13 +78,12 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 
 			<d2l-dialog-fullscreen
 				id="create-new-association-dialog"
-				title-text = ${this.localize('rubrics.hdrCreateRubric')}
-				@d2l-dialog-close="${this._clearNewRubricHref}">
+				title-text = ${this.localize('rubrics.hdrCreateRubric')}>
 				${this._renderRubricEditor()}
 				<d2l-button slot="footer" primary  @click="${this._attachRubric}">
 					${this.localize('rubrics.btnAttachRubric')}
 				</d2l-button>
-				<d2l-button slot="footer" @click="${this._closeEditNewAssociationOverlay}">
+				<d2l-button slot="footer" @click="${this._closeEditNewAssociationDialog}">
 					${this.localize('rubrics.btnCancel')}
 				</d2l-button>
 			</d2l-dialog-fullscreen>
@@ -114,7 +113,7 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 
 		entity.addAssociations([this._newlyCreatedPotentialAssociation]);
 
-		this._closeEditNewAssociationOverlay();
+		this._closeEditNewAssociationDialog();
 		announce(this.localize('rubrics.txtRubricAdded'));
 	}
 	_clearNewRubricHref() {
@@ -130,12 +129,12 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 		}
 		this._toggleDialog(false);
 	}
-	_closeEditNewAssociationOverlay() {
-		const editNewAssociationOverlay =
+	_closeEditNewAssociationDialog() {
+		const editNewAssociationDialog =
 			this.shadowRoot.querySelector('#create-new-association-dialog');
-		if (editNewAssociationOverlay) {
+		if (editNewAssociationDialog) {
 			this._clearNewRubricHref();
-			editNewAssociationOverlay.opened = false;
+			editNewAssociationDialog.opened = false;
 		}
 	}
 	async _createNewAssociation() {
@@ -158,9 +157,13 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 
 		this._newlyCreatedPotentialAssociationHref = potentialAssociationEntity.getRubricLink();
 
-		const editNewAssociationOverlay = this.shadowRoot.querySelector('#create-new-association-dialog');
-		if (editNewAssociationOverlay) {
-			editNewAssociationOverlay.opened = true;
+		const editNewAssociationDialog = this.shadowRoot.querySelector('#create-new-association-dialog');
+		if (editNewAssociationDialog) {
+			editNewAssociationDialog.opened = true;
+			editNewAssociationDialog.addEventListener('d2l-dialog-close', (e) => {
+				// only update when the dialog closes, not any nested popups that bubble a close event
+				if(e.target == editNewAssociationDialog) this._clearNewRubricHref();
+			});
 		}
 
 	}

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -167,7 +167,7 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 	_onDialogClose(e) {
 		const editNewAssociationDialog = this.shadowRoot.querySelector('#create-new-association-dialog');
 		// only update when the dialog closes, not any nested popups that bubble a close event
-		if(e.target == editNewAssociationDialog) this._clearNewRubricHref();
+		if (e.target === editNewAssociationDialog) this._clearNewRubricHref();
 	}
 	_openAttachRubricDialog() {
 		this._toggleDialog(true);

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -167,7 +167,7 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 	_onDialogClose(e) {
 		const editNewAssociationDialog = this.shadowRoot.querySelector('#create-new-association-dialog');
 		// only update when the dialog closes, not any nested popups that bubble a close event
-		if (e.target === editNewAssociationDialog) this._clearNewRubricHref();
+		if (editNewAssociationDialog && e.target === editNewAssociationDialog) this._clearNewRubricHref();
 	}
 	_openAttachRubricDialog() {
 		this._toggleDialog(true);


### PR DESCRIPTION
This is required for https://github.com/Brightspace/d2l-rubric/pull/819 to merge. Changing the dialogs to the best-practice web components allows them to fire the d2l-dialog-close events. The fullscreen dialog (that wraps the create rubric page) gets the bubbled event and turns the page blank. Checking that the event is intended for the fullscreen dialog will ensure it doesn't interpret any popup dialogs as a sign for it to close. 