### PR TITLE
fix: label grade units correctly

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -183,15 +183,15 @@ class ActivityScoreEditor extends ActivityEditorMixin(SkeletonMixin(LocalizeActi
 	render() {
 		const activity = store.get(this.href);
 
-		let gradeType;
+		let gradeUnits;
 		let inGrades;
 
 		if (this._createSelectboxGradeItemEnabled) {
 			const associateGradeEntity = associateGradeStore.get(this._associateGradeHref);
-			gradeType = associateGradeEntity && associateGradeEntity.gradeType;
+			gradeUnits = this.localize('grades.gradeUnits');
 			inGrades = associateGradeEntity && associateGradeEntity.gradebookStatus !== GradebookStatus.NotInGradebook;
 		} else {
-			gradeType = activity && activity.scoreAndGrade && activity.scoreAndGrade.gradeType;
+			gradeUnits = activity && activity.scoreAndGrade && activity.scoreAndGrade.gradeType;
 			inGrades = activity && activity.scoreAndGrade && activity.scoreAndGrade.inGrades;
 		}
 
@@ -244,7 +244,7 @@ class ActivityScoreEditor extends ActivityEditorMixin(SkeletonMixin(LocalizeActi
 							${scoreOutOfError ? html`<span>${this.localize(`editor.${scoreOutOfError}`)}</span>` : null}
 						</d2l-tooltip>
 					` : null}
-					<div class="d2l-body-compact d2l-grade-type-text">${gradeType}</div>
+					<div class="d2l-body-compact d2l-grade-type-text">${gradeUnits}</div>
 				</div>
 				${canSeeGrades ? html`
 					<div id="grade-info-container">

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -104,6 +104,7 @@ export default {
 	"grades.points": "Points: {points}", // Text label for displaying points of a grade
 	"grades.weight": "Weight: {weight}", // Text label for displaying weight of a grade
 	"grades.gradeItem": "Grade Item", //ARIA label for grade-item picker when linking an activity to an existing grade item
+	"grades.gradeUnits": "points", // unit label for GradeOutOf value (e.g. 10 points)
 	"grades.chooseNewGradeItemCategory": "Choose Grade Category", // Label for add category button
 	"grades.newGradeItemCategory": "Grade Category", // Label for selecting a category dropdown
 	"grades.noGradeItemCategory": "No Category", // Category dropdown text for not selecting a category


### PR DESCRIPTION
This fixes the issue where the units label of the grade becomes the grade type (i.e. "numeric" or "selectbox" instead of "points"). I'm sure there was a trello or defect logged somewhere but I could not locate it.