### PR TITLE
US127819 - Text replacement confirmation dialog

### DIFF
--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -165,5 +165,9 @@ export default {
 	"content.openInNewWindow": "Open in New Window", // The label text for the subtle-button for opening a LTI link in a new window
 	"content.externalActivity": "External Activity", // The label text for the external activity section on the LTI link page
 	"content.externalActivityOpened": "Open the activity in new window to view its content.", // Text for displaying underneath the LTI link jump logo
-	"content.externalActivityEmbeddedNotAllowed": "This external activity does not support embedding. It can only be viewed by opening in a new window." // Text that replaces the LTI display options if embedding is not allowed
+	"content.externalActivityEmbeddedNotAllowed": "This external activity does not support embedding. It can only be viewed by opening in a new window.", // Text that replaces the LTI display options if embedding is not allowed
+	"content.confirmDialogTitle": "Your existing content will be deleted", // The text for the title of the replace html template confirmation dialog
+	"content.confirmDialogBody": "Are you sure you want to replace your existing content with this template?", // The text for the body of the replace html template confirmation dialog
+	"content.confirmDialogActionOption": "Replace", // The text for the confirmation action to replace content
+	"content.confirmDialogCancelOption": "Cancel" // The text for the cancel action to not replace content
 };

--- a/components/d2l-activity-editor/lang/en.js
+++ b/components/d2l-activity-editor/lang/en.js
@@ -166,7 +166,7 @@ export default {
 	"content.externalActivity": "External Activity", // The label text for the external activity section on the LTI link page
 	"content.externalActivityOpened": "Open the activity in new window to view its content.", // Text for displaying underneath the LTI link jump logo
 	"content.externalActivityEmbeddedNotAllowed": "This external activity does not support embedding. It can only be viewed by opening in a new window.", // Text that replaces the LTI display options if embedding is not allowed
-	"content.confirmDialogTitle": "Your existing content will be deleted", // The text for the title of the replace html template confirmation dialog
+	"content.confirmDialogTitle": "Your existing content will be deleted.", // The text for the title of the replace html template confirmation dialog
 	"content.confirmDialogBody": "Are you sure you want to replace your existing content with this template?", // The text for the body of the replace html template confirmation dialog
 	"content.confirmDialogActionOption": "Replace", // The text for the confirmation action to replace content
 	"content.confirmDialogCancelOption": "Cancel" // The text for the cancel action to not replace content


### PR DESCRIPTION
## Relevant Rally Links
- [US127819](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F602981033764&fdp=true?fdp=true): FACE HTML file - Support Template Selection - Text replacement confirmation dialog

## Description
When a user selects an HTML template (from dropdown or from browse) they should see a warning dialog about replacing content if the editor currently has any content. This PR creates said dialog to warn the user when they are going to replace content.


## Video/Screenshots
![demo](https://user-images.githubusercontent.com/13461008/125669680-79d8ccbc-6741-407f-bfae-991629a2c61e.gif)


## Remaining Work
- [ ] Dev Testing: another developer will test this code on their machine
