### PR TITLE
fix: scoreOutOf error

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -72,6 +72,7 @@ class ActivityEditor extends ActivityEditorContainerMixin(ActivityEditorTelemetr
 		this.resizable = false;
 		this._backdropShown = false;
 		this._saveToastVisible = null;
+		this.saveOrder = 1500;
 	}
 
 	connectedCallback() {

--- a/components/d2l-activity-editor/d2l-activity-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-editor.js
@@ -72,7 +72,6 @@ class ActivityEditor extends ActivityEditorContainerMixin(ActivityEditorTelemetr
 		this.resizable = false;
 		this._backdropShown = false;
 		this._saveToastVisible = null;
-		this.saveOrder = 1500;
 	}
 
 	connectedCallback() {

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -163,6 +163,7 @@ class ActivityScoreEditor extends ActivityEditorMixin(SkeletonMixin(LocalizeActi
 
 	constructor() {
 		super(store);
+		this.saveOrder = 500;
 	}
 
 	connectedCallback() {
@@ -330,6 +331,7 @@ class ActivityScoreEditor extends ActivityEditorMixin(SkeletonMixin(LocalizeActi
 				this._associateGradeSetGradeName(this.activityName);
 			}
 		}
+		await super.save();
 	}
 
 	_addOrRemoveMenuItem() {


### PR DESCRIPTION
Make sure main page is checked in BEFORE score-out-of api is called. This way, if we set to ungraded, then state will be not-in-gradebook (disassociating the grade) before setting score-out-of to empty. Fixes error "score out of must have a value when grade is associated".