### PR TITLE
US129210 Add existing questions

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-add-activity-menu.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-add-activity-menu.js
@@ -57,6 +57,20 @@ class ActivityQuizAddActivityMenu extends ActivityEditorMixin(SkeletonMixin(Loca
 		`;
 	}
 
+	_dispatchAddItemEvent(itemDetails) {
+		const eventInit = {
+			bubbles: true,
+			composed: true
+		};
+
+		if (itemDetails && itemDetails.length) {
+			const activityUsageHrefs = itemDetails.map(q => q.href);
+			eventInit.detail = { activities: activityUsageHrefs };
+		}
+
+		this.dispatchEvent(new CustomEvent('d2l-question-activity-added', eventInit));
+	}
+
 	_onSelect(e) {
 		if (!e || !e.target) {
 			return;
@@ -74,7 +88,7 @@ class ActivityQuizAddActivityMenu extends ActivityEditorMixin(SkeletonMixin(Loca
 			url = new D2L.LP.Web.Http.UrlLocation(`/d2l/lms/question/new/${type}`);
 		}
 
-		D2L.LP.Web.UI.Legacy.MasterPages.Dialog.OpenFullscreen(
+		const delayedResult = D2L.LP.Web.UI.Legacy.MasterPages.Dialog.OpenFullscreen(
 			/*             location: */ url,
 			/*          srcCallback: */ 'SrcCallBack',
 			/*      responseDataKey: */ 'result',
@@ -84,7 +98,7 @@ class ActivityQuizAddActivityMenu extends ActivityEditorMixin(SkeletonMixin(Loca
 		);
 
 		// "Save" handler
-		// delayedResult.AddListener(result => console.log(result));
+		delayedResult.AddListener(itemDetails => this._dispatchAddItemEvent(itemDetails));
 	}
 
 	_renderActivityType(activityType) {

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-action-bar.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-action-bar.js
@@ -61,6 +61,13 @@ class ActivityQuizEditorActionBar extends ActivityEditorMixin(SkeletonMixin(RtlM
 			</div>
 		`;
 	}
+
+	refreshTotalPoints() {
+		const entity = store.get(this.href);
+		if (entity) {
+			entity.fetchScoreAndGradeScoreOutOf(true);
+		}
+	}
 }
 
 customElements.define(

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
@@ -183,7 +183,8 @@ class QuizEditorDetail extends ActivityQuizEditorTelemetryMixin(ActivityEditorMi
 				?skeleton="${this.skeleton}"
 				href="${this.activityUsageHref}"
 				.token="${this.token}"
-				quiz-href="${this.href}">
+				quiz-href="${this.href}"
+				@d2l-question-activity-added="${this._onActivityAdded}">
 			</d2l-activity-quiz-editor-action-bar>
 			<d2l-activity-quiz-question-editor href="${this.activityUsageHref}" .token="${this.token}">
 			</d2l-activity-quiz-question-editor>
@@ -223,6 +224,15 @@ class QuizEditorDetail extends ActivityQuizEditorTelemetryMixin(ActivityEditorMi
 		}
 
 		await quiz.save();
+	}
+
+	async _onActivityAdded(e) {
+		if (e && e.detail && e.detail.activities && e.detail.activities.length) {
+			const editor = this.shadowRoot.querySelector('d2l-activity-quiz-question-editor');
+			await editor.addToCollection(e.detail.activities);
+			const actionBar = this.shadowRoot.querySelector('d2l-activity-quiz-editor-action-bar');
+			actionBar.refreshTotalPoints();
+		}
 	}
 
 	_openPreview() {

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-question-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-question-editor.js
@@ -20,6 +20,12 @@ const componentClass = class extends LitElement {
 			<d2l-activity-editor-main href="${this.href}" .token="${this.token}"></d2l-activity-editor-main>
 		`;
 	}
+	async addToCollection(activities) {
+		const editor = this.shadowRoot.querySelector('d2l-activity-collection-editor-quiz');
+		if (editor) {
+			await editor.addToCollection(activities);
+		}
+	}
 };
 
 customElements.define('d2l-activity-quiz-question-editor', componentClass);


### PR DESCRIPTION
Receive activity usage hrefs of created questions and call the add-existing workflow in the hmc quiz editor with that information, then update the total points display. 

Related hmc PR: https://github.com/BrightspaceHypermediaComponents/foundation-components/pull/250

https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F601851661777