### PR TITLE
fix: remove visible re-rendering between setting grade type and fetch…

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-edit-new-grade.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-edit-new-grade.js
@@ -3,7 +3,6 @@ import './d2l-activity-grade-type-scheme-selector.js';
 import { sharedAssociateGrade as associateGradeStore, shared as store } from '../state/activity-store.js';
 import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
-import { GradeType } from 'siren-sdk/src/activities/associateGrade/AssociateGradeEntity.js';
 import { LocalizeActivityEditorMixin } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
@@ -58,9 +57,7 @@ class ActivityEditNewGrade extends ActivityEditorMixin(LocalizeActivityEditorMix
 			return html``;
 		}
 		const categoriesEmpty =	associateGradeEntity.gradeCategoryCollection.gradeCategories.length === 0;
-		const schemesEmpty = associateGradeEntity.gradeType === GradeType.Selectbox ?
-			associateGradeEntity.gradeSchemeCollection.gradeSchemes.length === 0 :
-			associateGradeEntity.gradeSchemeCollection.gradeSchemes.length === 1;
+		const schemesEmpty = associateGradeEntity.schemesIsEmpty;
 
 		return html`
 		<div class="d2l-activity-grades-dialog-property-buttons">

--- a/components/d2l-activity-editor/state/associate-grade.js
+++ b/components/d2l-activity-editor/state/associate-grade.js
@@ -122,6 +122,7 @@ decorate(AssociateGrade, {
 	gradeCandidateCollection: observable,
 	gradeSchemeCollection: observable,
 	selectedSchemeHref: observable,
+	schemesIsEmpty: observable,
 	// actions
 	load: action,
 	getGradeCategories: action,

--- a/components/d2l-activity-editor/state/associate-grade.js
+++ b/components/d2l-activity-editor/state/associate-grade.js
@@ -74,7 +74,7 @@ export class AssociateGrade {
 		this.canGetSchemes = entity.canGetSchemesForType(this.gradeType);
 
 		if (this.gradeSchemeCollection && existingGradeType !== this.gradeType) {
-			this.getGradeSchemes(true)
+			this.getGradeSchemes(true);
 		}
 	}
 

--- a/components/d2l-activity-editor/state/associate-grade.js
+++ b/components/d2l-activity-editor/state/associate-grade.js
@@ -4,6 +4,7 @@ import { fetchEntity } from './fetch-entity.js';
 import { GradeCandidateCollection } from '../d2l-activity-grades/state/grade-candidate-collection.js';
 import { GradeCategoryCollection } from '../d2l-activity-grades/state/grade-category-collection.js';
 import { GradeSchemeCollection } from '../d2l-activity-grades/state/grade-scheme-collection.js';
+import { GradeType } from 'siren-sdk/src/activities/associateGrade/AssociateGradeEntity.js';
 
 configureMobx({ enforceActions: 'observed' });
 
@@ -55,6 +56,9 @@ export class AssociateGrade {
 			this.gradeSchemeCollection = new GradeSchemeCollection(gradeSchemeCollectionEntity, this.token);
 		});
 		await this.gradeSchemeCollection.fetch();
+		this.schemesIsEmpty = this.gradeType === GradeType.Selectbox ?
+			this.gradeSchemeCollection.gradeSchemes.length === 0 :
+			this.gradeSchemeCollection.gradeSchemes.length === 1;
 	}
 
 	load(entity) {
@@ -71,7 +75,7 @@ export class AssociateGrade {
 		this.canGetSchemes = entity.canGetSchemesForType(this.gradeType);
 
 		if (this.gradeSchemeCollection && existingGradeType !== this.gradeType) {
-			this.getGradeSchemes(true);
+			this.getGradeSchemes(true)
 		}
 	}
 

--- a/components/d2l-activity-editor/state/associate-grade.js
+++ b/components/d2l-activity-editor/state/associate-grade.js
@@ -1,10 +1,9 @@
 import { action, configure as configureMobx, decorate, observable, runInAction } from 'mobx';
-import { AssociateGradeEntity } from 'siren-sdk/src/activities/associateGrade/AssociateGradeEntity.js';
+import { AssociateGradeEntity, GradeType } from 'siren-sdk/src/activities/associateGrade/AssociateGradeEntity.js';
 import { fetchEntity } from './fetch-entity.js';
 import { GradeCandidateCollection } from '../d2l-activity-grades/state/grade-candidate-collection.js';
 import { GradeCategoryCollection } from '../d2l-activity-grades/state/grade-category-collection.js';
 import { GradeSchemeCollection } from '../d2l-activity-grades/state/grade-scheme-collection.js';
-import { GradeType } from 'siren-sdk/src/activities/associateGrade/AssociateGradeEntity.js';
 
 configureMobx({ enforceActions: 'observed' });
 


### PR DESCRIPTION
…ing schemes
Fixes this task: https://rally1.rallydev.com/#/29180338367ud/custom/486232622040?detail=%2Ftask%2F602159610977&fdp=true

Since schemes are always fetched after type is updated, we make sure we only decide whether schemes is empty after both are done updating.