### PR TITLE
Improve loading skeletons in Content editors

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -1,6 +1,5 @@
 import '../shared-components/d2l-activity-content-editor-title.js';
 import './d2l-activity-content-file-loading.js';
-import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
 import { bodySmallStyles, labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import { ContentFileEntity, FILE_TYPES } from 'siren-sdk/src/activities/content/ContentFileEntity.js';
 import { css, html } from 'lit-element/lit-element.js';
@@ -21,7 +20,7 @@ import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 
-class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingMixin(LocalizeActivityEditorMixin(EntityMixinLit(RtlMixin(ActivityEditorMixin(MobxLitElement))))))) {
+class ContentFileDetail extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivityEditorMixin(EntityMixinLit(RtlMixin(ActivityEditorMixin(MobxLitElement)))))) {
 
 	static get properties() {
 		return {
@@ -107,12 +106,6 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 				${pageRenderer}
 			</div>
 		`;
-	}
-
-	updated(changedProperties) {
-		if (changedProperties.has('asyncState')) {
-			// this.skeleton = this.asyncState !== asyncStates.complete;
-		}
 	}
 
 	async cancelCreate() {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -99,7 +99,7 @@ class ContentFileDetail extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 				.href="${this.activityUsageHref}"
 				.token="${this.token}"
 				?skeleton="${this.skeleton}"
-				.expanded="true"
+				expanded="true"
 			>
 			</d2l-activity-content-editor-due-date>
 			<div id="content-page-content-container">

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -25,6 +25,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 
 	static get properties() {
 		return {
+			activityUsageHref: { type: String },
 			htmlFileTemplates: { type: Array },
 			sortHTMLTemplatesByName: { type: Boolean },
 		};
@@ -92,9 +93,16 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 			<d2l-activity-content-editor-title
 				.entity=${contentFileEntity}
 				.onSave=${this.saveTitle}
+				?skeleton="${this.skeleton}"
 			>
 			</d2l-activity-content-editor-title>
-			<slot name="due-date"></slot>
+			<d2l-activity-content-editor-due-date
+				.href="${this.activityUsageHref}"
+				.token="${this.token}"
+				?skeleton="${this.skeleton}"
+				.expanded="true"
+			>
+			</d2l-activity-content-editor-due-date>
 			<div id="content-page-content-container">
 				${pageRenderer}
 			</div>
@@ -103,7 +111,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 
 	updated(changedProperties) {
 		if (changedProperties.has('asyncState')) {
-			this.skeleton = this.asyncState !== asyncStates.complete;
+			// this.skeleton = this.asyncState !== asyncStates.complete;
 		}
 	}
 
@@ -133,7 +141,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 
 		this._saveOnChange('htmlContent');
 
-		const originalActivityUsageHref = contentFileActivity.activityUsageHref;
+		const originalActivityUsageHref = this.activityUsageHref;
 		const updatedEntity = await contentFileActivity.save();
 		const event = new CustomEvent('d2l-content-working-copy-committed', {
 			detail: {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
@@ -38,10 +38,6 @@ class ContentEditorDetail extends MobxLitElement {
 		];
 	}
 
-	constructor() {
-		super(store);
-	}
-
 	render() {
 		const contentEntity = store.getContentActivity(this.href);
 		if (!contentEntity) {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
@@ -57,8 +57,8 @@ class ContentEditorDetail extends MobxLitElement {
 				<d2l-activity-content-module-detail
 					.href="${contentActivityHref}"
 					.token="${this.token}"
+					.activityUsageHref="${this.href}"
 				>
-					${this._renderDueDate()}
 				</d2l-activity-content-module-detail>
 			`;
 		}
@@ -68,8 +68,8 @@ class ContentEditorDetail extends MobxLitElement {
 				<d2l-activity-content-web-link-detail
 					.href="${contentActivityHref}"
 					.token="${this.token}"
+					.activityUsageHref="${this.href}"
 				>
-					${this._renderDueDate(true)}
 				</d2l-activity-content-web-link-detail>
 			`;
 		}
@@ -79,8 +79,8 @@ class ContentEditorDetail extends MobxLitElement {
 				<d2l-activity-content-lti-link-detail
 					.href="${contentActivityHref}"
 					.token="${this.token}"
+					.activityUsageHref="${this.href}"
 				>
-					${this._renderDueDate(true)}
 				</d2l-activity-content-lti-link-detail>
 			`;
 		}
@@ -91,26 +91,13 @@ class ContentEditorDetail extends MobxLitElement {
 					.href="${contentActivityHref}"
 					.token="${this.token}"
 					?sortHTMLTemplatesByName="${this.sortHTMLTemplatesByName}"
+					.activityUsageHref="${this.href}"
 				>
-					${this._renderDueDate(true)}
 				</d2l-activity-content-file-detail>
 			`;
 		}
 
 		return html``;
-	}
-
-	_renderDueDate(expanded) {
-		return html`
-			<div slot="due-date">
-				<d2l-activity-content-editor-due-date
-					.href="${this.href}"
-					.token="${this.token}"
-					.expanded="${expanded}"
-				>
-				</d2l-activity-content-editor-due-date>
-			</div>
-		`;
 	}
 }
 customElements.define('d2l-activity-content-editor-detail', ContentEditorDetail);

--- a/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/d2l-activity-content-editor-detail.js
@@ -13,7 +13,7 @@ class ContentEditorDetail extends MobxLitElement {
 
 	static get properties() {
 		return {
-			sortHTMLTemplatesByName: { type: Boolean },
+			sortHTMLTemplatesByName: { type: Boolean }
 		};
 	}
 
@@ -36,6 +36,10 @@ class ContentEditorDetail extends MobxLitElement {
 				}
 			`
 		];
+	}
+
+	constructor() {
+		super(store);
 	}
 
 	render() {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-detail.js
@@ -17,6 +17,12 @@ import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton
 
 class ContentLTILinkDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingMixin(LocalizeActivityEditorMixin(EntityMixinLit(RtlMixin(ActivityEditorMixin(MobxLitElement))))))) {
 
+	static get properties() {
+		return {
+			activityUsageHref: { type: String },
+		};
+	}
+
 	static get styles() {
 		return  [
 			super.styles,
@@ -47,30 +53,42 @@ class ContentLTILinkDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandli
 
 	render() {
 		const ltiLinkEntity = ltiLinkStore.getContentLTILinkActivity(this.href);
-		const canEmbedIframePromise = this._canEmbedIframe();
+		let canEmbed = false;
 
 		if (ltiLinkEntity) {
-			this.skeleton = false;
+			this._canEmbedIframe().then(canEmbedIframe => {
+				canEmbed = canEmbedIframe;
+				this.skeleton = false;
+			});
 		}
 
 		return html`
 			<d2l-activity-content-editor-title
 				.entity=${ltiLinkEntity}
 				.onSave=${this.saveTitle}
+				?skeleton="${this.skeleton}"
 			>
 			</d2l-activity-content-editor-title>
-			<slot name="due-date"></slot>
+			<d2l-activity-content-editor-due-date
+				.href="${this.activityUsageHref}"
+				.token="${this.token}"
+				?skeleton="${this.skeleton}"
+				.expanded="true"
+			>
+			</d2l-activity-content-editor-due-date>
 
 			<d2l-activity-content-lti-link-options
 				.entity=${ltiLinkEntity}
 				.onSave=${this.saveLinkOptions}
-				.canEmbedIframePromise=${canEmbedIframePromise}
+				?skeleton="${this.skeleton}"
+				?showLinkOptions="${canEmbed}"
 			>
 			</d2l-activity-content-lti-link-options>
 
 			<d2l-activity-content-lti-link-external-activity
 				.entity=${ltiLinkEntity}
-				.canEmbedIframePromise=${canEmbedIframePromise}
+				?skeleton="${this.skeleton}"
+				?showExternalActivity="${canEmbed}"
 			>
 			</d2l-activity-content-lti-link-external-activity>
 		`;
@@ -78,7 +96,7 @@ class ContentLTILinkDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandli
 
 	updated(changedProperties) {
 		if (changedProperties.has('asyncState')) {
-			this.skeleton = this.asyncState !== asyncStates.complete;
+			// this.skeleton = this.asyncState !== asyncStates.complete;
 		}
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-detail.js
@@ -42,6 +42,7 @@ class ContentLTILinkDetail extends SkeletonMixin(ErrorHandlingMixin(LocalizeActi
 		this._setEntityType(ContentLTILinkEntity);
 		this.skeleton = true;
 		this.saveOrder = 2000;
+		this.canEmbed = false;
 	}
 
 	connectedCallback() {
@@ -52,11 +53,10 @@ class ContentLTILinkDetail extends SkeletonMixin(ErrorHandlingMixin(LocalizeActi
 
 	render() {
 		const ltiLinkEntity = ltiLinkStore.getContentLTILinkActivity(this.href);
-		let canEmbed = false;
 
 		if (ltiLinkEntity) {
 			this._canEmbedIframe().then(canEmbedIframe => {
-				canEmbed = canEmbedIframe;
+				this.canEmbed = canEmbedIframe;
 				this.skeleton = false;
 			});
 		}
@@ -80,14 +80,14 @@ class ContentLTILinkDetail extends SkeletonMixin(ErrorHandlingMixin(LocalizeActi
 				.entity=${ltiLinkEntity}
 				.onSave=${this.saveLinkOptions}
 				?skeleton="${this.skeleton}"
-				?showLinkOptions="${canEmbed}"
+				?showLinkOptions="${this.canEmbed}"
 			>
 			</d2l-activity-content-lti-link-options>
 
 			<d2l-activity-content-lti-link-external-activity
 				.entity=${ltiLinkEntity}
 				?skeleton="${this.skeleton}"
-				?showActivityPreview="${canEmbed}"
+				?showActivityPreview="${this.canEmbed}"
 			>
 			</d2l-activity-content-lti-link-external-activity>
 		`;

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-detail.js
@@ -72,7 +72,7 @@ class ContentLTILinkDetail extends SkeletonMixin(ErrorHandlingMixin(LocalizeActi
 				.href="${this.activityUsageHref}"
 				.token="${this.token}"
 				?skeleton="${this.skeleton}"
-				.expanded="true"
+				expanded="true"
 			>
 			</d2l-activity-content-editor-due-date>
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-detail.js
@@ -1,7 +1,6 @@
 import '../shared-components/d2l-activity-content-editor-title.js';
 import './d2l-activity-content-lti-link-options.js';
 import './d2l-activity-content-lti-link-external-activity.js';
-import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { activityContentEditorStyles } from '../shared-components/d2l-activity-content-editor-styles.js';
 import { ActivityEditorMixin } from '../../mixins/d2l-activity-editor-mixin.js';
@@ -15,7 +14,7 @@ import { MobxLitElement } from '@adobe/lit-mobx';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
-class ContentLTILinkDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingMixin(LocalizeActivityEditorMixin(EntityMixinLit(RtlMixin(ActivityEditorMixin(MobxLitElement))))))) {
+class ContentLTILinkDetail extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivityEditorMixin(EntityMixinLit(RtlMixin(ActivityEditorMixin(MobxLitElement)))))) {
 
 	static get properties() {
 		return {
@@ -88,16 +87,10 @@ class ContentLTILinkDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandli
 			<d2l-activity-content-lti-link-external-activity
 				.entity=${ltiLinkEntity}
 				?skeleton="${this.skeleton}"
-				?showExternalActivity="${canEmbed}"
+				?showActivityPreview="${canEmbed}"
 			>
 			</d2l-activity-content-lti-link-external-activity>
 		`;
-	}
-
-	updated(changedProperties) {
-		if (changedProperties.has('asyncState')) {
-			// this.skeleton = this.asyncState !== asyncStates.complete;
-		}
 	}
 
 	async cancelCreate() {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-detail.js
@@ -42,7 +42,7 @@ class ContentLTILinkDetail extends SkeletonMixin(ErrorHandlingMixin(LocalizeActi
 		this._setEntityType(ContentLTILinkEntity);
 		this.skeleton = true;
 		this.saveOrder = 2000;
-		this.canEmbed = false;
+		this.canEmbed = true;
 	}
 
 	connectedCallback() {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-external-activity.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-external-activity.js
@@ -14,6 +14,7 @@ class ActivityContentLTILinkExternalActivity extends SkeletonMixin(LocalizeActiv
 	static get properties() {
 		return {
 			entity: { type: Object },
+			skeleton: { type: Boolean },
 			showInNewTab: { type: Boolean },
 			showActivityPreview: { type: Boolean }
 		};
@@ -48,20 +49,11 @@ class ActivityContentLTILinkExternalActivity extends SkeletonMixin(LocalizeActiv
 
 	constructor() {
 		super();
-		this.skeleton = true;
 		this.showInNewTab = false;
 		this.activityWindowPopout = null;
-		// this.showActivityPreview = false;
 	}
 
 	render() {
-		// if (this.entity) {
-		// 	this.canEmbedIframePromise.then(canEmbedIframe => {
-		// 		this.showActivityPreview = canEmbedIframe;
-		// 		this.skeleton = false;
-		// 	});
-		// }
-
 		return html`
 			<div class="d2l-external-activity-outer-frame d2l-skeletize-container">
 				<div class="d2l-content-link-external-activity">

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-external-activity.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-external-activity.js
@@ -15,7 +15,6 @@ class ActivityContentLTILinkExternalActivity extends SkeletonMixin(LocalizeActiv
 		return {
 			entity: { type: Object },
 			showInNewTab: { type: Boolean },
-			canEmbedIframePromise: { type: Object },
 			showActivityPreview: { type: Boolean }
 		};
 	}
@@ -52,16 +51,16 @@ class ActivityContentLTILinkExternalActivity extends SkeletonMixin(LocalizeActiv
 		this.skeleton = true;
 		this.showInNewTab = false;
 		this.activityWindowPopout = null;
-		this.showActivityPreview = false;
+		// this.showActivityPreview = false;
 	}
 
 	render() {
-		if (this.entity) {
-			this.canEmbedIframePromise.then(canEmbedIframe => {
-				this.showActivityPreview = canEmbedIframe;
-				this.skeleton = false;
-			});
-		}
+		// if (this.entity) {
+		// 	this.canEmbedIframePromise.then(canEmbedIframe => {
+		// 		this.showActivityPreview = canEmbedIframe;
+		// 		this.skeleton = false;
+		// 	});
+		// }
 
 		return html`
 			<div class="d2l-external-activity-outer-frame d2l-skeletize-container">

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-options.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-options.js
@@ -55,6 +55,7 @@ class ContentEditorLtiLinkOptions extends SkeletonMixin(ErrorHandlingMixin(Local
 		super();
 		this._debounceJobs = {};
 		this.saveOrder = 2000;
+		this.showLinkOptions = true;
 	}
 
 	render() {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-options.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-options.js
@@ -17,9 +17,9 @@ class ContentEditorLtiLinkOptions extends SkeletonMixin(ErrorHandlingMixin(Local
 	static get properties() {
 		return {
 			entity: { type: Object },
+			skeleton: { type: Boolean },
 			onSave: { type: Function },
-			showLinkOptions: { type: Boolean },
-			skeleton: { type: Boolean }
+			showLinkOptions: { type: Boolean }
 		};
 	}
 
@@ -55,7 +55,6 @@ class ContentEditorLtiLinkOptions extends SkeletonMixin(ErrorHandlingMixin(Local
 		super();
 		this._debounceJobs = {};
 		this.saveOrder = 2000;
-		// this.showLinkOptions = true;
 	}
 
 	render() {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-options.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/lti-link/d2l-activity-content-lti-link-options.js
@@ -18,8 +18,8 @@ class ContentEditorLtiLinkOptions extends SkeletonMixin(ErrorHandlingMixin(Local
 		return {
 			entity: { type: Object },
 			onSave: { type: Function },
-			canEmbedIframePromise: { type: Object },
-			showLinkOptions: { type: Boolean }
+			showLinkOptions: { type: Boolean },
+			skeleton: { type: Boolean }
 		};
 	}
 
@@ -54,9 +54,8 @@ class ContentEditorLtiLinkOptions extends SkeletonMixin(ErrorHandlingMixin(Local
 	constructor() {
 		super();
 		this._debounceJobs = {};
-		this.skeleton = true;
 		this.saveOrder = 2000;
-		this.showLinkOptions = true;
+		// this.showLinkOptions = true;
 	}
 
 	render() {
@@ -64,11 +63,6 @@ class ContentEditorLtiLinkOptions extends SkeletonMixin(ErrorHandlingMixin(Local
 
 		if (this.entity) {
 			isExternalResource = this.entity.isExternalResource;
-
-			this.canEmbedIframePromise.then(canEmbedIframe => {
-				this.showLinkOptions = canEmbedIframe;
-				this.skeleton = false;
-			});
 
 			if (!this.showLinkOptions) {
 				isExternalResource = true;

--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -1,3 +1,4 @@
+import '../shared-components/d2l-activity-content-editor-due-date.js';
 import '../shared-components/d2l-activity-content-editor-title.js';
 import '../../d2l-activity-text-editor.js';
 import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
@@ -19,6 +20,12 @@ import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 
 class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingMixin(LocalizeActivityEditorMixin(EntityMixinLit(RtlMixin(ActivityEditorMixin(MobxLitElement))))))) {
+
+	static get properties() {
+		return {
+			activityUsageHref: { type: String }
+		};
+	}
 
 	static get styles() {
 		return  [
@@ -69,8 +76,14 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 			<d2l-activity-content-editor-title
 				.entity=${moduleEntity}
 				.onSave=${this.saveTitle}
+				?skeleton="${this.skeleton}"
 			></d2l-activity-content-editor-title>
-			<slot name="due-date"></slot>
+			<d2l-activity-content-editor-due-date
+				.href="${this.activityUsageHref}"
+				.token="${this.token}"
+				?skeleton="${this.skeleton}"
+			>
+			</d2l-activity-content-editor-due-date>
 			<div id="content-description-container">
 				<div class="d2l-activity-label-container d2l-label-text d2l-skeletize">
 					${this.localize('content.description')}
@@ -92,7 +105,7 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 
 	updated(changedProperties) {
 		if (changedProperties.has('asyncState')) {
-			this.skeleton = this.asyncState !== asyncStates.complete;
+			// this.skeleton = this.asyncState !== asyncStates.complete;
 		}
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/module/d2l-activity-content-module-detail.js
@@ -1,7 +1,6 @@
 import '../shared-components/d2l-activity-content-editor-due-date.js';
 import '../shared-components/d2l-activity-content-editor-title.js';
 import '../../d2l-activity-text-editor.js';
-import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
 import { activityContentEditorStyles } from '../shared-components/d2l-activity-content-editor-styles.js';
 import { ActivityEditorMixin } from '../../mixins/d2l-activity-editor-mixin.js';
 import { activityHtmlEditorStyles } from '../shared-components/d2l-activity-html-editor-styles.js';
@@ -19,7 +18,7 @@ import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import { timeOut } from '@polymer/polymer/lib/utils/async.js';
 
-class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingMixin(LocalizeActivityEditorMixin(EntityMixinLit(RtlMixin(ActivityEditorMixin(MobxLitElement))))))) {
+class ContentModuleDetail extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivityEditorMixin(EntityMixinLit(RtlMixin(ActivityEditorMixin(MobxLitElement)))))) {
 
 	static get properties() {
 		return {
@@ -101,12 +100,6 @@ class ContentModuleDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlin
 				</div>
 			</div>
 		`;
-	}
-
-	updated(changedProperties) {
-		if (changedProperties.has('asyncState')) {
-			// this.skeleton = this.asyncState !== asyncStates.complete;
-		}
 	}
 
 	async cancelCreate() {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-due-date.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-due-date.js
@@ -11,7 +11,8 @@ class ContentEditorDueDate extends SkeletonMixin(LocalizeActivityEditorMixin(Rtl
 	static get properties() {
 		return {
 			expanded: { type: Boolean },
-			_hasDatePermissions: { type: Boolean }
+			_hasDatePermissions: { type: Boolean },
+			skeleton: { type: Boolean }
 		};
 	}
 
@@ -71,8 +72,6 @@ class ContentEditorDueDate extends SkeletonMixin(LocalizeActivityEditorMixin(Rtl
 
 	_getDueDateAndPermission() {
 		const entity = activityStore.get(this.href);
-
-		console.log({entity});
 
 		if (!entity || !entity.dates) {
 			return;

--- a/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-due-date.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-due-date.js
@@ -11,8 +11,8 @@ class ContentEditorDueDate extends SkeletonMixin(LocalizeActivityEditorMixin(Rtl
 	static get properties() {
 		return {
 			expanded: { type: Boolean },
-			_hasDatePermissions: { type: Boolean },
-			skeleton: { type: Boolean }
+			skeleton: { type: Boolean },
+			_hasDatePermissions: { type: Boolean }
 		};
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-due-date.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-due-date.js
@@ -35,7 +35,6 @@ class ContentEditorDueDate extends SkeletonMixin(LocalizeActivityEditorMixin(Rtl
 	constructor() {
 		super();
 		this._hasDatePermissions = false;
-		this.skeleton = true;
 	}
 
 	render() {
@@ -73,9 +72,7 @@ class ContentEditorDueDate extends SkeletonMixin(LocalizeActivityEditorMixin(Rtl
 	_getDueDateAndPermission() {
 		const entity = activityStore.get(this.href);
 
-		if (entity) {
-			this.skeleton = false;
-		}
+		console.log({entity});
 
 		if (!entity || !entity.dates) {
 			return;

--- a/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-title.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-title.js
@@ -18,7 +18,8 @@ class ContentEditorTitle extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivi
 		return {
 			entity: { type: Object },
 			onSave: { type: Function },
-			_titleError: { type: String }
+			_titleError: { type: String },
+			skeleton: { type: Boolean }
 		};
 	}
 
@@ -46,13 +47,11 @@ class ContentEditorTitle extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivi
 	constructor() {
 		super();
 		this._debounceJobs = {};
-		this.skeleton = true;
 	}
 
 	render() {
 		let title = '';
 		if (this.entity) {
-			this.skeleton = false;
 			title = this.entity.title;
 		}
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-title.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/shared-components/d2l-activity-content-editor-title.js
@@ -17,9 +17,9 @@ class ContentEditorTitle extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivi
 	static get properties() {
 		return {
 			entity: { type: Object },
+			skeleton: { type: Boolean },
 			onSave: { type: Function },
-			_titleError: { type: String },
-			skeleton: { type: Boolean }
+			_titleError: { type: String }
 		};
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-editor-link.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-editor-link.js
@@ -21,7 +21,8 @@ class ContentEditorLink extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 		return {
 			entity: { type: Object },
 			onSave: { type: Function },
-			_linkError: { type: String }
+			_linkError: { type: String },
+			skeleton: { type: Boolean }
 		};
 	}
 
@@ -60,7 +61,6 @@ class ContentEditorLink extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 	constructor() {
 		super();
 		this._debounceJobs = {};
-		this.skeleton = true;
 		this.saveOrder = 2000;
 	}
 
@@ -69,7 +69,6 @@ class ContentEditorLink extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 		let isExternalResource = false;
 
 		if (this.entity) {
-			this.skeleton = false;
 			link = this.entity.link;
 			isExternalResource = this.entity.isExternalResource;
 		}

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-detail.js
@@ -2,7 +2,6 @@ import '../shared-components/d2l-activity-content-editor-due-date.js';
 import '../shared-components/d2l-activity-content-editor-title.js';
 import './d2l-activity-content-web-link-url-preview.js';
 import './d2l-activity-content-editor-link.js';
-import { AsyncContainerMixin, asyncStates } from '@brightspace-ui/core/mixins/async-container/async-container-mixin.js';
 import { activityContentEditorStyles } from '../shared-components/d2l-activity-content-editor-styles.js';
 import { ActivityEditorMixin } from '../../mixins/d2l-activity-editor-mixin.js';
 import { ContentWebLinkEntity } from 'siren-sdk/src/activities/content/ContentWebLinkEntity.js';
@@ -16,7 +15,7 @@ import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import { shared as webLinkStore } from './state/content-web-link-store.js';
 
-class ContentWebLinkDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingMixin(LocalizeActivityEditorMixin(EntityMixinLit(RtlMixin(ActivityEditorMixin(MobxLitElement))))))) {
+class ContentWebLinkDetail extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivityEditorMixin(EntityMixinLit(RtlMixin(ActivityEditorMixin(MobxLitElement)))))) {
 
 	static get properties() {
 		return {
@@ -79,12 +78,6 @@ class ContentWebLinkDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandli
 			>
 			</d2l-activity-content-web-link-url-preview>
 		`;
-	}
-
-	updated(changedProperties) {
-		if (changedProperties.has('asyncState')) {
-			// this.skeleton = this.asyncState !== asyncStates.complete;
-		}
 	}
 
 	async cancelCreate() {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-detail.js
@@ -62,7 +62,7 @@ class ContentWebLinkDetail extends SkeletonMixin(ErrorHandlingMixin(LocalizeActi
 				.href="${this.activityUsageHref}"
 				.token="${this.token}"
 				?skeleton="${this.skeleton}"
-				.expanded="true"
+				expanded="true"
 			>
 			</d2l-activity-content-editor-due-date>
 			<d2l-activity-content-editor-link

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-detail.js
@@ -1,3 +1,4 @@
+import '../shared-components/d2l-activity-content-editor-due-date.js';
 import '../shared-components/d2l-activity-content-editor-title.js';
 import './d2l-activity-content-web-link-url-preview.js';
 import './d2l-activity-content-editor-link.js';
@@ -16,6 +17,12 @@ import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton
 import { shared as webLinkStore } from './state/content-web-link-store.js';
 
 class ContentWebLinkDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingMixin(LocalizeActivityEditorMixin(EntityMixinLit(RtlMixin(ActivityEditorMixin(MobxLitElement))))))) {
+
+	static get properties() {
+		return {
+			activityUsageHref: { type: String }
+		};
+	}
 
 	static get styles() {
 		return  [
@@ -49,18 +56,26 @@ class ContentWebLinkDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandli
 			<d2l-activity-content-editor-title
 				.entity=${webLinkEntity}
 				.onSave=${this.saveTitle}
+				?skeleton="${this.skeleton}"
 			>
 			</d2l-activity-content-editor-title>
-			<slot name="due-date"></slot>
-
+			<d2l-activity-content-editor-due-date
+				.href="${this.activityUsageHref}"
+				.token="${this.token}"
+				?skeleton="${this.skeleton}"
+				.expanded="true"
+			>
+			</d2l-activity-content-editor-due-date>
 			<d2l-activity-content-editor-link
 				.entity=${webLinkEntity}
 				.onSave=${this.saveLink}
+				?skeleton="${this.skeleton}"
 			>
 			</d2l-activity-content-editor-link>
 
 			<d2l-activity-content-web-link-url-preview
 				.entity=${webLinkEntity}
+				?skeleton="${this.skeleton}"
 			>
 			</d2l-activity-content-web-link-url-preview>
 		`;
@@ -68,7 +83,7 @@ class ContentWebLinkDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandli
 
 	updated(changedProperties) {
 		if (changedProperties.has('asyncState')) {
-			this.skeleton = this.asyncState !== asyncStates.complete;
+			// this.skeleton = this.asyncState !== asyncStates.complete;
 		}
 	}
 
@@ -95,7 +110,7 @@ class ContentWebLinkDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandli
 			return;
 		}
 
-		const originalActivityUsageHref = webLinkEntity.activityUsageHref;
+		const originalActivityUsageHref = this.activityUsageHref;
 		const updatedEntity = await webLinkEntity.save();
 		const event = new CustomEvent('d2l-content-working-copy-committed', {
 			detail: {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-url-preview.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-url-preview.js
@@ -10,7 +10,8 @@ class ContentWebLinkUrlPreview extends SkeletonMixin(LocalizeActivityEditorMixin
 
 	static get properties() {
 		return {
-			entity: { type: Object }
+			entity: { type: Object },
+			skeleton: { type: Boolean }
 		};
 	}
 
@@ -32,18 +33,12 @@ class ContentWebLinkUrlPreview extends SkeletonMixin(LocalizeActivityEditorMixin
 		];
 	}
 
-	constructor() {
-		super();
-		this.skeleton = true;
-	}
-
 	render() {
 		const attachment = {};
 		if (!this.entity || !this.entity.link) {
 			return html``;
 		}
 
-		this.skeleton = false;
 		attachment.id = this.entity.href;
 		attachment.name = this.entity.title;
 		attachment.url = this.entity.link;


### PR DESCRIPTION
This pr sets out to improve the UX for the skeletons in the Content editors. 

It was noticed that the due date element was loading in way faster than everything else. This was because each component was handling it's own `skeleton` state by checking against their entity, and the due date was using the activity usage entity which is higher up the chain than everything else. 

As many of these components use the same entity, it made sense to let the `detail` part of the editor be in charge of the skeleton state and pass that down to each of the components. As `detail` is the one fetching the entity, the time for each sub-component refetching the same entity is negligible as it won't actually make another network request. The result of this is that each component will stop visual loading at the same time, with the exception of some other components like the LTI preview which was already happening anyways.



### BEFORE:

![skeletonz1](https://user-images.githubusercontent.com/14796305/125318194-42315800-e2ff-11eb-9ebe-733da9387d2b.gif)

### AFTER - MODULES:

![skeletonzmod](https://user-images.githubusercontent.com/14796305/125318673-ace29380-e2ff-11eb-8b75-35407f0b9e6f.gif)

### AFTER - WEBLINKS:

![skeletonzlink](https://user-images.githubusercontent.com/14796305/125318789-cbe12580-e2ff-11eb-993f-96db9a2b708e.gif)

### AFTER - LTI LINKS:

![skeletonzlti](https://user-images.githubusercontent.com/14796305/125318566-91778880-e2ff-11eb-8d1a-0e08b68d2084.gif)

### AFTER - FILES:

![skeletonzfile](https://user-images.githubusercontent.com/14796305/125318957-f337f280-e2ff-11eb-8fdf-5e548ddda52d.gif)
