### PR TITLE
Bump node version used in GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
           persist-credentials: false
       - name: Setup Node
         uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version: '14'
       - name: Semantic Release
         uses: BrightspaceUI/actions/semantic-release@master
         with:

--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version: '14'
       - name: Install Dependencies
         run: npm install
       - name: Visual Diff Tests


### PR DESCRIPTION
We are planning to bump the version of Puppeteer used in visual-diff and so this PR is to bump the node version to the current LTS version.