### PR TITLE
Remove fullpage attributes for content modules

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -83,9 +83,6 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 						@d2l-activity-text-editor-change="${activityTextEditorChange}"
 						.richtextEditorConfig="${{}}"
 						html-editor-height="100%"
-						full-page
-						full-page-font-size="12pt"
-						full-page-font-family="Lato"
 					>
 					</d2l-activity-text-editor>
 				</div>


### PR DESCRIPTION
This pr removes the "full page" attributes when using the new html editor. This means that the font size and family that are selected by default will use the system settings when editing modules. The full page attributes are still present when editing html topics.

Removing these was necessary for modules as it would add extra template stuff which is not meant for modules. This was causing all those extra new lines to appear as they were added when the html content was filtered.

Rally: https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F601628066803

### Modules

![image](https://user-images.githubusercontent.com/14796305/122600408-57370600-d035-11eb-869a-0ae201f27330.png)


### HTML Files

![image](https://user-images.githubusercontent.com/14796305/122600479-72097a80-d035-11eb-8c32-54dc930159ad.png)
