### PR TITLE
Mawang/us131180/update automatic grade wording

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-auto-set-graded-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-auto-set-graded-editor.js
@@ -1,3 +1,6 @@
+import '@brightspace-ui/core/components/button/button-icon.js';
+import '@brightspace-ui/core/components/dialog/dialog.js';
+import { ActivityEditorDialogMixin } from '../mixins/d2l-activity-editor-dialog-mixin.js';
 import { ActivityEditorMixin } from '../mixins/d2l-activity-editor-mixin.js';
 import { checkboxStyles } from '../styles/checkbox-styles.js';
 import { html } from 'lit-element/lit-element.js';
@@ -7,7 +10,7 @@ import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { shared as store } from './state/quiz-store';
 
 class ActivityQuizAutomaticGradeEditor
-	extends ActivityEditorMixin(RtlMixin(LocalizeActivityQuizEditorMixin(MobxLitElement))) {
+	extends ActivityEditorMixin(RtlMixin(LocalizeActivityQuizEditorMixin(ActivityEditorDialogMixin(MobxLitElement)))) {
 
 	static get styles() {
 		return checkboxStyles;
@@ -27,14 +30,43 @@ class ActivityQuizAutomaticGradeEditor
 			<d2l-input-checkbox-spacer
 				class="d2l-body-small">
 			</d2l-input-checkbox-spacer>
+		
+				<d2l-input-checkbox 
+					?checked="${entity.isAutoSetGradedEnabled}"
+					@change="${this._setAutoSetGraded}"
+					ariaLabel="${this.localize('autoSetGradedDescription')}"
+					?disabled="${!entity.canEditAutoSetGraded}">
 
-			<d2l-input-checkbox
-				?checked="${entity.isAutoSetGradedEnabled}"
-				@change="${this._setAutoSetGraded}"
-				ariaLabel="${this.localize('autoSetGradedDescription')}"
-				?disabled="${!entity.canEditAutoSetGraded}">
-				${this.localize('autoSetGradedDescription')}
-			</d2l-input-checkbox>
+					<label> ${this.localize('autoSetGradedDescription')} </label>
+
+					<d2l-button-icon
+						text="${this.localize('autoSetGradedAccessibleHelpText')}"
+						icon="tier1:help"
+						@click="${this.open}">
+					</d2l-button-icon>
+					
+				</d2l-input-checkbox>
+				${this._renderDialog()}
+		`;
+	}
+
+	_renderDialog() {
+		return html`
+			<d2l-dialog
+				?opened="${this.opened}"
+				@d2l-dialog-close="${this.handleClose}"
+				title-text="${this.localize('autoSetGradedHelpDialogTitle')}">
+					<div>
+						<p>${this.localize('autoSetGradedHelpDialogParagraph1')}</p>
+						<p>${this.localize('autoSetGradedHelpDialogParagraph2')}</p>
+					</div>
+					<d2l-button
+						data-dialog-action="done"
+						slot="footer"
+						primary>
+						${this.localize('autoSetGradedHelpDialogConfirmationText')}
+					</d2l-button>
+			</d2l-dialog>
 		`;
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
@@ -47,6 +47,8 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 					${this.localize('hdrEvaluationAndFeedback')}
 				</span>
 
+				<li slot="summary-items">${this._renderAutoSetGradedSummary()}</li>
+
 				<div class="d2l-editor" slot="components">
 					${this._renderAutomaticGradesEditor()}
 				</div>
@@ -67,6 +69,7 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 			</d2l-activity-quiz-auto-set-graded-editor>
 	`;
 	}
+
 
 	_renderAutoSetGradedSummary() {
 		return html`

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
@@ -47,14 +47,10 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 					${this.localize('hdrEvaluationAndFeedback')}
 				</span>
 
-				<li slot="summary-items">${this._renderAutoSetGradedSummary()}</li>
-
 				<div class="d2l-editor" slot="components">
 					${this._renderAutomaticGradesEditor()}
 				</div>
 			</d2l-activity-accordion-collapse>
-
-			${this._renderDialog()}
 		`;
 	}
 
@@ -72,50 +68,12 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 	`;
 	}
 
-	_renderAutoSetGradedSubHeader() {
-		return html`
-			<div>
-				<span>
-					<div class="d2l-label-text">
-						${this.localize('subHdrAutomaticGrades')}
-					</div>
-				</span>
-				<span>
-					<d2l-button-icon
-						text="${this.localize('autoSetGradedAccessibleHelpText')}"
-						icon="tier1:help"
-						@click="${this.open}">
-					</d2l-button-icon>
-				</span>
-			</div>
-		`;
-	}
 	_renderAutoSetGradedSummary() {
 		return html`
 			<d2l-activity-quiz-auto-set-graded-summary
 				href="${this.href}"
 				.token="${this.token}">
 			</d2l-activity-quiz-auto-set-graded-summary>
-		`;
-	}
-	_renderDialog() {
-		return html`
-			<d2l-dialog
-				?opened="${this.opened}"
-				@d2l-dialog-close="${this.handleClose}"
-				title-text="${this.localize('autoSetGradedHelpDialogTitle')}">
-					<div>
-						<p>${this.localize('autoSetGradedHelpDialogParagraph1')}</p>
-						<p>${this.localize('autoSetGradedHelpDialogParagraph2')}</p>
-						<p>${this.localize('autoSetGradedHelpDialogParagraph3')}</p>
-					</div>
-					<d2l-button
-						data-dialog-action="done"
-						slot="footer"
-						primary>
-						${this.localize('autoSetGradedHelpDialogConfirmationText')}
-					</d2l-button>
-			</d2l-dialog>
 		`;
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
@@ -70,7 +70,6 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 	`;
 	}
 
-
 	_renderAutoSetGradedSummary() {
 		return html`
 			<d2l-activity-quiz-auto-set-graded-summary

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-evaluation-and-feedback-editor.js
@@ -50,7 +50,6 @@ class ActivityQuizEvaluationAndFeedbackEditor extends AsyncContainerMixin(Locali
 				<li slot="summary-items">${this._renderAutoSetGradedSummary()}</li>
 
 				<div class="d2l-editor" slot="components">
-					${this._renderAutoSetGradedSubHeader()}
 					${this._renderAutomaticGradesEditor()}
 				</div>
 			</d2l-activity-accordion-collapse>

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
@@ -31,7 +31,7 @@ export default {
 	"hdrEvaluationAndFeedback": "Evaluation & Feedback", // evaluation/feedback accordion header
 	"subHdrAutomaticGrades": "Automatic Grade", // Title for automatic grade tool
 	"autoSetGradedDescription": "Auto-publish attempt results immediately upon completion", // description for automatic grade checkbox
-	"autoSetGradedSummary": "Automatically grade", // summary for auto set graded checkbox
+	"autoSetGradedSummary": "Auto-publish results", // summary for auto set graded checkbox
 	"passwordDescription": "Only users who enter this password will be granted access to write this quiz.", // description for password input
 	"hlpSubmissionNotificationEmail": "Enter an email or multiple emails separated by a comma, to receive notifications when a quiz is attempted.", // description for email notification input
 	"autoSetGradedAccessibleHelpText": "Get help on - Automatic Grade", // accessible help text for autoSetGraded question mark button

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
@@ -30,16 +30,16 @@ export default {
 	"hlpReleaseConditions": "Users are not able to access or view the quiz unless they meet the release conditions.", // release conditions help
 	"hdrEvaluationAndFeedback": "Evaluation & Feedback", // evaluation/feedback accordion header
 	"subHdrAutomaticGrades": "Automatic Grade", // Title for automatic grade tool
-	"autoSetGradedDescription": "Allow attempt to be set as graded immediately upon completion", // description for automatic grade checkbox
+	"autoSetGradedDescription": "Auto-publish attempt results immediately upon completion", // description for automatic grade checkbox
 	"autoSetGradedSummary": "Automatically grade", // summary for auto set graded checkbox
 	"passwordDescription": "Only users who enter this password will be granted access to write this quiz.", // description for password input
 	"hlpSubmissionNotificationEmail": "Enter an email or multiple emails separated by a comma, to receive notifications when a quiz is attempted.", // description for email notification input
 	"autoSetGradedAccessibleHelpText": "Get help on - Automatic Grade", // accessible help text for autoSetGraded question mark button
-	"autoSetGradedHelpDialogTitle": "Information: Automatic Grade", // title that appears when the autoSetGraded help dialog is rendered
+	"autoSetGradedHelpDialogTitle": "Information: Auto-publish attempt results immediately upon completion", // title that appears when the autoSetGraded help dialog is rendered
 	"autoSetGradedHelpDialogConfirmationText": "OK", // copy that appears on the autoSetGraded help dialog confirmation button
-	"autoSetGradedHelpDialogParagraph1": "When this setting is turned on users can see their score as soon as they submit their attempt. The score displayed is only what the system can auto-grade.", // content for paragraph 1 of autoSetGraded help dialog
-	"autoSetGradedHelpDialogParagraph2": "This setting must be turned on for grades to be automatically sent to the grade book, and for the default submission view to be released to users when they complete an attempt.", // content for paragraph 2 of autoSetGraded help dialog
-	"autoSetGradedHelpDialogParagraph3": "Note: Written Response questions will be marked as 0 until manually graded.", // content for paragraph 3 of autoSetGraded help dialog
+	"autoSetGradedHelpDialogParagraph1": "With this feature turned on, the auto-evaluated attempt results will be published and appear to learners.", // content for paragraph 1 of autoSetGraded help dialog
+	"autoSetGradedHelpDialogParagraph2": "Note: If questions cannot be evaluated by the system (e.g. written response questions), those questions will be automatically scored with a zero until manual evaluation.", // content for paragraph 2 of autoSetGraded help dialog
+	"autoSetGradedHelpDialogParagraph3": "", // content for paragraph 3 of autoSetGraded help dialog
 	"disableAlertsHelpDialogTitle": "Information: Disable Email, Instant Messages and Alerts within Brightspace", // title that appears when the disable alerts help dialog is rendered
 	"disableAlertsHelpDialogContent": "If you turn on this option, learners cannot access the Brightspace Email, Instant Messages, or their alerts if they have a quiz attempt in progress.", // content that appears when the disable alerts help dialog is rendered
 	"disableAlertsHelpDialogConfirmationText": "OK", // copy that appears on the disable alerts help dialog confirmation button

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "wct-mocha": "^1.0.1",
     "whatwg-fetch": "^3.0.0"
   },
-  "version": "3.197.0",
+  "version": "3.197.1",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "wct-mocha": "^1.0.1",
     "whatwg-fetch": "^3.0.0"
   },
-  "version": "3.196.4",
+  "version": "3.197.0",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",


### PR DESCRIPTION
Minor UI changes, US131180. 

In the dialog box, the number of paragraphs is reduced from 3 to 2. In en.js, autoSetGradedHelpDialogParagraph3 is no longer used: I set it to "" instead of removing it entirely. 

[US131180](https://rally1.rallydev.com/#/?detail=/userstory/607688202799&fdp=true): Update "Automatic Grade" wording

UI Image: 

![pr1](https://user-images.githubusercontent.com/88114520/132423957-f26eb045-d0a3-46dd-9aed-8e815f69d742.png)

Dialog box image: 

![pr2](https://user-images.githubusercontent.com/88114520/132423865-47044e9c-0b55-4edf-aaf0-c4a665ff2209.png)
