### PR TITLE
fix: grade scheme simplification

### DIFF
--- a/components/d2l-activity-editor/state/associate-grade.js
+++ b/components/d2l-activity-editor/state/associate-grade.js
@@ -91,7 +91,6 @@ export class AssociateGrade {
 	}
 
 	async setGradeType(gradeType) {
-		this.gradeType = gradeType;
 		await this._updateProperty(() => this._entity.setGradeType(gradeType));
 	}
 


### PR DESCRIPTION
This was actually breaking your simplification in loading grade schemes because `existingGradeType` ended up being the same as the newly loaded grade type. Taking this out here doesn't hurt performance because the radio buttons in the UI just show what the user clicked anyway.