### PR TITLE
fix: duplicate grade created

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -158,7 +158,16 @@ class ActivityEditor extends ActivityEditorContainerMixin(ActivityEditorTelemetr
 	async save() {
 		const activity = store.get(this.href);
 		if (activity) {
-			await activity.save();
+			const event = new CustomEvent('d2l-request-provider', {
+				detail: { key: 'd2l-provider-create-selectbox-grade-item-enabled' },
+				bubbles: true,
+				composed: true,
+				cancelable: true
+			});
+			this.dispatchEvent(event);
+
+			const createSelectboxGradeItemEnabled = event.detail.provider;
+			await activity.save(createSelectboxGradeItemEnabled);
 		}
 	}
 

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -57,14 +57,16 @@ export class ActivityUsage extends WorkingCopy {
 			this.unevaluatedCompetenciesCount = entity.unevaluatedCount() || 0;
 		});
 	}
-	async save() {
+	async save(createSelectboxGradeItemEnabled) {
 		if (!this._entity) {
 			return;
 		}
 
-		await this.scoreAndGrade.primeGradeSave();
+		if (!createSelectboxGradeItemEnabled) {
+			await this.scoreAndGrade.primeGradeSave();
+		}
 
-		await super.save();
+		await super.save(createSelectboxGradeItemEnabled);
 	}
 	setAlignmentsHref(value) {
 		this.alignmentsHref = value;

--- a/components/d2l-activity-editor/state/working-copy.js
+++ b/components/d2l-activity-editor/state/working-copy.js
@@ -88,7 +88,7 @@ export class WorkingCopy {
 		return this;
 	}
 
-	async save() {
+	async save(createSelectboxGradeItemEnabled) {
 		if (!this._entity) {
 			return;
 		}
@@ -97,7 +97,7 @@ export class WorkingCopy {
 			return this._saving;
 		}
 
-		this._saving = this._entity.save(this._makeEntityData());
+		this._saving = this._entity.save(this._makeEntityData(), createSelectboxGradeItemEnabled);
 		await this._saving;
 		this._saving = null;
 


### PR DESCRIPTION
Fixes https://trello.com/c/JVZtua6s/393-creating-new-grade-creates-duplicate-numeric-grade-item
Goes with https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/352