### PR TITLE
FACE HTML file - Support Template Selection - Dropdown Menu

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -39,9 +39,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 					align-items: center;
 					display: flex;
 					justify-content: space-between;
-				}
-				.d2l-new-html-editor-container {
-					margin-top: 6px;
+					margin-bottom: 6px;
 				}
 			`
 		];
@@ -55,7 +53,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 		this.saveOrder = 500;
 		this.htmlTemplatesHref = null;
 		this.htmlFileTemplates = [];
-		this.htmlFileTemplatesLoading = false;
+		this.firstTemplatesLoadAttempted = false;
 		this.htmlFileTemplatesLoaded = false;
 	}
 
@@ -73,13 +71,11 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 			this.skeleton = false;
 			pageContent = contentFileEntity.fileContent;
 
-			if (contentFileEntity.htmlTemplatesHref) {
-				this.htmlTemplatesHref = contentFileEntity.htmlTemplatesHref;
-			}
+			this.htmlTemplatesHref = contentFileEntity.htmlTemplatesHref;
 
 			switch (contentFileEntity.fileType) {
 				case FILE_TYPES.html:
-					pageRenderer = this._renderHtmlEditor(pageContent, this.htmlTemplatesHref);
+					pageRenderer = this._renderHtmlEditor(pageContent);
 					break;
 			}
 		} else {
@@ -164,12 +160,11 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 		const templates = htmlTemplatesEntity.getHtmlFileTemplates();
 		this.htmlFileTemplates = templates;
 		this.htmlFileTemplatesLoaded = true;
-		this.htmlFileTemplatesLoading = false;
 	}
 
 	_handleClickSelectTemplateButton() {
-		if (!this.htmlFileTemplatesLoaded && !this.htmlFileTemplatesLoading) {
-			this.htmlFileTemplatesLoading = true;
+		if (!this.htmlFileTemplatesLoaded && !this.firstTemplatesLoadAttempted) {
+			this.firstTemplatesLoadAttempted = true;
 			this._getHtmlTemplates(this.htmlTemplatesHref);
 		}
 	}
@@ -217,9 +212,9 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 					<d2l-dropdown-menu
 						style="${this.htmlTemplatesHref ? '' : 'visibility:hidden;'}" 
 					>
-						<d2l-menu label="HTML File Templates">
-							${this.htmlFileTemplatesLoaded ? this.htmlFileTemplates.map((template) => { return html`<d2l-menu-item text=${template.properties.title}></d2l-menu-item>`; }) : this._getHtmlTemplateLoadingMenuItem()}
+						<d2l-menu label=${this.localize('content.htmlTemplatesLoading')}>
 							<d2l-menu-item text=${this.localize('content.BrowseForHtmlTemplate')}></d2l-menu-item>
+							${this.htmlFileTemplatesLoaded ? this.htmlFileTemplates.map((template) => { return html`<d2l-menu-item text=${template.properties.title}></d2l-menu-item>`; }) : this._getHtmlTemplateLoadingMenuItem()}
 						</d2l-menu>
 					</d2l-dropdown-menu>
 				</d2l-dropdown-button-subtle>	

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -27,10 +27,13 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 			activityContentEditorStyles,
 			activityHtmlEditorStyles,
 			css`
