### PR TITLE
DE44349: HTML Template Dropdown - Loading styled as a menu item

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -157,7 +157,7 @@ class ContentFileDetail extends AsyncContainerMixin(SkeletonMixin(ErrorHandlingM
 	}
 
 	_getHtmlTemplateLoadingMenuItem() {
-		return html`<d2l-menu-item text=${this.localize('content.htmlTemplatesLoading')} disabled="true"></d2l-menu-item>`;
+		return html`<p class="d2l-menu-item-span d2l-body-small">${this.localize('content.htmlTemplatesLoading')}</p>`;
 	}
 
 	async _getHtmlTemplates() {


### PR DESCRIPTION
## Relevant Rally Links

- [DE44349](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F603801138963&fdp=true?fdp=true): FACE > HTML Template Dropdown - Loading styled as a menu item

## Description
Loading in dropdown should not be styled as a menu item. The styling has been changed to match the "No content available" item.

## Video/Screenshots
Previous:
![image](https://user-images.githubusercontent.com/13461008/125512631-321dd29d-6564-461b-9495-3ded1c1105dc.png)

New:
![image](https://user-images.githubusercontent.com/13461008/125512586-400a610f-89db-4449-a909-c4233e2d89ba.png)
