### PR TITLE
DE43776 - Inconsistent Error Tooltips for Name and Dates

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-title.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-title.js
@@ -87,7 +87,9 @@ class ContentEditorTitle extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivi
 				id="title-tooltip"
 				for="content-title"
 				position="bottom"
-				?showing="${!!this._titleError}">
+				?showing="${!!this._titleError}"
+				state="error"
+				align="start">
 				${this._titleError}
 			</d2l-tooltip>
 		`;


### PR DESCRIPTION
## Relevant Rally Links
- [DE43776](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F600734692385&fdp=true?fdp=true): FACE > Inconsistent error tooltips for Name and Dates

## Description
On FACE some face pages, the color and alignment of error tooltips is inconsistent.

## Goal/Solution
This PR changes the state and alignment of error tooltips to ensure consistency.

## Video/Screenshots
Before:
![image](https://user-images.githubusercontent.com/13461008/124982059-4b22e080-e004-11eb-86eb-e5fcf834ef48.png)

After:
![image](https://user-images.githubusercontent.com/13461008/124982269-80c7c980-e004-11eb-9a65-4b53c1d17b5b.png)

## Remaining Work
- [ ] Dev Testing: another developer will test this code on their machine
