### PR TITLE
Us129739/fix missing lang terms

### DIFF
--- a/activities.serge.json
+++ b/activities.serge.json
@@ -219,5 +219,27 @@
       "sv-se sv",
       "tr-tr tr"
     ]
+  },{
+    "name": "quizActivityEditor",
+    "parser_plugin": {
+      "plugin": "parse_js"
+    },
+    "source_match": "en\\.js$",
+    "source_dir": "components/d2l-activity-editor/d2l-activity-quiz-editor/lang",
+    "output_file_path": "components/d2l-activity-editor/d2l-activity-quiz-editor/lang/%LANG%.js",
+    "output_lang_rewrite": [
+      "ar-sa ar",
+      "cy-gb cy",
+      "da-dk da",
+      "de-de de",
+      "es-mx es",
+      "fr-ca fr",
+      "ja-jp ja",
+      "ko-kr ko",
+      "nl-nl nl",
+      "pt-br pt",
+      "sv-se sv",
+      "tr-tr tr"
+    ]
   }
 ]

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/mixins/d2l-activity-quiz-lang-mixin.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/mixins/d2l-activity-quiz-lang-mixin.js
@@ -1,35 +1,11 @@
-import { getLocalizeOverrideResources } from '@brightspace-ui/core/helpers/getLocalizeResources.js';
-import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { LocalizeDynamicMixin } from '@brightspace-ui/core/mixins/localize-dynamic-mixin.js';
 
-export const LocalizeActivityQuizEditorMixin = superclass => class extends LocalizeMixin(superclass) {
+export const LocalizeActivityQuizEditorMixin = superclass => class extends LocalizeDynamicMixin(superclass) {
 
-	static async getLocalizeResources(langs) {
-
-		function resolveOverridesFunc() {
-			return 'd2l-activities\\quizActivityEditor';
-		}
-
-		let translations;
-		for await (const lang of langs) {
-			switch (lang) {
-				case 'en':
-					translations = await import('../lang/en.js');
-					break;
-			}
-			if (translations && translations.default) {
-				return await getLocalizeOverrideResources(
-					lang,
-					translations.default,
-					resolveOverridesFunc
-				);
-			}
-		}
-		translations = await import('../lang/en.js');
-
-		return await getLocalizeOverrideResources(
-			'en',
-			translations.default,
-			resolveOverridesFunc
-		);
+	static get localizeConfig() {
+		return {
+			importFunc: async lang => (await import(`../lang/${lang}.js`)).default,
+			osloCollection: 'd2l-activities\\quizActivityEditor',
+		};
 	}
 };


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F603418168501

I don't think we've ever been getting lang terms for quizzes as we didn't have anything configured in our serge file. 

I also noticed the assignments localization mixin [had been updated here](https://github.com/BrightspaceHypermediaComponents/activities/pull/1611) and figured quizzing should likely use the same logic. 