### PR TITLE
US127570 - sorting html templates by name

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -158,10 +158,10 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 	async _getHtmlTemplates() {
 		const htmlTemplatesResponse = await fetchEntity(this.htmlTemplatesHref, this.token);
 		const htmlTemplatesEntity = new ContentHtmlFileTemplatesEntity(htmlTemplatesResponse, this.token, { remove: () => { } });
-		let templates = htmlTemplatesEntity.getHtmlFileTemplates();
+		const templates = htmlTemplatesEntity.getHtmlFileTemplates();
 
 		if (this.sortHTMLTemplatesByName) {
-			templates = templates.sort((a, b) => a?.properties?.title?.localeCompare(b?.properties?.title));
+			templates.sort((a, b) => a?.properties?.title?.localeCompare(b?.properties?.title));
 		}
 
 		this.htmlFileTemplates = templates;

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -41,6 +41,9 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 					justify-content: space-between;
 					margin-bottom: 6px;
 				}
+				.d2l-new-html-editor-container {
+					margin-top: 6px;
+				}
 			`
 		];
 	}
@@ -66,16 +69,23 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 		const contentFileEntity = contentFileStore.getContentFileActivity(this.href);
 		let pageContent = undefined;
 		let pageRenderer = undefined;
+		let htmlTemplatesHref = null;
 
 		if (contentFileEntity) {
 			this.skeleton = false;
 			pageContent = contentFileEntity.fileContent;
 
+<<<<<<< HEAD
 			this.htmlTemplatesHref = contentFileEntity.htmlTemplatesHref;
+=======
+			if (contentFileEntity.htmlTemplatesHref) {
+				htmlTemplatesHref = contentFileEntity.htmlTemplatesHref;
+			}
+>>>>>>> d361877c (Configure 'Select Template' subtle button to show dependent on wether 'contentFileEntity.htmlTemplatesHref' exists)
 
 			switch (contentFileEntity.fileType) {
 				case FILE_TYPES.html:
-					pageRenderer = this._renderHtmlEditor(pageContent);
+					pageRenderer = this._renderHtmlEditor(pageContent, htmlTemplatesHref);
 					break;
 			}
 		} else {
@@ -183,7 +193,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 		);
 	}
 
-	_renderHtmlEditor(pageContent) {
+	_renderHtmlEditor(pageContent, htmlTemplatesHref) {
 		const newEditorEvent = new CustomEvent('d2l-request-provider', {
 			detail: { key: 'd2l-provider-html-new-editor-enabled' },
 			bubbles: true,
@@ -203,6 +213,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 				<label class="d2l-label-text d2l-skeletize">
 					${this.localize('content.pageContent')}
 				</label>
+<<<<<<< HEAD
 				<d2l-dropdown-button-subtle
 					style="${this.htmlTemplatesHref ? '' : 'visibility:hidden;'}"
 					text=${this.localize('content.selectTemplate')}
@@ -217,6 +228,13 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 							${this.htmlFileTemplatesLoaded ? this.htmlFileTemplates.map((template) => { return html`<d2l-menu-item text=${template.properties.title}></d2l-menu-item>`; }) : this._getHtmlTemplateLoadingMenuItem()}
 						</d2l-menu>
 					</d2l-dropdown-menu>
+=======
+				<d2l-dropdown-button-subtle 
+					style="${htmlTemplatesHref ? '' : 'visibility:hidden;'}" 
+					text=${this.localize('content.selectTemplate')}
+					class="d2l-skeletize"
+				>
+>>>>>>> d361877c (Configure 'Select Template' subtle button to show dependent on wether 'contentFileEntity.htmlTemplatesHref' exists)
 				</d2l-dropdown-button-subtle>
 			</div>
 			<div class="d2l-skeletize ${htmlNewEditorEnabled ? 'd2l-new-html-editor-container' : ''}">

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -163,10 +163,12 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 
 		if (this.sortHTMLTemplatesByName) {
 			templates.sort((a, b) => {
-				if (a && a.title() && b) {
-					return a.title().localeCompare(b.title());
+				if (a.title() < b.title()) {
+					return -1;
+				} else if (a.title() > b.title()) {
+					return 1;
 				}
-				return -1;
+				return 0;
 			});
 		}
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -75,13 +75,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 			this.skeleton = false;
 			pageContent = contentFileEntity.fileContent;
 
-<<<<<<< HEAD
 			this.htmlTemplatesHref = contentFileEntity.htmlTemplatesHref;
-=======
-			if (contentFileEntity.htmlTemplatesHref) {
-				htmlTemplatesHref = contentFileEntity.htmlTemplatesHref;
-			}
->>>>>>> d361877c (Configure 'Select Template' subtle button to show dependent on wether 'contentFileEntity.htmlTemplatesHref' exists)
 
 			switch (contentFileEntity.fileType) {
 				case FILE_TYPES.html:
@@ -213,7 +207,6 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 				<label class="d2l-label-text d2l-skeletize">
 					${this.localize('content.pageContent')}
 				</label>
-<<<<<<< HEAD
 				<d2l-dropdown-button-subtle
 					style="${this.htmlTemplatesHref ? '' : 'visibility:hidden;'}"
 					text=${this.localize('content.selectTemplate')}
@@ -228,13 +221,6 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 							${this.htmlFileTemplatesLoaded ? this.htmlFileTemplates.map((template) => { return html`<d2l-menu-item text=${template.properties.title}></d2l-menu-item>`; }) : this._getHtmlTemplateLoadingMenuItem()}
 						</d2l-menu>
 					</d2l-dropdown-menu>
-=======
-				<d2l-dropdown-button-subtle 
-					style="${htmlTemplatesHref ? '' : 'visibility:hidden;'}" 
-					text=${this.localize('content.selectTemplate')}
-					class="d2l-skeletize"
-				>
->>>>>>> d361877c (Configure 'Select Template' subtle button to show dependent on wether 'contentFileEntity.htmlTemplatesHref' exists)
 				</d2l-dropdown-button-subtle>
 			</div>
 			<div class="d2l-skeletize ${htmlNewEditorEnabled ? 'd2l-new-html-editor-container' : ''}">

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -203,21 +203,21 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 				<label class="d2l-label-text d2l-skeletize">
 					${this.localize('content.pageContent')}
 				</label>
-				<d2l-dropdown-button-subtle 
-					style="${this.htmlTemplatesHref ? '' : 'visibility:hidden;'}" 
+				<d2l-dropdown-button-subtle
+					style="${this.htmlTemplatesHref ? '' : 'visibility:hidden;'}"
 					text=${this.localize('content.selectTemplate')}
 					class="d2l-skeletize"
 					@click=${this._handleClickSelectTemplateButton}
 				>
 					<d2l-dropdown-menu
-						style="${this.htmlTemplatesHref ? '' : 'visibility:hidden;'}" 
+						style="${this.htmlTemplatesHref ? '' : 'visibility:hidden;'}"
 					>
 						<d2l-menu label=${this.localize('content.htmlTemplatesLoading')}>
 							<d2l-menu-item text=${this.localize('content.BrowseForHtmlTemplate')}></d2l-menu-item>
 							${this.htmlFileTemplatesLoaded ? this.htmlFileTemplates.map((template) => { return html`<d2l-menu-item text=${template.properties.title}></d2l-menu-item>`; }) : this._getHtmlTemplateLoadingMenuItem()}
 						</d2l-menu>
 					</d2l-dropdown-menu>
-				</d2l-dropdown-button-subtle>	
+				</d2l-dropdown-button-subtle>
 			</div>
 			<div class="d2l-skeletize ${htmlNewEditorEnabled ? 'd2l-new-html-editor-container' : ''}">
 				<d2l-activity-text-editor

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -158,7 +158,12 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 	async _getHtmlTemplates() {
 		const htmlTemplatesResponse = await fetchEntity(this.htmlTemplatesHref, this.token);
 		const htmlTemplatesEntity = new ContentHtmlFileTemplatesEntity(htmlTemplatesResponse, this.token, { remove: () => { } });
-		const templates = htmlTemplatesEntity.getHtmlFileTemplates();
+		let templates = htmlTemplatesEntity.getHtmlFileTemplates();
+
+		if (this.sortHTMLTemplatesByName) {
+			templates = templates.sort((a, b) => a.properties.title.localeCompare(b.properties.title));
+		}
+
 		this.htmlFileTemplates = templates;
 		this.htmlFileTemplatesLoaded = true;
 	}

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -19,7 +19,6 @@ import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
-import { ContentHtmlFileTemplatesEntity } from 'siren-sdk/src/activities/content/ContentHtmlFileTemplatesEntity.js'
 
 class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingMixin(LocalizeActivityEditorMixin(EntityMixinLit(RtlMixin(ActivityEditorMixin(MobxLitElement))))))) {
 
@@ -42,9 +41,6 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 					display: flex;
 					justify-content: space-between;
 					margin-bottom: 6px;
-				}
-				.d2l-new-html-editor-container {
-					margin-top: 6px;
 				}
 			`
 		];
