### PR TITLE
DE44919 - fixing bugs in restrict file custom input field

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -171,7 +171,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 		}
 
 		const fileTypesList = fileTypes.split(',').map(type => type.trim());
-		const minimumExtensionLength = 3;
+		const minimumExtensionLength = 2;
 
 		const hasInvalidFileTypes = fileTypesList.some(type => this.restrictedFileTypes.includes(type) || !type.includes('.'));
 		const hasInvalidLength = fileTypesList.some(type => type.length < minimumExtensionLength);

--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -170,13 +170,13 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 			return true;
 		}
 
-		const fileTypesList = fileTypes.split(',').map(type => type.trim());
-		const minimumExtensionLength = 2;
+		const fileTypesList = fileTypes.split(',').map(fileType => fileType.trim().toLowerCase());
+		const isValidExtensionFormat = new RegExp(/^\.[a-zA-Z0-9]+$/);
 
-		const hasInvalidFileTypes = fileTypesList.some(type => this.restrictedFileTypes.includes(type) || !type.includes('.'));
-		const hasInvalidLength = fileTypesList.some(type => type.length < minimumExtensionLength);
+		const hasInvalidFormat = fileTypesList.some(fileType => !isValidExtensionFormat.test(fileType));
+		const hasRestrictedFileType = fileTypesList.some(fileType => this.restrictedFileTypes.includes(fileType));
 
-		return hasInvalidFileTypes || hasInvalidLength;
+		return hasInvalidFormat || hasRestrictedFileType;
 	}
 	async _loadRestrictedFileTypes(assignment) {
 		this.restrictedFileTypes = await assignment.loadRestrictedExtensions() || [];


### PR DESCRIPTION
[DE44919 ](https://rally1.rallydev.com/#/42960320374d/custom/236803223728?detail=%2Fdefect%2F607412067589)

Now accepts single character extensions.

Accepts:
```
.pdf
.m
```

Does not accept:
```
.
..
...
.exe
.EXE
pdf
..pdf
pdf.txt
.pdf.txt
.pdf txt
```