### PR TITLE
DE44294 - FACE > HTML Template Selection dropdown cutoff in frame

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -265,7 +265,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 			@click=${this._handleClickSelectTemplateButton}
 		>
 
-		<d2l-dropdown-menu>
+		<d2l-dropdown-menu align="end">
 			<d2l-menu label="${label}">
 				<d2l-menu-item text=${this.localize('content.BrowseForHtmlTemplate')}></d2l-menu-item>
 				${this.htmlFileTemplatesLoaded ? this._renderHtmlTemplates() : this._getHtmlTemplateLoadingMenuItem()}


### PR DESCRIPTION
## Relevant Rally Links

- [DE44294](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F603490082955&fdp=true?fdp=true): FACE > HTML Template Selection dropdown cutoff in frame

## Description
When you expand the availability dates in FACE when creating an HTML file, the HTML template dropdown content will sometimes be slightly cutoff.

## Goal/Solution
By changing the alignment on the dropdown, we can eliminate cases where the dropdown menu will be slightly cutoff

## Video/Screenshots
Bad Alignment:
![image](https://user-images.githubusercontent.com/13461008/124990841-e620b800-e00e-11eb-9dad-0ca8530b0f63.png)

Good Alignment: 
![image](https://user-images.githubusercontent.com/13461008/124991017-1d8f6480-e00f-11eb-8155-2912181effb3.png)

If applicable...
- [x] Dev Testing: another developer will test this code on their machine