### PR TITLE
Don't need to re-fetch schemes if it was previously `undefined`

### DIFF
--- a/components/d2l-activity-editor/state/associate-grade.js
+++ b/components/d2l-activity-editor/state/associate-grade.js
@@ -80,7 +80,7 @@ export class AssociateGrade {
 		this.gradeType = entity.gradeType();
 		this.canGetSchemes = entity.canGetSchemesForType(this.gradeType);
 
-		if (this.gradeSchemeCollection && existingGradeType !== this.gradeType) {
+		if (this.gradeSchemeCollection && existingGradeType && existingGradeType !== this.gradeType) {
 			await this.getGradeSchemes(true);
 		}
 


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F600744235069%2Ftasks&expandApp=486232622048&fdp=true?fdp=true