### PR TITLE
US128833 - adding allowable filetypes dropdown for assignments

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -76,7 +76,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 					${this._renderCategoriesDropdown(assignment)}
 					${this._renderAssignmentSubmissionType(assignment)}
 					${this._renderAssignmentFilesSubmissionLimit(assignment)}
-					${this._renderAllowableFiletypesDropdown(assignment)}
+					${this._renderAllowableFileTypesDropdown(assignment)}
 					${this._renderAssignmentSubmissionsRule(assignment)}
 					${this._renderAssignmentCompletionType(assignment)}
 					${this._renderAssignmentSubmissionNotificationEmail(assignment)}
@@ -130,6 +130,15 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 			${assignment.submissionAndCompletionProps.submissionTypeOptions.map(option => html`<option value=${option.value} ?selected=${String(option.value) === assignment.submissionAndCompletionProps.submissionType}>${option.title}</option>`)}
 		`;
 	}
+	_getAllowableFileTypeOptions(assignment) {
+		if (!assignment || !assignment.submissionAndCompletionProps) {
+			return html``;
+		}
+
+		return html`
+			${assignment.submissionAndCompletionProps.allowableFileTypeOptions.map(option => html`<option value=${option.value} ?selected=${String(option.value) === assignment.submissionAndCompletionProps.submissionType}>${option.title}</option>`)}
+		`;
+	}
 
 	_onNotificationEmailChanged(e) {
 		const assignment = store.get(this.href);
@@ -137,7 +146,8 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 		assignment && assignment.setNotificationEmail(data);
 	}
 
-	_renderAllowableFiletypesDropdown(assignment) {
+	_renderAllowableFileTypesDropdown(assignment) {
+		console.log('assignment')
 		console.log(assignment)
 
 		// only show the dropdown if the API provides the Restrict File Ext property (check here)
@@ -154,8 +164,8 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 					id="assignment-allowable-filetypes"
 					aria-labelledby="assignment-allowable-filetypes-label"
 					class="d2l-input-select d2l-block-select"
-					@change="${this._saveSubmissionTypeOnChange}">
-						${this._getSubmissionTypeOptions(assignment)}
+					@change="${this._saveAllowableFileTypesOnChange}">
+						${this._getAllowableFileTypeOptions(assignment)}
 				</select>
 			</div>
 		`;

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -99,7 +99,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 		}
 
 		return html`
-			${assignment.submissionAndCompletionProps.allowableFileTypeOptions.map(option => html`<option value=${option.value} ?selected=${String(option.value) === assignment.submissionAndCompletionProps.submissionType}>${option.title}</option>`)}
+			${assignment.submissionAndCompletionProps.allowableFileTypeOptions.map(option => html`<option value=${option.value} ?selected=${String(option.value) === assignment.submissionAndCompletionProps.allowableFileType}>${option.title}</option>`)}
 		`;
 	}
 	_getCompletionTypeOptions(assignment) {
@@ -154,6 +154,9 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 		if (!assignment || !assignment.submissionAndCompletionProps) {
 			return html``;
 		}
+
+		console.log('assignment')
+		console.log(assignment.submissionAndCompletionProps)
 
 		let allowableFileTypeContent = html``;
 		if (assignment.submissionAndCompletionProps.canEditSubmissionType) {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -49,6 +49,15 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 				.d2l-input-radio-label {
 					margin-bottom: 10px;
 				}
+
+				#allowable-filetypes-help-span {
+					margin-left: 10px;
+				}
+
+				:host([dir='rtl']) #allowable-filetypes-help-span {
+					margin-left: 0;
+					margin-right: 10px;
+				}
 			`
 		];
 	}
@@ -150,13 +159,17 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 		assignment && assignment.setNotificationEmail(data);
 	}
 
+	_openPopoutInNewTab() {
+		window.open(
+			'https://documentation.brightspace.com/EN/le/assignments/learner/assignments_intro_1.htm',
+			'_blank '
+		);
+	}
+
 	_renderAllowableFileTypesDropdown(assignment) {
 		if (!assignment || !assignment.submissionAndCompletionProps) {
 			return html``;
 		}
-
-		console.log('assignment')
-		console.log(assignment.submissionAndCompletionProps)
 
 		let allowableFileTypeContent = html``;
 		if (assignment.submissionAndCompletionProps.canEditSubmissionType) {
@@ -178,6 +191,13 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 			<div id="assignment-allowable-filetypes-container" class="d2l-editor">
 				<div class="d2l-label-text" id="assignment-allowable-filetypes-label">
 					${this.localize('allowableFiletypes')}
+					<span id="allowable-filetypes-help-span">
+						<d2l-button-icon
+							text="${this.localize('allowableFileTypesHelp')}"
+							icon="tier1:help"
+							@click="${this._openPopoutInNewTab}">
+						</d2l-button-icon>
+					</span>
 				</div>
 				${allowableFileTypeContent}
 			</div>

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -16,6 +16,7 @@ import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import { shared as store } from './state/assignment-store.js';
+const allowableFileTypeDocumentationURL = 'https://documentation.brightspace.com/EN/le/assignments/learner/assignments_intro_1.htm';
 
 class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(ActivityEditorMixin(RtlMixin(LocalizeActivityAssignmentEditorMixin(MobxLitElement)))) {
 
@@ -103,7 +104,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 		await assignment.save();
 	}
 	_getAllowableFileTypeOptions(assignment) {
-		if (!assignment || !assignment.submissionAndCompletionProps) {
+		if (!assignment || !assignment.submissionAndCompletionProps || !assignment.submissionAndCompletionProps.allowableFileTypeOptions) {
 			return html``;
 		}
 
@@ -145,7 +146,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 		return assignment.submissionAndCompletionProps.submissionTypeOptions.find(opt => String(opt.value) === assignment.submissionAndCompletionProps.submissionType);
 	}
 	_getSubmissionTypeOptions(assignment) {
-		if (!assignment || !assignment.submissionAndCompletionProps) {
+		if (!assignment || !assignment.submissionAndCompletionProps || !assignment.submissionAndCompletionProps.submissionTypeOptions) {
 			return html``;
 		}
 
@@ -161,7 +162,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 
 	_openPopoutInNewTab() {
 		window.open(
-			'https://documentation.brightspace.com/EN/le/assignments/learner/assignments_intro_1.htm',
+			allowableFileTypeDocumentationURL,
 			'_blank '
 		);
 	}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -76,6 +76,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 					${this._renderCategoriesDropdown(assignment)}
 					${this._renderAssignmentSubmissionType(assignment)}
 					${this._renderAssignmentFilesSubmissionLimit(assignment)}
+					${this._renderAllowableFiletypesDropdown(assignment)}
 					${this._renderAssignmentSubmissionsRule(assignment)}
 					${this._renderAssignmentCompletionType(assignment)}
 					${this._renderAssignmentSubmissionNotificationEmail(assignment)}
@@ -136,6 +137,29 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 		assignment && assignment.setNotificationEmail(data);
 	}
 
+	_renderAllowableFiletypesDropdown(assignment) {
+		console.log(assignment)
+
+		// only show the dropdown if the API provides the Restrict File Ext property (check here)
+		if (!assignment || !assignment.submissionAndCompletionProps) {
+			return html``;
+		}
+
+		return html`
+			<div id="assignment-allowable-filetypes-container" class="d2l-editor">
+				<div class="d2l-label-text" id="assignment-allowable-filetypes-label">
+					${this.localize('allowableFiletypes')}
+				</div>
+				<select
+					id="assignment-allowable-filetypes"
+					aria-labelledby="assignment-allowable-filetypes-label"
+					class="d2l-input-select d2l-block-select"
+					@change="${this._saveSubmissionTypeOnChange}">
+						${this._getSubmissionTypeOptions(assignment)}
+				</select>
+			</div>
+		`;
+	}
 	_renderAssignmentCompletionType(assignment) {
 		if (!assignment ||
 			!assignment.submissionAndCompletionProps ||

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
@@ -3,6 +3,7 @@
 export default {
 	"hdrReleaseConditions": "Release Conditions", // release conditions heading
 	"hlpReleaseConditions": "Users are not able to access or view the assignment unless they meet the release conditions.", // release conditions help
+	"allowableFiletypes": "Allowable Filetypes", // Label for the allowable filetypes field when creating/editing an assignment
 	"completionType": "Marked as completed", // Label for the completion type field when creating/editing an assignment
 	"lblAnonymousMarking": "Anonymous Marking", // Label for anonymous marking
 	"chkAnonymousMarking": "Hide student names during assessment", // Checkbox for anonymous marking

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/lang/en.js
@@ -4,6 +4,7 @@ export default {
 	"hdrReleaseConditions": "Release Conditions", // release conditions heading
 	"hlpReleaseConditions": "Users are not able to access or view the assignment unless they meet the release conditions.", // release conditions help
 	"allowableFiletypes": "Allowable Filetypes", // Label for the allowable filetypes field when creating/editing an assignment
+	"allowableFileTypesHelp": "Open allowable filetypes information in a new tab", // Help icon for allowable filetypes info
 	"completionType": "Marked as completed", // Label for the completion type field when creating/editing an assignment
 	"lblAnonymousMarking": "Anonymous Marking", // Label for anonymous marking
 	"chkAnonymousMarking": "Hide student names during assessment", // Checkbox for anonymous marking

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-submission-and-completion.js
@@ -30,6 +30,9 @@ export class SubmissionAndCompletionProps {
 		}
 	}
 
+	setAllowableFileType(value) {
+		this.allowableFileType = value;
+	}
 	setCompletionType(value) {
 		this.completionType = value;
 	}
@@ -43,10 +46,6 @@ export class SubmissionAndCompletionProps {
 		this.submissionType = value;
 
 		this._setValidCompletionTypeForSubmissionType();
-	}
-
-	setAllowableFileType(value) {
-		this.allowableFileType = value;
 	}
 
 	get showFilesSubmissionLimit() {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-submission-and-completion.js
@@ -5,7 +5,9 @@ configureMobx({ enforceActions: 'observed' });
 export class SubmissionAndCompletionProps {
 
 	constructor(entity) {
-
+		this.allowableFileTypeOptions = entity.allowableFileTypeOptions;
+		this.allowableFileType = String(entity.allowableFileType);
+		this.canEditAllowableFileType = entity.canEditAllowableFileType;
 		this.submissionTypeOptions = entity.submissionTypeOptions;
 		this.submissionType = String(entity.submissionType);
 		this.canEditSubmissionType = entity.canEditSubmissionType;
@@ -41,6 +43,10 @@ export class SubmissionAndCompletionProps {
 		this.submissionType = value;
 
 		this._setValidCompletionTypeForSubmissionType();
+	}
+
+	setAllowableFileType(value) {
+		this.allowableFileType = value;
 	}
 
 	get showFilesSubmissionLimit() {
@@ -109,6 +115,9 @@ export class SubmissionAndCompletionProps {
 
 decorate(SubmissionAndCompletionProps, {
 	// props
+	allowableFileTypeOptions: observable,
+	allowableFileType: observable,
+	canEditAllowableFileType: observable,
 	submissionTypeOptions: observable,
 	submissionType: observable,
 	canEditSubmissionType: observable,

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-submission-and-completion.js
@@ -5,6 +5,7 @@ configureMobx({ enforceActions: 'observed' });
 export class SubmissionAndCompletionProps {
 
 	constructor(entity) {
+
 		this.submissionTypeOptions = entity.submissionTypeOptions;
 		this.submissionType = String(entity.submissionType);
 		this.canEditSubmissionType = entity.canEditSubmissionType;

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -38,6 +38,8 @@ export class Assignment {
 
 	load(entity) {
 		this._entity = entity;
+		// console.log('ENTITY!!')
+		// console.log(entity)
 		this.submissionAndCompletionProps = new SubmissionAndCompletionProps({
 			submissionTypeOptions: entity.submissionTypeOptions(),
 			submissionType: entity.submissionType().value,

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -38,8 +38,6 @@ export class Assignment {
 
 	load(entity) {
 		this._entity = entity;
-		console.log('ENTITY!!')
-		console.log(entity)
 		this.submissionAndCompletionProps = new SubmissionAndCompletionProps({
 			allowableFileTypeOptions: entity.allowableFileTypeOptions(),
 			allowableFileType: entity.allowableFileType().value,
@@ -123,6 +121,9 @@ export class Assignment {
 
 		await this.fetch();
 	}
+	setAllowableFileType(value) {
+		this.submissionAndCompletionProps.setAllowableFileType(value);
+	}
 	setAnnotationToolsAvailable(value) {
 		this.annotationToolsAvailable = value;
 	}
@@ -176,9 +177,6 @@ export class Assignment {
 		this.submissionAndCompletionProps.setSubmissionType(value);
 
 		this.anonymousMarkingProps.setIsAnonymousMarkingAvailableForSubmissionType(this.submissionAndCompletionProps.submissionType);
-	}
-	setAllowableFileType(value) {
-		this.submissionAndCompletionProps.setAllowableFileType(value);
 	}
 	setToGroupAssignmentType() {
 		this.assignmentTypeProps.setToGroupAssignmentType();

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -38,9 +38,12 @@ export class Assignment {
 
 	load(entity) {
 		this._entity = entity;
-		// console.log('ENTITY!!')
-		// console.log(entity)
+		console.log('ENTITY!!')
+		console.log(entity)
 		this.submissionAndCompletionProps = new SubmissionAndCompletionProps({
+			allowableFileTypeOptions: entity.allowableFileTypeOptions(),
+			allowableFileType: entity.allowableFileType().value,
+			canEditAllowableFileType: entity.canEditAllowableFileType(),
 			submissionTypeOptions: entity.submissionTypeOptions(),
 			submissionType: entity.submissionType().value,
 			canEditSubmissionType: entity.canEditSubmissionType(),
@@ -174,6 +177,9 @@ export class Assignment {
 
 		this.anonymousMarkingProps.setIsAnonymousMarkingAvailableForSubmissionType(this.submissionAndCompletionProps.submissionType);
 	}
+	setAllowableFileType(value) {
+		this.submissionAndCompletionProps.setAllowableFileType(value);
+	}
 	setToGroupAssignmentType() {
 		this.assignmentTypeProps.setToGroupAssignmentType();
 	}
@@ -197,6 +203,7 @@ export class Assignment {
 			name: this.name,
 			annotationToolsAvailable: this.annotationToolsAvailable,
 			submissionType: this.submissionAndCompletionProps.submissionType,
+			allowableFileType: this.submissionAndCompletionProps.allowableFileType,
 			isIndividualAssignmentType: this.assignmentTypeProps.isIndividualAssignmentType,
 			groupTypeId: this.assignmentTypeProps.selectedGroupCategoryId,
 			defaultScoringRubricId: this.defaultScoringRubricId
@@ -228,6 +235,7 @@ decorate(Assignment, {
 	submissionAndCompletionProps: observable,
 	name: observable,
 	canEditName: observable,
+	allowableFileType: observable,
 	instructions: observable,
 	canEditInstructions: observable,
 	instructionsRichTextEditorConfig: observable,
@@ -257,6 +265,7 @@ decorate(Assignment, {
 	setAnonymousMarking: action,
 	setAnnotationToolsAvailable: action,
 	setSubmissionType: action,
+	setAllowableFileType: action,
 	setTurnitin: action,
 	setCompletionType: action,
 	save: action,

--- a/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
@@ -46,6 +46,14 @@ describe('Assignment ', function() {
 					{ title: 'On paper submission', value: 2, completionTypes: [1, 2], selected: true },
 					{ title: 'Observed in person', value: 3, completionTypes: [3], selected: false }
 				],
+				allowableFileTypeOptions: () => [
+					{ title: 'No Restrictions', value: 0, selected: true },
+					{ title: 'Pdf Only', value: 1, selected: false },
+					{ title: 'Annotatable Files', value: 2, selected: true },
+					{ title: 'Files that can be previewed without conversion', value: 3, selected: false },
+					{ title: 'Images and Videos', value: 4, selected: false },
+					{ title: 'Custom File Types', value: 5, selected: false },
+				],
 				allCompletionTypeOptions: () => [
 					{
 						'title': 'Automatically on submission',
@@ -69,12 +77,14 @@ describe('Assignment ', function() {
 					}
 				],
 				canEditSubmissionType: () => true,
+				canEditAllowableFileType: () => true,
 				canEditCompletionType: () => true,
 				canEditFilesSubmissionLimit: () => true,
 				canEditDefaultScoringRubric: () => true,
 				getDefaultScoringRubric: () => '-1',
 				filesSubmissionLimit: () => 'unlimited',
 				submissionType: () => { return { title: 'On paper submission', value: 2 }; },
+				allowableFileType: () => { return { title: 'No restrictions', value: 0 }; },
 				completionType: () => { return { title: 'Manually by learners', value: 2 }; },
 				completionTypeValue: () => { return '2'; },
 				isGroupAssignmentTypeDisabled: () => false,


### PR DESCRIPTION
[US128833 - [Restrict File Ext][UI] Add new dropdown for the restrict file extension options](https://rally1.rallydev.com/#/42960320374d/dashboard?detail=%2Fuserstory%2F600937249791)

Depends on [US128833 - adding support for update-allowable-filetype action for assignments](https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/362) 