### PR TITLE
DE44122: FACE Weblinks > No error message shown when saving link that is missing http/https

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/helpers/url-validation-helper.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/helpers/url-validation-helper.js
@@ -4,7 +4,7 @@ export const getWeblinkError = (link, isExternalResource, isSubmitting = false) 
 		return isSubmitting ? 'content.emptyLinkField' : null;
 	}
 
-	const expression = /^(?:https?:\/\/)?(?:[a-zA-Z0-9][a-zA-Z0-9-]*\.)+[a-zA-Z0-9][a-zA-Z0-9-]*(?::\d+)?(?:$|[/?#].*$)/;
+	const expression = /^(?:https?:\/\/){1}(?:[a-zA-Z0-9][a-zA-Z0-9-]*\.)+[a-zA-Z0-9][a-zA-Z0-9-]*(?::\d+)?(?:$|[/?#].*$)/;
 	const urlRegExp = new RegExp(expression);
 
 	if (!urlRegExp.test(link)) {

--- a/test/d2l-activity-editor/d2l-activity-content-editor/web-link/helpers/url-validation-helper.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-content-editor/web-link/helpers/url-validation-helper.spec.js
@@ -17,11 +17,42 @@ describe('UrlValidationHelper', () => {
 
 				expect(result).to.be.null;
 			});
+
+			it('returns content.invalidLink when missing protocol', () => {
+				testUrl = 'google.ca';
+
+				const result = getWeblinkError(testUrl, isExternalResource);
+
+				expect(result).to.be.eq('content.invalidLink');
+			});
 		});
 
 		describe('when url is not embedded', () => {
-			isExternalResource = true;
+			isExternalResource = false;
 
+			it('returns content.invalidLink when missing protocol', () => {
+				testUrl = 'google.ca';
+
+				const result = getWeblinkError(testUrl, isExternalResource);
+
+				expect(result).to.be.eq('content.invalidLink');
+			});
+
+			it('returns content.notHttps when protocol is not https and is embedded', () => {
+				testUrl = 'http://google.ca';
+
+				const result = getWeblinkError(testUrl, isExternalResource);
+
+				expect(result).to.be.eq('content.notHttps');
+			});
+
+			it('returns null when a valid url is passed', () => {
+				testUrl = 'https://google.ca';
+
+				const result = getWeblinkError(testUrl, isExternalResource);
+
+				expect(result).to.be.null;
+			});
 		});
 	});
 });

--- a/test/d2l-activity-editor/d2l-activity-content-editor/web-link/helpers/url-validation-helper.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-content-editor/web-link/helpers/url-validation-helper.spec.js
@@ -7,7 +7,7 @@ describe('UrlValidationHelper', () => {
 
 	// TODO: Finish writing tests for this
 	describe('getWeblinkError', () => {
-		describe('when url is embedded', () => {
+		describe('when url is not embedded', () => {
 			isExternalResource = true;
 
 			it('returns null on a valid url', () => {
@@ -27,7 +27,7 @@ describe('UrlValidationHelper', () => {
 			});
 		});
 
-		describe('when url is not embedded', () => {
+		describe('when url is embedded', () => {
 			isExternalResource = false;
 
 			it('returns content.invalidLink when missing protocol', () => {


### PR DESCRIPTION
Rally: https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F602348528019

This PR changes the URL validation to require the input to have either http:// or https:// at the beginning of the URL.

Before:
There would be no indication of an error, and when trying to save nothing would occur. Network tab would show a failure.
![image](https://user-images.githubusercontent.com/13461008/123142267-3c92d180-d427-11eb-825c-4b93f62dec58.png)

After:
The user is notified that the URL is invalid before trying to submit.
![image](https://user-images.githubusercontent.com/13461008/123142120-179e5e80-d427-11eb-92f2-9edc5e6246c7.png)

## TODO
- [x] Another developer will devtest this on their machine