### PR TITLE
fix: mobile view of buttons, and button position

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-edit-new-grade.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-edit-new-grade.js
@@ -30,6 +30,12 @@ class ActivityEditNewGrade extends ActivityEditorMixin(LocalizeActivityEditorMix
 				display: flex;
 				flex-direction: row;
 				justify-content: space-between;
+				flex-wrap: wrap;
+				margin-left: -0.6rem;
+			}
+			:host([dir="rtl"]) .d2l-activity-grades-dialog-property-buttons {
+				margin-left: 0;
+				margin-right: -0.6rem;
 			}
 			`
 		];

--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-edit-new-grade.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-edit-new-grade.js
@@ -29,8 +29,8 @@ class ActivityEditNewGrade extends ActivityEditorMixin(LocalizeActivityEditorMix
 			.d2l-activity-grades-dialog-property-buttons {
 				display: flex;
 				flex-direction: row;
-				justify-content: space-between;
 				flex-wrap: wrap;
+				justify-content: space-between;
 				margin-left: -0.6rem;
 			}
 			:host([dir="rtl"]) .d2l-activity-grades-dialog-property-buttons {


### PR DESCRIPTION
Fixes https://trello.com/c/Fh9ceWDx/392-grade-category-and-type-selector-buttons-too-wide-for-mobile
Also, moves button position over so that button text is aligned instead of button border (Patrick's request)