### PR TITLE
Fix dirty check in activity usage

### DIFF
--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -19,10 +19,14 @@ export class ActivityUsage extends WorkingCopy {
 	}
 
 	async checkin(store, refetch) {
+		/* We `skipStoringResult` in the super.checkin function so that entity.load is not called.
+		 * This keeps the existing `scoreAndGrade` (out of) value instead of refetching the scoreAndGrade entity and overwriting it.
+		 */
 		const { sirenEntity } = await super.checkin(store, refetch, true) || {};
 		if (!sirenEntity) return;
 		const entity = store.get(sirenEntity.self());
 		if (entity) {
+			entity._entity = sirenEntity;
 			entity.setAssociateGradeHref(sirenEntity.associateGradeHref());
 		}
 	}


### PR DESCRIPTION
Needs updated activity usage entity, otherwise we will be comparing to the old entity which may be missing the `canCheckIn` action.

https://rally1.rallydev.com/#/10235005524d/dashboard?detail=%2Fuserstory%2F600744235069%2Ftasks&fdp=true?fdp=true