### PR TITLE
US130754 - adding undefined check for allowableFileType property

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -250,6 +250,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 			</div>
 		`;
 	}
+
 	_renderAssignmentCompletionTypeSummary() {
 		return html``;
 	}

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -175,7 +175,10 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 	}
 
 	_renderAllowableFileTypesDropdown(assignment) {
-		if (!assignment || !assignment.submissionAndCompletionProps || !assignment.submissionAndCompletionProps.showFilesSubmissionOptions) {
+		if (!assignment ||
+			!assignment.submissionAndCompletionProps ||
+			!assignment.submissionAndCompletionProps.showFilesSubmissionOptions ||
+			assignment.submissionAndCompletionProps.allowableFileType === 'undefined') {
 			return html``;
 		}
 


### PR DESCRIPTION
https://rally1.rallydev.com/#/42960320374d/dashboard?detail=%2Fuserstory%2F606213375445

Added an extra undefined check for the assignment's `allowableFileType` property to avoid rendering anything when the d2l.Tools.Dropbox.RestrictFileExtensions ( Org ) config variable is off.