-				.d2l-activity-label-container {
+				.d2l-page-content-label-select-template-container {
 					align-items: center;
 					display: flex;
 					justify-content: space-between;
+				}
+				.d2l-new-html-editor-container {
+					margin-top: 6px;
 				}
 			`
 		];
@@ -53,14 +56,19 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 		const contentFileEntity = contentFileStore.getContentFileActivity(this.href);
 		let pageContent = undefined;
 		let pageRenderer = undefined;
+		let htmlTemplatesHref = null;
 
 		if (contentFileEntity) {
 			this.skeleton = false;
 			pageContent = contentFileEntity.fileContent;
 
+			if (contentFileEntity.htmlTemplatesHref) {
+				htmlTemplatesHref = contentFileEntity.htmlTemplatesHref;
+			}
+
 			switch (contentFileEntity.fileType) {
 				case FILE_TYPES.html:
-					pageRenderer = this._renderHtmlEditor(pageContent);
+					pageRenderer = this._renderHtmlEditor(pageContent, htmlTemplatesHref);
 					break;
 			}
 		} else {
@@ -149,7 +157,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 		);
 	}
 
-	_renderHtmlEditor(pageContent) {
+	_renderHtmlEditor(pageContent, htmlTemplatesHref) {
 		const newEditorEvent = new CustomEvent('d2l-request-provider', {
 			detail: { key: 'd2l-provider-html-new-editor-enabled' },
 			bubbles: true,
@@ -165,9 +173,15 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 		const activityTextEditorChange = htmlNewEditorEnabled ? this._onPageContentChange : this._onPageContentChangeDebounced;
 
 		return html`
-			<div class="d2l-activity-label-container d2l-label-text d2l-skeletize">
-				${this.localize('content.pageContent')}
-				<d2l-dropdown-button-subtle text=${this.localize('content.selectTemplate')}>
+			<div class="d2l-page-content-label-select-template-container">
+				<label class="d2l-label-text d2l-skeletize">
+					${this.localize('content.pageContent')}
+				</label>
+				<d2l-dropdown-button-subtle 
+					style="${htmlTemplatesHref ? '' : 'visibility:hidden;'}" 
+					text=${this.localize('content.selectTemplate')}
+					class="d2l-skeletize"
+				>
 				</d2l-dropdown-button-subtle>
 			</div>
 			<div class="d2l-skeletize ${htmlNewEditorEnabled ? 'd2l-new-html-editor-container' : ''}">

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -2,6 +2,7 @@ import '../shared-components/d2l-activity-content-editor-title.js';
 import './d2l-activity-content-file-loading.js';
 import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
 import { ContentFileEntity, FILE_TYPES } from 'siren-sdk/src/activities/content/ContentFileEntity.js';
+import { css, html } from 'lit-element/lit-element.js';
 import { activityContentEditorStyles } from '../shared-components/d2l-activity-content-editor-styles.js';
 import { ActivityEditorMixin } from '../../mixins/d2l-activity-editor-mixin.js';
 import { activityHtmlEditorStyles } from '../shared-components/d2l-activity-html-editor-styles.js';
@@ -10,7 +11,6 @@ import { shared as contentFileStore } from './state/content-file-store.js';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { ErrorHandlingMixin } from '../../error-handling-mixin.js';
-import { html } from 'lit-element/lit-element.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeActivityEditorMixin } from '../../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
@@ -25,7 +25,14 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 			super.styles,
 			labelStyles,
 			activityContentEditorStyles,
-			activityHtmlEditorStyles
+			activityHtmlEditorStyles,
+			css`
+				.d2l-activity-label-container {
+					align-items: center;
+					display: flex;
+					justify-content: space-between;
+				}
+			`
 		];
 	}
 
