### PR TITLE
Update weblink working copy methods

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/web-link/state/content-web-link.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/web-link/state/content-web-link.js
@@ -77,7 +77,7 @@ export class ContentWebLink {
 			return;
 		}
 
-		const sirenEntity = await webLinkEntity.checkoutWebLink();
+		const sirenEntity = await webLinkEntity.checkout();
 		if (!sirenEntity) {
 			return webLinkEntity;
 		}
@@ -90,7 +90,7 @@ export class ContentWebLink {
 			return;
 		}
 
-		const sirenEntity = await webLinkEntity.commitWebLink();
+		const sirenEntity = await webLinkEntity.commit();
 		if (!sirenEntity) {
 			return webLinkEntity;
 		}


### PR DESCRIPTION
## Description

Update naming for working copy stuff for weblinks, since they were updated [in this PR](https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/360).

## Goal/Solution

Some code cleanup.

## Related PRs

https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/360

## Note

We will need to merge the related PR first for the tests to pass.
