### PR TITLE
fix: DE44541 end of day that was previously manually entered (11:59:0…

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,6 @@ module.exports = {
 		'^.+\\.jsx?$': './jest.babel.config.js'
 	},
 	transformIgnorePatterns: [
-		'node_modules/(?!(siren-sdk|d2l-polymer-siren-behaviors|d2l-fetch)/)'
+		'node_modules/(?!(siren-sdk|d2l-polymer-siren-behaviors|d2l-fetch|@brightspace-ui)/)'
 	],
 };


### PR DESCRIPTION
…0) is converted to END_OF_DAY (11:59:59)

Fixes https://rally1.rallydev.com/#/29180338367ud/custom/486232622040?detail=%2Fdefect%2F605123292669&fdp=true

The issue is that when an EOD time (i.e. 11:59 PM) is entered manually, the seconds value is set to 0, and when the default value of END_OF_DAY is used, the seconds value is set to 59. The causes problems when comparing times.

Note: [the fix in core/components/inputs/input-time.js](https://github.com/BrightspaceUI/core/pull/1598/files) makes sure that any new times entered going forward are saved properly as END_OF_DAY.

The change in this repo updates any currently saved EOD time values when a FACE page is loaded.