### PR TITLE
TA154603 - Prefetch schemes and candidates

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -358,6 +358,8 @@ class ActivityScoreEditor extends ActivityEditorMixin(SkeletonMixin(LocalizeActi
 		` : null;
 	}
 	_addToGrades() {
+		this._prefetchGradeCandidates();
+		this._prefetchGradeSchemes();
 		store.get(this.href).scoreAndGrade.addToGrades();
 		this._associateGradeSetGradebookStatus(GradebookStatus.NewGrade);
 	}
@@ -377,6 +379,8 @@ class ActivityScoreEditor extends ActivityEditorMixin(SkeletonMixin(LocalizeActi
 		associateGradeEntity && associateGradeEntity.setGradeMaxPoints(maxPoints);
 	}
 	_chooseFromGrades() {
+		this._prefetchGradeCandidates();
+		this._prefetchGradeSchemes();
 		const activityGradesElement = this.shadowRoot.querySelector('d2l-activity-grades-dialog');
 		if (activityGradesElement) {
 			activityGradesElement.openGradesDialog();
@@ -400,12 +404,21 @@ class ActivityScoreEditor extends ActivityEditorMixin(SkeletonMixin(LocalizeActi
 
 		scoreAndGrade.setScoreOutOf(scoreOutOf);
 	}
-
+	_prefetchGradeCandidates() {
+		const entity = associateGradeStore.get(this._associateGradeHref);
+		entity && entity.getGradeCandidates();
+	}
+	_prefetchGradeSchemes() {
+		const entity = associateGradeStore.get(this._associateGradeHref);
+		entity && entity.getGradeSchemes();
+	}
 	_removeFromGrades() {
 		store.get(this.href).scoreAndGrade.removeFromGrades();
 		this._associateGradeSetGradebookStatus(GradebookStatus.NotInGradebook);
 	}
 	_setGraded() {
+		this._prefetchGradeCandidates();
+		this._prefetchGradeSchemes();
 		const scoreAndGrade = store.get(this.href).scoreAndGrade;
 		scoreAndGrade.setGraded(scoreAndGrade.canEditGrades);
 		this._associateGradeSetGradebookStatus(GradebookStatus.NewGrade);


### PR DESCRIPTION
Avoids individual scheme, category, and grade items from being individually fetched when dialog is opened.


Task: TA154603 - Prevent /grade-candidates cache-primers from being fetched on every dialog open https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Ftask%2F601362328529&expandApp=486232622048
and TA155032 - Prevent /grade-schemes cache-primer from being fetched on every /grade-schemes GET
https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Ftask%2F602157892421&expandApp=486232622048

from story: https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F600744235069&expandApp=486232622048&fdp=true?fdp=true


Whenever the dialog is opened, /grade-candidates needs to be re-fetched because it will have a different workingCopyId query param. The /grade-candidates response always includes a link to the cache-primers /grade-categories/cache-primer and /grades/cache-primer. So these cache-primers are always re-fetched when the dialog is opened.
- In the front-end, do an initial /grade-candidates fetch on the initial checkout, we won't be using the grade-candidates when the dialog is closed, however, this request is important as it will request the cache-primers and load the /grade-categories and /grades in to the entity store.

- In the back-end, only return cache-primer link headers in the /grade-candidates response when it is a non-working copy OR a working copy with NO Parent working copy id. So only the initial checkout should return cache-primers. Subsequent forks/checkout off that initial working copy will not return cache-primer links.

This PR is the front-end fix.