### PR TITLE
fix: Quick Eval load more breaking due to d2l-table changes

### DIFF
--- a/components/d2l-quick-eval/d2l-quick-eval-submissions.js
+++ b/components/d2l-quick-eval/d2l-quick-eval-submissions.js
@@ -316,7 +316,7 @@ class D2LQuickEvalSubmissions extends mixinBehaviors(
 					return;
 				}
 
-				const tbody = this.shadowRoot.querySelector('d2l-quick-eval-submissions-table').shadowRoot.querySelector('d2l-tbody');
+				const tbody = this.shadowRoot.querySelector('d2l-quick-eval-submissions-table').shadowRoot.querySelector('tbody');
 				const lastFocusableTableElement = D2L.Dom.Focus.getLastFocusableDescendant(tbody, false);
 
 				try {

--- a/test/d2l-quick-eval/d2l-quick-eval.html
+++ b/test/d2l-quick-eval/d2l-quick-eval.html
@@ -60,7 +60,7 @@
 			const expectedFiltersWithMasterTeacher = expectedFilters.concat('Primary Facilitator');
 
 			function waitForList(callback) {
-				const firstDataCell = list.shadowRoot.querySelector('d2l-tbody > d2l-tr > d2l-td.d2l-table-cell-first');
+				const firstDataCell = list.shadowRoot.querySelector('tbody > tr > td.d2l-table-cell-first');
 
 				if (firstDataCell) {
 					callback(firstDataCell);


### PR DESCRIPTION
After #1754, Quick Eval's "Load More" fails with an error as a query into the modified component's shadow DOM wasn't updated. 

- [x] Create 20.21.7 backport
- [x] Create 20.21.8 backport