### PR TITLE
US127570 - FACE HTML file - Support Sorting HTML Templates By Name

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -166,14 +166,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 		const templates = htmlTemplatesEntity.getHtmlFileTemplates().map(rawEntity => new FileEntity(rawEntity)) || [];
 
 		if (this.sortHTMLTemplatesByName) {
-			templates.sort((a, b) => {
-				if (a.title() < b.title()) {
-					return -1;
-				} else if (a.title() > b.title()) {
-					return 1;
-				}
-				return 0;
-			});
+			templates.sort((a, b) => a.title().localeCompare(b.title(), undefined, { sensitivity: 'base' }));
 		}
 
 		this.htmlFileTemplates = templates;


### PR DESCRIPTION
## Relevant Rally Links

- [US127570](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F602050357608&fdp=true?fdp=true): FACE HTML file - Support Sorting HTML Templates By Name



## Description
The first PR to sort templates did so in a less than ideal way (based on ASCII values for characters). This led to a sort that went:
1. Numbers
2. Uppercase letters
3. Symbols
4. Lowercase symbols
 
This PR fixes the sorting to perform the sort with the following order:
1. Symbols
2. Numbers
3. Letters 


## Video/Screenshots
Example of non-ideal sort:
![image](https://user-images.githubusercontent.com/13461008/124988158-a1dfe880-e00b-11eb-9c86-1d3eede3a781.png)

Now:
![image](https://user-images.githubusercontent.com/13461008/124988325-d94e9500-e00b-11eb-8d5f-69e577072d23.png)

## Related PRs
The following was the first PR that was merged with a non-ideal sort
- https://github.com/BrightspaceHypermediaComponents/activities/pull/1860

## Remaining Work
- [x] Dev Testing: another developer will test this code on their machine