### PR TITLE
Content with invalid dates can still be saved if you collapse the date controls first

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-availability-editor.js
@@ -2,7 +2,6 @@ import '../d2l-activity-availability-dates-summary.js';
 import '../d2l-activity-availability-dates-editor.js';
 import '../d2l-activity-accordion-collapse.js';
 import { accordionStyles } from '../styles/accordion-styles';
-import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin';
 import { html } from 'lit-element/lit-element.js';
 import { LocalizeActivityEditorMixin } from '../mixins/d2l-activity-editor-lang-mixin.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
@@ -10,7 +9,7 @@ import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import { shared as store } from '../state/activity-store';
 
-class ContentAvailabilityEditor extends SkeletonMixin(LocalizeActivityEditorMixin((ActivityEditorMixin(RtlMixin(MobxLitElement))))) {
+class ContentAvailabilityEditor extends SkeletonMixin(LocalizeActivityEditorMixin((RtlMixin(MobxLitElement)))) {
 
 	static get properties() {
 		return {
@@ -24,10 +23,6 @@ class ContentAvailabilityEditor extends SkeletonMixin(LocalizeActivityEditorMixi
 			super.styles,
 			accordionStyles
 		];
-	}
-
-	connectedCallback() {
-		super.connectedCallback();
 	}
 
 	render() {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-availability-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-availability-editor.js
@@ -1,16 +1,18 @@
 import '../d2l-activity-availability-dates-summary.js';
 import '../d2l-activity-availability-dates-editor.js';
 import '../d2l-activity-accordion-collapse.js';
-import { css, html, LitElement } from 'lit-element/lit-element.js';
 import { accordionStyles } from '../styles/accordion-styles';
+import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin';
+import { html } from 'lit-element/lit-element.js';
 import { LocalizeActivityEditorMixin } from '../mixins/d2l-activity-editor-lang-mixin.js';
+import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
+import { shared as store } from '../state/activity-store';
 
-class ContentAvailabilityEditor extends SkeletonMixin(LocalizeActivityEditorMixin(RtlMixin(LitElement))) {
+class ContentAvailabilityEditor extends SkeletonMixin(LocalizeActivityEditorMixin((ActivityEditorMixin(RtlMixin(MobxLitElement))))) {
 
 	static get properties() {
-
 		return {
 			href: { type: String },
 			token: { type: Object }
@@ -20,22 +22,19 @@ class ContentAvailabilityEditor extends SkeletonMixin(LocalizeActivityEditorMixi
 	static get styles() {
 		return [
 			super.styles,
-			accordionStyles,
-			css`
-				.d2l-editor {
-					margin: 1rem 0;
-				}
-
-				.d2l-editor:last-child {
-					margin-bottom: 0;
-				}
-			`
+			accordionStyles
 		];
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
 	}
 
 	render() {
 		return html`
-			<d2l-activity-accordion-collapse ?skeleton="${this.skeleton}">
+			<d2l-activity-accordion-collapse
+				?has-errors=${this._errorInAccordion()}
+				?skeleton="${this.skeleton}">
 				<span slot="header">
 					${this.localize('content.availabilityHeader')}
 				</span>
@@ -47,8 +46,17 @@ class ContentAvailabilityEditor extends SkeletonMixin(LocalizeActivityEditorMixi
 		`;
 	}
 
-	_renderAvailabilityDatesEditor() {
+	_errorInAccordion() {
+		const activity = store.get(this.href);
 
+		if (!activity || !activity.dates) {
+			return false;
+		}
+
+		return !!(activity.dates.endDateErrorTerm || activity.dates.startDateErrorTerm);
+	}
+
+	_renderAvailabilityDatesEditor() {
 		return html`
 			<div class="d2l-editor">
 				<d2l-activity-availability-dates-editor
@@ -60,7 +68,6 @@ class ContentAvailabilityEditor extends SkeletonMixin(LocalizeActivityEditorMixi
 	}
 
 	_renderAvailabilityDatesSummary() {
-
 		return html`
 			<d2l-activity-availability-dates-summary
 				href="${this.href}"
@@ -69,4 +76,5 @@ class ContentAvailabilityEditor extends SkeletonMixin(LocalizeActivityEditorMixi
 		`;
 	}
 }
+
 customElements.define('d2l-activity-content-availability-editor', ContentAvailabilityEditor);


### PR DESCRIPTION
Brings the content dates editor inline with how assignments does it. That accordion component has an error property - so our content dates editor needed to add it's own error checking function and to use the MobxLitElement instead of LitElement so we can access the store.


![invaliddates](https://user-images.githubusercontent.com/14796305/125103348-e1f1aa80-e0a1-11eb-8485-e6de3ad9b929.gif)


Unfortunately there is a weird UI behavior where if the accordion is expanded with invalid dates and you attempt to save, it will close and then open. I think this is because the opened state is being controlled by that `hasError` value, which temporarily gets set to false while it is saving. This is in-line with how the Assignments Editor behaves as well so it might be best to leave it and ideally have the team that wrote the `d2l-activity-accordion-collapse` component to investigate.


![invaliddates2](https://user-images.githubusercontent.com/14796305/125103539-0fd6ef00-e0a2-11eb-84d5-2cf82b58d17c.gif)

