### PR TITLE
Change weblink working copy methods

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-detail.js
@@ -41,7 +41,7 @@ class ContentWebLinkDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandli
 
 	render() {
 		const webLinkEntity = webLinkStore.getContentWebLinkActivity(this.href);
-		
+
 		if (webLinkEntity) {
 			this.skeleton = false;
 		}

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/d2l-activity-content-web-link-detail.js
@@ -41,6 +41,7 @@ class ContentWebLinkDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandli
 
 	render() {
 		const webLinkEntity = webLinkStore.getContentWebLinkActivity(this.href);
+		
 		if (webLinkEntity) {
 			this.skeleton = false;
 		}

--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/state/content-web-link.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/state/content-web-link.js
@@ -77,7 +77,7 @@ export class ContentWebLink {
 			return;
 		}
 
-		const sirenEntity = await webLinkEntity.checkoutWebLink();
+		const sirenEntity = await webLinkEntity.checkout();
 		if (!sirenEntity) {
 			return webLinkEntity;
 		}
@@ -90,7 +90,7 @@ export class ContentWebLink {
 			return;
 		}
 
-		const sirenEntity = await webLinkEntity.commitWebLink();
+		const sirenEntity = await webLinkEntity.commit();
 		if (!sirenEntity) {
 			return webLinkEntity;
 		}

--- a/test/d2l-activity-editor/d2l-activity-content-editor/state/content-web-link.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-content-editor/state/content-web-link.spec.js
@@ -31,7 +31,7 @@ describe('Content Web Link', function() {
 				isExternalResource: () => false,
 				self: () => 'http://test-web-link-href.com',
 				getActivityUsageHref: () => 'http://test-activity-usage-link-href.com',
-				checkoutWebLink: checkoutWebLinkMock
+				checkout: checkoutWebLinkMock
 			};
 		});
 


### PR DESCRIPTION
## Description

Update naming for working copy stuff for weblinks, since they were updated [in this PR](https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/360).

## Goal/Solution

Some code cleanup.

## Related PRs

https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/360

## Note

We will need to merge the related PR first for the tests to pass.
