### PR TITLE
US129212: Add a browse button to the Template Selection Dropdown

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -71,7 +71,7 @@ class ContentFileDetail extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 		this.editorKey = editorKeyInitial;
 
 		const context = JSON.parse(document.documentElement.getAttribute('data-he-context'));
-		this.orgUnitId = context.orgUnitId;
+		this.orgUnitId = context ? context.orgUnitId : '';
 	}
 
 	connectedCallback() {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/content-file/d2l-activity-content-file-detail.js
@@ -69,7 +69,9 @@ class ContentFileDetail extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 		this.htmlFileTemplatesLoaded = false;
 		this.pageContent = null;
 		this.editorKey = editorKeyInitial;
-		this._context = JSON.parse(document.documentElement.getAttribute('data-he-context'));
+
+		const context = JSON.parse(document.documentElement.getAttribute('data-he-context'));
+		this.orgUnitId = context.orgUnitId;
 	}
 
 	connectedCallback() {
@@ -183,9 +185,7 @@ class ContentFileDetail extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 	}
 
 	async _handleBrowseHtmlTemplates() {
-		const { orgUnitId } = this._context;
-
-		const location = `/d2l/le/lessons/${orgUnitId}/OpenTemplateDialog`;
+		const location = `/d2l/le/lessons/${this.orgUnitId}/OpenTemplateDialog`;
 
 		const dialogResult = await D2L.LP.Web.UI.Desktop.MasterPages.Dialog.Open(
 			getComposedActiveElement(),
@@ -201,23 +201,18 @@ class ContentFileDetail extends SkeletonMixin(ErrorHandlingMixin(LocalizeActivit
 	}
 
 	async _handleBrowseHtmlTemplatesDialogClosed([file]) {
-		const { orgUnitId } = this._context;
-
 		const valenceHost = `${window.location.protocol}//${window.location.host}`;
 
 		const encodedFileUrl = encodeURIComponent(file.m_id);
 
-		const fileContentUrl = `${valenceHost}/d2l/api/le/unstable/file/GetFileContents?ou=${orgUnitId}&filters=ConvertToAbsolutePaths&fileId=${encodedFileUrl}`;
+		const fileContentUrl = `${valenceHost}/d2l/api/le/unstable/file/GetFileContents?ou=${this.orgUnitId}&filters=ConvertToAbsolutePaths&fileId=${encodedFileUrl}`;
 
-		const response = await window.d2lfetch.fetch(new Request(fileContentUrl, {
-			method: 'GET',
-			headers: { Accept: 'application/json' },
-		}));
+		const response = await window.d2lfetch.fetch(new Request(fileContentUrl));
 
 		if (response.ok) {
 			const content = await response.text();
-
 			this._savePageContent(content);
+			this.editorKey = `${editorKeyInitial}-${Date.now().toString()}`; // key needs to be modified in order to re-render old HTML editor
 		}
 	}
 

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -147,7 +147,7 @@ export default {
 	"content.htmlTemplatesLoading": "Loading...", // Message displayed while list of html templates is loading
 	"content.noHtmlTemplates": "No templates available", // Message displayed in dropdown when no html templates are found
 	"content.defaultHtmlTemplateHeader": "HTML File Templates", // The text to display as the default header for the html template select dropdown
-	"content.BrowseForHtmlTemplate": "Browse for a Template", // Text for button to browse for an html template
+	"content.browseForHtmlTemplate": "Browse for a Template", // Text for button to browse for an html template
 	"content.availabilityHeader": "Availability Dates", // availability header
 	"content.saveError": "Your content item wasn't saved. Please correct the fields outlined in red.", // Error message to inform the user that there was a problem saving the content item, instructing them to correct invalid fields
 	"content.displayOptions": "Display Options", // Text label for display options


### PR DESCRIPTION
## Relevant Rally Links
- [US129212](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F601858951433&fdp=true?fdp=true): FACE HTML - Add a browse button to the Template Selection Dropdown
 

## Description
Based on the Telemetry data, we will need a Browse option as well as the list of template HTML files. This PR adds functionality to browse for HTML templates in a dialog.

## Video/Screenshots
![demo](https://user-images.githubusercontent.com/13461008/125653730-f469ca2f-858d-47c4-b94d-808fc4405161.gif)

## Remaining Work
- [x] Dev Testing: another developer will test this code on their machine