### PR TITLE
US128833 - Allowable filetype fixes

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -168,7 +168,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 	}
 
 	_renderAllowableFileTypesDropdown(assignment) {
-		if (!assignment || !assignment.submissionAndCompletionProps || !assignment.submissionAndCompletionProps.showAllowableFileTypes) {
+		if (!assignment || !assignment.submissionAndCompletionProps || !assignment.submissionAndCompletionProps.showFilesSubmissionOptions) {
 			return html``;
 		}
 
@@ -247,7 +247,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 	_renderAssignmentFilesSubmissionLimit(assignment) {
 		if (!assignment ||
 			!assignment.submissionAndCompletionProps ||
-			!assignment.submissionAndCompletionProps.showFilesSubmissionLimit) {
+			!assignment.submissionAndCompletionProps.showFilesSubmissionOptions) {
 			return html``;
 		}
 

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -168,12 +168,12 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 	}
 
 	_renderAllowableFileTypesDropdown(assignment) {
-		if (!assignment || !assignment.submissionAndCompletionProps) {
+		if (!assignment || !assignment.submissionAndCompletionProps || !assignment.submissionAndCompletionProps.showAllowableFileTypes) {
 			return html``;
 		}
 
 		let allowableFileTypeContent = html``;
-		if (assignment.submissionAndCompletionProps.canEditSubmissionType) {
+		if (assignment.submissionAndCompletionProps.canEditAllowableFileType) {
 			allowableFileTypeContent = html`<select
 										id="assignment-allowable-filetypes"
 										aria-labelledby="assignment-allowable-filetypes-label"

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-submission-and-completion.js
@@ -48,11 +48,7 @@ export class SubmissionAndCompletionProps {
 		this._setValidCompletionTypeForSubmissionType();
 	}
 
-	get showAllowableFileTypes() {
-		return this.submissionTypeOptions
-			.find(x => String(x.value) === '0' && `${x.value}` === `${this.submissionType}`);
-	}
-	get showFilesSubmissionLimit() {
+	get showFilesSubmissionOptions() {
 		return this.submissionTypeOptions
 			.find(x => String(x.value) === '0' && `${x.value}` === `${this.submissionType}`);
 	}
@@ -133,8 +129,7 @@ decorate(SubmissionAndCompletionProps, {
 	completionTypeOptions: observable,
 	canEditCompletionType: observable,
 	// computed
-	showAllowableFileTypes: computed,
-	showFilesSubmissionLimit: computed,
+	showFilesSubmissionOptions: computed,
 	showSubmissionsRule: computed,
 	// actions
 	setSubmissionsRule: action,

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-submission-and-completion.js
@@ -48,6 +48,10 @@ export class SubmissionAndCompletionProps {
 		this._setValidCompletionTypeForSubmissionType();
 	}
 
+	get showAllowableFileTypes() {
+		return this.submissionTypeOptions
+			.find(x => String(x.value) === '0' && `${x.value}` === `${this.submissionType}`);
+	}
 	get showFilesSubmissionLimit() {
 		return this.submissionTypeOptions
 			.find(x => String(x.value) === '0' && `${x.value}` === `${this.submissionType}`);
@@ -129,6 +133,7 @@ decorate(SubmissionAndCompletionProps, {
 	completionTypeOptions: observable,
 	canEditCompletionType: observable,
 	// computed
+	showAllowableFileTypes: computed,
 	showFilesSubmissionLimit: computed,
 	showSubmissionsRule: computed,
 	// actions

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -215,7 +215,7 @@ export class Assignment {
 		if (this.submissionAndCompletionProps.canEditCompletionType) {
 			data.completionType = this.submissionAndCompletionProps.completionType;
 		}
-		if (this.submissionAndCompletionProps.showFilesSubmissionLimit) {
+		if (this.submissionAndCompletionProps.showFilesSubmissionOptions) {
 			data.filesSubmissionLimit = this.submissionAndCompletionProps.filesSubmissionLimit;
 		}
 		if (this.submissionAndCompletionProps.showSubmissionsRule) {

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -40,7 +40,7 @@ export class Assignment {
 		this._entity = entity;
 		this.submissionAndCompletionProps = new SubmissionAndCompletionProps({
 			allowableFileTypeOptions: entity.allowableFileTypeOptions(),
-			allowableFileType: entity.allowableFileType().value,
+			allowableFileType: entity.allowableFileType() ? entity.allowableFileType().value : undefined,
 			canEditAllowableFileType: entity.canEditAllowableFileType(),
 			submissionTypeOptions: entity.submissionTypeOptions(),
 			submissionType: entity.submissionType().value,


### PR DESCRIPTION
Fixes related to [US128833 ](https://rally1.rallydev.com/#/42960320374d/dashboard?detail=%2Fuserstory%2F600937249791).

Now renders dropdown conditionally based on Submission Type.

Also fixing an error that was popping up when trying to save any submission types other than File submission.
