### PR TITLE
US128779 - Announce what is saved when grades dialog OK is pressed

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
@@ -8,9 +8,11 @@ import '@brightspace-ui/core/components/inputs/input-radio-spacer.js';
 import { sharedAssociateGrade as associateGradeStore, shared as store } from '../state/activity-store.js';
 import { css, html } from 'lit-element/lit-element';
 import { ActivityEditorWorkingCopyDialogMixin } from '../mixins/d2l-activity-editor-working-copy-dialog-mixin.js';
+import { announce } from '@brightspace-ui/core/helpers/announce.js';
 import { bodySmallStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { formatNumber } from '@brightspace-ui/intl/lib/number.js';
 import { GradebookStatus } from 'siren-sdk/src/activities/associateGrade/AssociateGradeEntity.js';
+import { GradeType } from 'siren-sdk/src/activities/associateGrade/AssociateGradeEntity.js';
 import { LocalizeActivityEditorMixin } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { radioStyles } from '@brightspace-ui/core/components/inputs/input-radio-styles.js';
@@ -321,6 +323,16 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 			if (!entity) return;
 
 			await entity.saving; // Wait for activity usage entity PATCH requests to complete before checking in
+
+			const associateGradeEntity = associateGradeStore.get(this._associateGradeHref);
+			if (this._createNewRadioChecked) {
+				const localizeTerm = associateGradeEntity.gradeType === GradeType.Selectbox ? 'grades.creatingNewSelectboxGradeItem' : 'grades.creatingNewNumericGradeItem'
+				const scoreAndGrade = store.get(this.href).scoreAndGrade;
+				announce(`${this.localize(localizeTerm, { newGradeName: scoreAndGrade.newGradeName })}`);
+			} else {
+				const gradeCandidateCollection = associateGradeEntity && associateGradeEntity.gradeCandidateCollection;
+				announce(`${this.localize('grades.linkingToGradeItem', { gradeName: gradeCandidateCollection.selected.name })}`);
+			}
 
 			await this.checkinDialog(e);
 

--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
@@ -7,12 +7,11 @@ import '@brightspace-ui/core/components/icons/icon.js';
 import '@brightspace-ui/core/components/inputs/input-radio-spacer.js';
 import { sharedAssociateGrade as associateGradeStore, shared as store } from '../state/activity-store.js';
 import { css, html } from 'lit-element/lit-element';
+import { GradebookStatus, GradeType } from 'siren-sdk/src/activities/associateGrade/AssociateGradeEntity.js';
 import { ActivityEditorWorkingCopyDialogMixin } from '../mixins/d2l-activity-editor-working-copy-dialog-mixin.js';
 import { announce } from '@brightspace-ui/core/helpers/announce.js';
 import { bodySmallStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { formatNumber } from '@brightspace-ui/intl/lib/number.js';
-import { GradebookStatus } from 'siren-sdk/src/activities/associateGrade/AssociateGradeEntity.js';
-import { GradeType } from 'siren-sdk/src/activities/associateGrade/AssociateGradeEntity.js';
 import { LocalizeActivityEditorMixin } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { radioStyles } from '@brightspace-ui/core/components/inputs/input-radio-styles.js';
@@ -326,7 +325,7 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 
 			const associateGradeEntity = associateGradeStore.get(this._associateGradeHref);
 			if (this._createNewRadioChecked) {
-				const localizeTerm = associateGradeEntity.gradeType === GradeType.Selectbox ? 'grades.creatingNewSelectboxGradeItem' : 'grades.creatingNewNumericGradeItem'
+				const localizeTerm = associateGradeEntity.gradeType === GradeType.Selectbox ? 'grades.creatingNewSelectboxGradeItem' : 'grades.creatingNewNumericGradeItem';
 				const scoreAndGrade = store.get(this.href).scoreAndGrade;
 				announce(`${this.localize(localizeTerm, { newGradeName: scoreAndGrade.newGradeName })}`);
 			} else {

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -118,6 +118,9 @@ export default {
 	"grades.selectboxDescriptionExample": "E.g. \"Very Good\" or \"B+\"", // Example of selectbox grade type
 	"grades.newGradeScheme": "Grade Scheme", // Label for the grade scheme
 	"grades.defaultGradeScheme": "--Default-- ({schemeName})", // name of default grade scheme
+	"grades.creatingNewNumericGradeItem": "Creating new numeric grade item {newGradeName}", // Aria text for new grade we are creating
+	"grades.creatingNewSelectboxGradeItem": "Creating new selectbox grade item {newGradeName}", // Aria text for new grade we are creating
+	"grades.linkingToGradeItem": "Linking to existing grade item {gradeName}", // Aria text for grade item we are linking to
 
 	"attachments.addGoogleDriveLink": "Attach from Google Drive", // Tooltip for a button that adds a link to a Google Drive file
 	"attachments.addFile": "File Upload", // Tooltip for a button that opens a file upload dialog


### PR DESCRIPTION
Task https://rally1.rallydev.com/#/29180338367d/dashboard?detail=%2Ftask%2F602375778941&fdp=true?fdp=true
for story https://rally1.rallydev.com/#/29180338367d/dashboard?detail=%2Fuserstory%2F600744235069&fdp=true?fdp=true

When grades dialog 'OK' is pressed, announce one of the following:
- "Creating new {numeric|selectbox} grade item {name}"
- "Linking to existing grade item {name}"