### PR TITLE
Do not filter scripts out when previewing HTML files

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -47,6 +47,7 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 				.html="${live(this.value)}"
 				label="${this.ariaLabel}"
 				label-hidden
+				no-filter
 				?disabled="${this.disabled}"
 				height=${ifDefined(this.htmlEditorHeight)}
 				?full-page="${this.fullPage}"


### PR DESCRIPTION
The "no-filter" property will tell the HTMLFilesController to not filter out scripts when previewing the HTML. This is necessary as we need to include MathJax as part of those scripts so that they can be properly rendered.

![image](https://user-images.githubusercontent.com/14796305/125811715-103ed7bf-7b92-4762-bff8-2bc0f2776485.png)
