### PR TITLE
Us129487/change quizzing html editor type

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-html-new-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-html-new-editor.js
@@ -12,6 +12,7 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 			value: { type: String },
 			ariaLabel: { type: String },
 			disabled: { type: Boolean },
+			htmlEditorType: { type: String },
 			_filesToReplace: { type: Object },
 			htmlEditorHeight: { type: String, attribute: 'html-editor-height' },
 			fullPage: { type: Boolean, attribute: 'full-page' },
@@ -36,7 +37,9 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 		this._filesToReplace = {};
 		this.saveOrder = 400;
 		this.fullPage = false;
-		this.htmlEditorHeight = '10rem';
+		this.htmlEditorHeight = this.htmlEditorHeight || '10rem';
+		this.value = this.value || '';
+		this.htmlEditorType = this.htmlEditorType || 'full';
 	}
 
 	render() {
@@ -50,6 +53,7 @@ class ActivityHtmlNewEditor extends ActivityEditorMixin(LocalizeActivityEditorMi
 				?disabled="${this.disabled}"
 				height=${ifDefined(this.htmlEditorHeight)}
 				?full-page="${this.fullPage}"
+				type="${this.htmlEditorType}"
 				full-page-font-size="${ifDefined(this.fullPageFontSize)}"
 				full-page-font-family="${ifDefined(this.fullPageFontFamily)}"
 				?paste-local-images="${allowPaste}"

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
@@ -159,6 +159,8 @@ class QuizEditorDetail extends ActivityQuizEditorTelemetryMixin(ActivityEditorMi
 				</div>
 				<div class="d2l-skeletize">
 					<d2l-activity-text-editor
+						htmlEditorType="inline"
+						html-editor-height="4rem"
 						.value="${description}"
 						.richtextEditorConfig="${descriptionRichTextEditorConfig}"
 						@d2l-activity-text-editor-change="${this._saveDescriptionOnChange}"

--- a/components/d2l-activity-editor/d2l-activity-text-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-text-editor.js
@@ -13,6 +13,7 @@ class ActivityTextEditor extends LitElement {
 			ariaLabel: { type: String },
 			key: { type: String },
 			htmlEditorHeight: { type: String, attribute: 'html-editor-height' },
+			htmlEditorType: { type: String },
 			fullPage: { type: Boolean, attribute: 'full-page' },
 			fullPageFontSize: { type: String, attribute: 'full-page-font-size' },
 			fullPageFontFamily: { type: String, attribute: 'full-page-font-family' }
@@ -51,6 +52,7 @@ class ActivityTextEditor extends LitElement {
 				return html`
 					<d2l-activity-html-new-editor
 						.value="${live(this.value)}"
+						htmlEditorType="${ifDefined(this.htmlEditorType)}"
 						ariaLabel="${this.ariaLabel}"
 						?disabled="${this.disabled}"
 						@d2l-activity-html-editor-change="${this._onRichtextChange}"


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F602613109707

This story calls for specific customizations to the quizzing implementation of the HTML editor so I added `htmlEditorType` as a property to configure the type.

I also set a few default values at the html editor level.

The story does call for a 'single line' input but with the new HTML editor it's not quite possible...we have the same issue on AF. TinyMCE enforces what they believe to be the minimum acceptable height for input so we can't go smaller than that without getting some fairly jank behaviour. 

With this change it will look something like: 

![image](https://user-images.githubusercontent.com/46040098/126017850-97e10191-9b22-4aa1-a6b5-e6153bbed359.png)


with the toolbar only appearing when the editor is focused

![image](https://user-images.githubusercontent.com/46040098/126017868-5f27be55-3c96-4745-bde2-5f7aef4b6d12.png)