@@ -71,7 +67,6 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 		const contentFileEntity = contentFileStore.getContentFileActivity(this.href);
 		let pageContent = undefined;
 		let pageRenderer = undefined;
-		let htmlTemplatesHref = null;
 
 		if (contentFileEntity) {
 			this.skeleton = false;
@@ -81,7 +76,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 
 			switch (contentFileEntity.fileType) {
 				case FILE_TYPES.html:
-					pageRenderer = this._renderHtmlEditor(pageContent, htmlTemplatesHref);
+					pageRenderer = this._renderHtmlEditor(pageContent);
 					break;
 			}
 		} else {
@@ -189,7 +184,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 		);
 	}
 
-	_renderHtmlEditor(pageContent, htmlTemplatesHref) {
+	_renderHtmlEditor(pageContent) {
 		const newEditorEvent = new CustomEvent('d2l-request-provider', {
 			detail: { key: 'd2l-provider-html-new-editor-enabled' },
 			bubbles: true,

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -25,7 +25,8 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 
 	static get properties() {
 		return {
-			htmlFileTemplates: { type: Array }
+			htmlFileTemplates: { type: Array },
+			sortHTMLTemplatesByName: { type: Boolean },
 		};
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -161,7 +161,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 		let templates = htmlTemplatesEntity.getHtmlFileTemplates();
 
 		if (this.sortHTMLTemplatesByName) {
-			templates = templates.sort((a, b) => a.properties.title.localeCompare(b.properties.title));
+			templates = templates.sort((a, b) => a?.properties?.title?.localeCompare(b?.properties?.title));
 		}
 
 		this.htmlFileTemplates = templates;

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -19,6 +19,7 @@ import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
+import { ContentHtmlFileTemplatesEntity } from 'siren-sdk/src/activities/content/ContentHtmlFileTemplatesEntity.js'
 
 class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingMixin(LocalizeActivityEditorMixin(EntityMixinLit(RtlMixin(ActivityEditorMixin(MobxLitElement))))))) {
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
@@ -11,6 +11,12 @@ import { shared as store } from './state/content-store.js';
 
 class ContentEditorDetail extends MobxLitElement {
 
+	static get properties() {
+		return {
+			sortHTMLTemplatesByName: { type: Boolean },
+		};
+	}
+
 	static get styles() {
 		return  [
 			css`
@@ -84,6 +90,7 @@ class ContentEditorDetail extends MobxLitElement {
 				<d2l-activity-content-file-detail
 					.href="${contentActivityHref}"
 					.token="${this.token}"
+					?sortHTMLTemplatesByName="${this.sortHTMLTemplatesByName}"
 				>
 					${this._renderDueDate(true)}
 				</d2l-activity-content-file-detail>

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor.js
@@ -25,6 +25,7 @@ class ContentEditor extends LocalizeActivityEditorMixin(RtlMixin(ActivityEditorM
 			saveHref: { type: String },
 			unfurlEndpoint: { type: String },
 			trustedSitesEndpoint: { type: String },
+			sortHTMLTemplatesByName: { type: Boolean }
 		};
 	}
 
@@ -120,6 +121,7 @@ class ContentEditor extends LocalizeActivityEditorMixin(RtlMixin(ActivityEditorM
 				<d2l-activity-content-editor-detail
 					.href="${this.href}"
 					.token="${this.token}"
+					?sortHTMLTemplatesByName="${this.sortHTMLTemplatesByName}"
 				>
 				</d2l-activity-content-editor-detail>
 			</div>

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -146,10 +146,7 @@ export default {
 	"content.selectTemplate": "Select Template", // The label text for the subtle-button for selecting an html template
 	"content.htmlTemplatesLoading": "Loading...", // Message displayed while list of html templates is loading
 	"content.BrowseForHtmlTemplate": "Browse for a Template", // Text for button to browse for an html template
-<<<<<<< HEAD
 	"content.defaultHtmlTemplateHeader": "HTML File Templates", // The message to display as the default header for the html template select dropdown
-=======
->>>>>>> 96f42a4c (Configure async code to fetch templates on select button template click)
 	"content.availabilityHeader": "Availability Dates", // availability header
 	"content.saveError": "Your content item wasn't saved. Please correct the fields outlined in red.", // Error message to inform the user that there was a problem saving the content item, instructing them to correct invalid fields
 	"content.displayOptions": "Display Options", // Text label for display options

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -146,7 +146,10 @@ export default {
 	"content.selectTemplate": "Select Template", // The label text for the subtle-button for selecting an html template
 	"content.htmlTemplatesLoading": "Loading...", // Message displayed while list of html templates is loading
 	"content.BrowseForHtmlTemplate": "Browse for a Template", // Text for button to browse for an html template
+<<<<<<< HEAD
 	"content.defaultHtmlTemplateHeader": "HTML File Templates", // The message to display as the default header for the html template select dropdown
+=======
+>>>>>>> 96f42a4c (Configure async code to fetch templates on select button template click)
 	"content.availabilityHeader": "Availability Dates", // availability header
 	"content.saveError": "Your content item wasn't saved. Please correct the fields outlined in red.", // Error message to inform the user that there was a problem saving the content item, instructing them to correct invalid fields
 	"content.displayOptions": "Display Options", // Text label for display options


### PR DESCRIPTION
Co-authored with @quinnbudan 

## Relevant Rally Links

- [US127570](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F602050357608&fdp=true?fdp=true): FACE HTML file - Support Sorting HTML Templates By Name 

## Description

This PR enables a config variable to sort HTML templates by name.



## Goal/Solution

This PR enables a config variable to sort HTML templates by name. The config variable is passed into FACE by the LMS.


## Video/Screenshots

N/A



## Related PRs

- https://github.com/Brightspace/lms/pull/12034




## Remaining Work
- [ ] Dev Testing: another developer will test this code on their machine
