### PR TITLE
DE43776: Inconsistent Error Tooltips for Weblink Name

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-editor-link.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-editor-link.js
@@ -151,6 +151,8 @@ class ContentEditorLink extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 				for="content-link"
 				position="bottom"
 				tabIndex="0"
+				state="error"
+				align="start"
 				?showing="${!!this._linkError}"
 			>
 				${this._linkError}


### PR DESCRIPTION
## Relevant Rally Links
- [DE43776](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F600734692385&fdp=true?fdp=true): FACE > Inconsistent error tooltips for Name and Dates


## Description
This is another instance of the fix from the following PR

https://github.com/BrightspaceHypermediaComponents/activities/pull/1871