### PR TITLE
Do not recreate the entity if it already exists

### DIFF
--- a/components/d2l-activity-editor/state/working-copy.js
+++ b/components/d2l-activity-editor/state/working-copy.js
@@ -32,11 +32,17 @@ export class WorkingCopy {
 		}
 
 		if (!sirenEntity) return;
+
 		const href = sirenEntity.self();
 		if (!skipStoringResult) {
-			const entity = new this.StateType(href, this.token);
-			entity.load(sirenEntity);
-			store.put(href, entity);
+			const existingEntity = store.get(href);
+			if (existingEntity) {
+				existingEntity.load(sirenEntity);
+			} else {
+				const entity = new this.StateType(href, this.token);
+				entity.load(sirenEntity);
+				store.put(href, entity);
+			}
 		}
 
 		if (refetch) {


### PR DESCRIPTION
Recreating the entity meant the new entity had `this._checkedOut` set back to `null`, so the base `quiz/activity/assignment` would no longer know its `checkedOutHref`.

https://trello.com/c/wGtoz9Iz/430-after-a-change-to-quiz-timing-attempts-or-ip-restrictions-and-a-first-save-without-refresh-subsequent-changes-to-timing-attempts