### PR TITLE
US129748 Updated runner to ubuntu latest

### DIFF
--- a/.github/workflows/d2l-activities-backport.yml
+++ b/.github/workflows/d2l-activities-backport.yml
@@ -8,7 +8,7 @@ jobs:
   respond:
     if: github.event.issue.pull_request && startswith(github.event.comment.body, '/backport')
     timeout-minutes: 5
-    runs-on: [self-hosted, AWS, Linux]
+    runs-on: ubuntu-latest
 
     steps:
       - id: source-pr


### PR DESCRIPTION
### Motivation/Context
Public repo cannot access self hosted runners on AWS

### Summary of Changes
Updated runner to `ubuntu-latest` as this is a public repo

### Rally Story
https://rally1.rallydev.com/#/29180338367d/dashboard?detail=%2Fuserstory%2F603436954475&fdp=true?fdp=true