@@ -160,6 +167,8 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 		return html`
 			<div class="d2l-activity-label-container d2l-label-text d2l-skeletize">
 				${this.localize('content.pageContent')}
+				<d2l-dropdown-button-subtle text=${this.localize('content.selectTemplate')}>
+				</d2l-dropdown-button-subtle>
 			</div>
 			<div class="d2l-skeletize ${htmlNewEditorEnabled ? 'd2l-new-html-editor-container' : ''}">
 				<d2l-activity-text-editor

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -11,6 +11,7 @@ import { shared as contentFileStore } from './state/content-file-store.js';
 import { Debouncer } from '@polymer/polymer/lib/utils/debounce.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit.js';
 import { ErrorHandlingMixin } from '../../error-handling-mixin.js';
+import { fetchEntity } from '../../state/fetch-entity.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { LocalizeActivityEditorMixin } from '../../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
@@ -182,6 +183,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 					text=${this.localize('content.selectTemplate')}
 					class="d2l-skeletize"
 				>
+					${this._getHtmlTemplates(htmlTemplatesHref)}
 				</d2l-dropdown-button-subtle>
 			</div>
 			<div class="d2l-skeletize ${htmlNewEditorEnabled ? 'd2l-new-html-editor-container' : ''}">
@@ -219,6 +221,21 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 			return;
 		}
 		contentFileEntity.setPageContent(pageContent);
+	}
+
+	async _getHtmlTemplates(htmlTemplatesHref) {
+		const htmlTemplatesEntity = await fetchEntity(htmlTemplatesHref, this.token);
+		const htmlTemplatesEntities = htmlTemplatesEntity && htmlTemplatesEntity.entities;
+
+		let d2lDropdownContentTemplates = '';
+		if (htmlTemplatesEntities) {
+			htmlTemplatesEntities.forEach(templateEntity => {
+				if (templateEntity.properties && templateEntity.properties.title) {
+					d2lDropdownContentTemplates += ('<d2l-dropdown-content>' + templateEntity.properties.title + '</d2l-dropdown-content>');
+				}
+			});
+			return html`${d2lDropdownContentTemplates}`;
+		}
 	}
 }
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
@@ -18,6 +18,7 @@ export class ContentFile {
 		this.persistedFileContent = '';
 		this.fileContent = '';
 		this.fileType = null;
+		this.htmlTemplatesHref = null;
 	}
 
 	async cancelCreate() {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/state/content-file.js
@@ -61,6 +61,7 @@ export class ContentFile {
 		this.fileContent = fileContent;
 		this.fileType = contentFileEntity.getFileType();
 		this.fileHref = contentFileEntity.getFileHref();
+		this.htmlTemplatesHref = contentFileEntity.getHtmlTemplatesHref();
 	}
 
 	async save() {

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -140,6 +140,7 @@ export default {
 	"content.emptyNameField": "Name is required.", // Error text that appears below name field when it is left empty
 	"content.description": "Description", // Text label for description input field
 	"content.pageContent": "Page Content", // Text label for page content input field (HTML files)
+	"content.selectTemplate": "Select Template", // The label text for the subtle-button for selecting an HTML template
 	"content.availabilityHeader": "Availability Dates", // availability header
 	"content.saveError": "Your content item wasn't saved. Please correct the fields outlined in red.", // Error message to inform the user that there was a problem saving the content item, instructing them to correct invalid fields
 	"content.displayOptions": "Display Options", // Text label for display options

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -139,8 +139,10 @@ export default {
 	"content.name": "Name", // Text label for name input field
 	"content.emptyNameField": "Name is required.", // Error text that appears below name field when it is left empty
 	"content.description": "Description", // Text label for description input field
-	"content.pageContent": "Page Content", // Text label for page content input field (HTML files)
-	"content.selectTemplate": "Select Template", // The label text for the subtle-button for selecting an HTML template
+	"content.pageContent": "Page Content", // Text label for page content input field (html files)
+	"content.selectTemplate": "Select Template", // The label text for the subtle-button for selecting an html template
+	"content.htmlTemplatesLoading": "Loading...", // Message displayed while list of html templates is loading
+	"content.BrowseForHtmlTemplate": "Browse for a Template", // Text for button to browse for an html template
 	"content.availabilityHeader": "Availability Dates", // availability header
 	"content.saveError": "Your content item wasn't saved. Please correct the fields outlined in red.", // Error message to inform the user that there was a problem saving the content item, instructing them to correct invalid fields
 	"content.displayOptions": "Display Options", // Text label for display options

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -143,6 +143,7 @@ export default {
 	"content.selectTemplate": "Select Template", // The label text for the subtle-button for selecting an html template
 	"content.htmlTemplatesLoading": "Loading...", // Message displayed while list of html templates is loading
 	"content.BrowseForHtmlTemplate": "Browse for a Template", // Text for button to browse for an html template
+	"content.defaultHtmlTemplateHeader": "HTML File Templates", // The message to display as the default header for the html template select dropdown
 	"content.availabilityHeader": "Availability Dates", // availability header
 	"content.saveError": "Your content item wasn't saved. Please correct the fields outlined in red.", // Error message to inform the user that there was a problem saving the content item, instructing them to correct invalid fields
 	"content.displayOptions": "Display Options", // Text label for display options


### PR DESCRIPTION
## Relevant Rally Links

https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F424774442084

## Description

As part of the new Feature work for HTML FACE pages, we would like to support HTML File Template selection. The first piece to this is to fetch the relevant Siren Entities for this, and and display the list of templates in a dropdown menu. (See Rally link for link to designs).

## Goal/Solution

This PR adds a 'Select Template' subtle dropdown button, that displays 'Loading...' when clicked and then the list of templates once the template entities have been fetched.

## Video/Screenshots

![Demo](https://user-images.githubusercontent.com/29843252/123664297-d201dd00-d7fc-11eb-912b-3609053edd9a.gif)

## Related PRs

- https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/355

## Remaining Work

- [ ] Dev Testing: another developer will test this code on their machine
