### PR TITLE
DE41878: Add tooltip locale explaining/recommending 'open in new tab' option

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-options.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-options.js
@@ -95,6 +95,7 @@ class ContentEditorLtiLinkOptions extends SkeletonMixin(ErrorHandlingMixin(Local
 						</d2l-icon>
 						<d2l-tooltip
 							for="open-new-tab-help-span">
+							${this.localize('content.openNewTabRecommendation')}
 							${this.localize('content.openNewTabHelp')}
 						</d2l-tooltip>
 					</span>

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-editor-link.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-editor-link.js
@@ -122,6 +122,7 @@ class ContentEditorLink extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 							</d2l-icon>
 							<d2l-tooltip
 								for="open-new-tab-help-span">
+								${this.localize('content.openNewTabRecommendation')}
 								${this.localize('content.openNewTabHelp')}
 							</d2l-tooltip>
 						</span>

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -143,8 +143,8 @@ export default {
 	"content.addDueDate": "Add Due Date", // Text label for name input field
 	"content.embedOnPage": "Embed on the page", // Text label for link radio button
 	"content.openNewTab": "Open in a new tab (recommended)", // Text label for link radio button
-	"content.openNewTabRecommendation": "This option is recommended to prevent authentication issues to your resource.", // ARIA label for the help icon that explains reason for recommending new tab option
-	"content.openNewTabHelp": "Time on page is not tracked.", // ARIA label for the help icon next to link radio button
+	"content.openNewTabRecommendation": "This option is recommended to prevent authentication issues to your resource.", // Text for the help icon that explains reason for recommending new tab option
+	"content.openNewTabHelp": "Time on page is not tracked.", // Text for the help icon next to link radio button
 	"content.link": "Link", //Text label for link input field
 	"content.emptyLinkField": "Link is required.", //Error message shown on link tooltip when the link is empty
 	"content.invalidLink": "Please enter a valid URL.", //Error message shown on link tooltip when the link is not formatted correctly

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -143,7 +143,8 @@ export default {
 	"content.addDueDate": "Add Due Date", // Text label for name input field
 	"content.embedOnPage": "Embed on the page", // Text label for link radio button
 	"content.openNewTab": "Open in a new tab (recommended)", // Text label for link radio button
-	"content.openNewTabHelp": "Time on page is not tracked", // ARIA label for the help icon next to link radio button
+	"content.openNewTabRecommendation": "This option is recommended to prevent authentication issues to your resource.", // ARIA label for the help icon that explains reason for recommending new tab option
+	"content.openNewTabHelp": "Time on page is not tracked.", // ARIA label for the help icon next to link radio button
 	"content.link": "Link", //Text label for link input field
 	"content.emptyLinkField": "Link is required.", //Error message shown on link tooltip when the link is empty
 	"content.invalidLink": "Please enter a valid URL.", //Error message shown on link tooltip when the link is not formatted correctly


### PR DESCRIPTION
## Relevant Rally Links

- https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F470674608400

## Description

The FACE page for Creating Web Links should have the link option default to the 'open in new tab' option. This has already been done here: https://github.com/Brightspace/lms/pull/11192/files. The user should be let known the reason for recommendation/defaulting to this.

## Goal/Solution

This PR adds a locale/statement to the help icon tooltip for the open in new tab option explaining why opening in a new tab is the better option.

## Video/Screenshots

![image](https://user-images.githubusercontent.com/29843252/122098373-62d8c180-cdd6-11eb-8697-ff78fb52ef58.png)

## Related PRs

- https://github.com/Brightspace/smart-curriculum/pull/1266

## Remaining Work

- [x] Dev Testing: another developer will test this code on their machine
