### PR TITLE
fix: US130775 set the _createSelectboxGradeItemEnabled to true everyw…

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/scorm/d2l-activity-content-scorm-activity-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/scorm/d2l-activity-content-scorm-activity-detail.js
@@ -54,7 +54,7 @@ class ContentScormActivityDetail extends SkeletonMixin(ErrorHandlingMixin(Locali
 		});
 		this.dispatchEvent(event);
 
-		this._createSelectboxGradeItemEnabled = event.detail.provider;
+		this._createSelectboxGradeItemEnabled = typeof this._createSelectboxGradeItemEnabled === 'undefined' || event.detail.provider;
 
 		this.saveTitle = this.saveTitle.bind(this);
 		this.saveLinkOptions = this.saveLinkOptions.bind(this);

--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grade-candidate-selector.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grade-candidate-selector.js
@@ -48,7 +48,7 @@ class ActivityGradeCandidateSelector extends ActivityEditorMixin(LocalizeActivit
 		});
 		this.dispatchEvent(event);
 
-		this._createSelectboxGradeItemEnabled = event.detail.provider;
+		this._createSelectboxGradeItemEnabled = typeof this._createSelectboxGradeItemEnabled === 'undefined' || event.detail.provider;
 	}
 
 	render() {

--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grade-category-selector.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grade-category-selector.js
@@ -55,7 +55,7 @@ class ActivityGradeCategorySelector extends ActivityEditorMixin(LocalizeActivity
 		});
 		this.dispatchEvent(event);
 
-		this._createSelectboxGradeItemEnabled = event.detail.provider;
+		this._createSelectboxGradeItemEnabled = typeof this._createSelectboxGradeItemEnabled === 'undefined' || event.detail.provider;
 	}
 
 	render() {

--- a/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
+++ b/components/d2l-activity-editor/d2l-activity-grades/d2l-activity-grades-dialog.js
@@ -87,7 +87,7 @@ class ActivityGradesDialog extends ActivityEditorWorkingCopyDialogMixin(Localize
 		});
 		this.dispatchEvent(event);
 
-		this._createSelectboxGradeItemEnabled = event.detail.provider;
+		this._createSelectboxGradeItemEnabled = typeof this._createSelectboxGradeItemEnabled === 'undefined' || event.detail.provider;
 		if (!this._createSelectboxGradeItemEnabled) {
 			this.checkoutOnLoad = false;
 		}

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -179,7 +179,7 @@ class ActivityScoreEditor extends ActivityEditorMixin(SkeletonMixin(LocalizeActi
 		});
 		this.dispatchEvent(event);
 
-		this._createSelectboxGradeItemEnabled = event.detail.provider;
+		this._createSelectboxGradeItemEnabled = typeof this._createSelectboxGradeItemEnabled === 'undefined' || event.detail.provider;
 		this.checkoutOnLoad = this._createSelectboxGradeItemEnabled;
 	}
 


### PR DESCRIPTION
…here except Assignments
https://rally1.rallydev.com/#/29180338367ud/custom/486232622040?detail=%2Fuserstory%2F606249971567&fdp=true

Since the selectbox flag is only relevant for Assignment activity types, the assumption here is that only assignment type activities will set this value. For other activity types that start adding the grades component to FACE, we should use the "new" implementation, therefore assume the flag is on if a value is not explicitly set.

@ChrisKraljevicD2L I did this for content-scrom activity as well.

