### PR TITLE
FACE HTML file - Support Template Selection - Selecting a template

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -22,7 +22,7 @@ import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 
 // Index for the browse template button
-const browseTemplateKey = -1;
+const browseTemplateKey = '-1';
 const editorKeyInitial = 'content-page-content';
 
 class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingMixin(LocalizeActivityEditorMixin(EntityMixinLit(RtlMixin(ActivityEditorMixin(MobxLitElement))))))) {
@@ -178,31 +178,35 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 
 	async _handleClickTemplateMenutItem(e) {
 		const targetMenuItem = e.target.getAttribute('key');
-		const template = this.htmlFileTemplates[targetMenuItem];
-		const fileEntity = new FileEntity(template);
-		const contentUrl = fileEntity.getFileDataLocationHref();
-		const response = await window.d2lfetch.fetch(contentUrl);
 
-		if (response.ok) {
-			const content = await response.text();
-			this.pageContent = ''; // we need to reset this first, otherwise if same template is selected again, it won't re-render
-			this.pageContent = content;
-			this._savePageContent();
-			this.editorKey = `${editorKeyInitial  }-${Date.now().toString()}`; // key needs to be modified in order to re-render old HTML editor
+		if (targetMenuItem === browseTemplateKey) {
+			// TODO: Add Browse Template Button Support
+		}
+		else {
+			const template = this.htmlFileTemplates[targetMenuItem];
+			const fileEntity = new FileEntity(template);
+			const contentUrl = fileEntity.getFileDataLocationHref();
+			const response = await window.d2lfetch.fetch(contentUrl);
+
+			if (response.ok) {
+				const content = await response.text();
+				this._savePageContent(content);
+				this.editorKey = `${editorKeyInitial}-${Date.now().toString()}`; // key needs to be modified in order to re-render old HTML editor
+			}
 		}
 	}
 
 	_onPageContentChange(e) {
-		this.pageContent = e.detail.content;
-		this._savePageContent();
+		const htmlContent = e.detail.content;
+		this._savePageContent(htmlContent);
 	}
 
 	_onPageContentChangeDebounced(e) {
-		this.pageContent = e.detail.content;
+		const htmlContent = e.detail.content;
 		this._debounceJobs.description = Debouncer.debounce(
 			this._debounceJobs.description,
 			timeOut.after(ContentEditorConstants.DEBOUNCE_TIMEOUT),
-			() => this._savePageContent()
+			() => this._savePageContent(htmlContent)
 		);
 	}
 
@@ -271,12 +275,13 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 		this._debounceJobs[jobName] && this._debounceJobs[jobName].flush();
 	}
 
-	_savePageContent() {
+	_savePageContent(htmlContent) {
 		const contentFileEntity = contentFileStore.getContentFileActivity(this.href);
 		if (!contentFileEntity) {
 			return;
 		}
-		contentFileEntity.setPageContent(this.pageContent);
+		contentFileEntity.setPageContent(htmlContent);
+		this.pageContent = htmlContent;
 	}
 }
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -22,7 +22,7 @@ import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 
 // Index for the browse template button
-const browseTemplateKey = '-1';
+const browseTemplateKey = 'browse';
 const editorKeyInitial = 'content-page-content';
 
 class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingMixin(LocalizeActivityEditorMixin(EntityMixinLit(RtlMixin(ActivityEditorMixin(MobxLitElement))))))) {
@@ -187,15 +187,13 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 	}
 
 	async _handleClickTemplateMenuItem(e) {
-		const targetMenuItem = e.target.getAttribute('key');
+		const target = e.target.getAttribute('key');
 
-		if (targetMenuItem === browseTemplateKey) {
+		if (target === browseTemplateKey) {
 			// TODO: Add Browse Template Button Support
 		}
 		else {
-			const fileEntity = this.htmlFileTemplates[targetMenuItem];
-			const contentUrl = fileEntity.getFileDataLocationHref();
-			const response = await window.d2lfetch.fetch(contentUrl);
+			const response = await window.d2lfetch.fetch(target);
 
 			if (response.ok) {
 				const content = await response.text();
@@ -262,7 +260,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 			return html`<p class="d2l-menu-item-span d2l-body-small">${this.localize('content.noHtmlTemplates')}</p>`;
 		}
 
-		return this.htmlFileTemplates.map((template, index) => html`<d2l-menu-item text=${template.title()} key=${index}></d2l-menu-item>`);
+		return this.htmlFileTemplates.map((template) => html`<d2l-menu-item text=${template.title()} key=${template.getFileDataLocationHref()}></d2l-menu-item>`);
 	}
 
 	_renderTemplateSelectDropdown() {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -186,7 +186,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 		}
 	}
 
-	async _handleClickTemplateMenutItem(e) {
+	async _handleClickTemplateMenuItem(e) {
 		const targetMenuItem = e.target.getAttribute('key');
 
 		if (targetMenuItem === browseTemplateKey) {
@@ -284,7 +284,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 		>
 
 		<d2l-dropdown-menu align="end">
-			<d2l-menu label="${label}" @d2l-menu-item-select=${this._handleClickTemplateMenutItem}>
+			<d2l-menu label="${label}" @d2l-menu-item-select=${this._handleClickTemplateMenuItem}>
 				<d2l-menu-item text=${this.localize('content.BrowseForHtmlTemplate')} key=${browseTemplateKey}></d2l-menu-item>
 				${this.htmlFileTemplatesLoaded ? this._renderHtmlTemplates() : this._getHtmlTemplateLoadingMenuItem()}
 			</d2l-menu>

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -23,6 +23,8 @@ import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 
 // Index for the browse template button
 const browseTemplateKey = -1;
+const editorKeyInitial = 'content-page-content';
+
 class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingMixin(LocalizeActivityEditorMixin(EntityMixinLit(RtlMixin(ActivityEditorMixin(MobxLitElement))))))) {
 
 	static get properties() {
@@ -60,6 +62,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 		this.firstTemplatesLoadAttempted = false;
 		this.htmlFileTemplatesLoaded = false;
 		this.pageContent = null;
+		this.editorKey = editorKeyInitial;
 	}
 
 	connectedCallback() {
@@ -182,8 +185,10 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 
 		if (response.ok) {
 			const content = await response.text();
+			this.pageContent = ''; // we need to reset this first, otherwise if same template is selected again, it won't re-render
 			this.pageContent = content;
 			this._savePageContent();
+			this.editorKey = `${editorKeyInitial  }-${Date.now().toString()}`; // key needs to be modified in order to re-render old HTML editor
 		}
 	}
 
@@ -240,7 +245,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 			<div class="d2l-skeletize ${htmlNewEditorEnabled ? 'd2l-new-html-editor-container' : ''}">
 				<d2l-activity-text-editor
 					.ariaLabel="${this.localize('content.pageContent')}"
-					.key="content-page-content"
+					.key=${this.editorKey}
 					.value="${this.pageContent}"
 					@d2l-activity-text-editor-change="${activityTextEditorChange}"
 					.richtextEditorConfig="${{}}"


### PR DESCRIPTION
## Relevant Rally Links

- US127822: https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F602982229180

## Description

As part of our FACE initiative and revamp, we would like to support HTML template selection.

## Goal/Solution

This PR makes the necessary changes to fetch the HTML template's contents, once one has been selected from the dropdown, and replaces the editor's contents with it (New HTML Editor, Old HTML Editor and NoWYSIWYG Text Editor).

## Video/Screenshots

![New HTML Editor Template File](https://user-images.githubusercontent.com/29843252/125107510-870e8200-e0a6-11eb-92ee-9d2a4ca88f3b.gif)

![Old HTML Editor Template File](https://user-images.githubusercontent.com/29843252/125107526-8aa20900-e0a6-11eb-8d07-3aefc5dd6169.gif)

![Text HTML Editor Template File](https://user-images.githubusercontent.com/29843252/125107536-8c6bcc80-e0a6-11eb-9777-e677bacb784c.gif)


## Related PRs

- https://github.com/Brightspace/lms/pull/12252

## Remaining Work

- [ ] Dev Testing: another developer will test this code on their machine (Note, test as a whole, you will need to keep the backend PR in mind). Lots to test: Test adding changes, then adding Template and make sure overwrites, then modify that, and then open the same template again, add changes, save, save and close etc. (I tested this stuff and it seems to work but testing by someone else would be great too!)