### PR TITLE
feat: US130775 add score container to quiz activity, which will also …

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/d2l-activity-quiz-editor-detail.js
@@ -73,11 +73,20 @@ class QuizEditorDetail extends ActivityQuizEditorTelemetryMixin(ActivityEditorMi
 					right: 0.6rem;
 				}
 				#score-and-duedate-container {
+					display: flex;
+					flex-wrap: wrap;
 					padding-bottom: 0;
 				}
 				d2l-alert {
 					margin-bottom: 10px;
 					max-width: 100%;
+				}
+				#score-container {
+					margin-right: 40px;
+				}
+				:host([dir="rtl"]) #score-container {
+					margin-left: 40px;
+					margin-right: 0;
 				}
 			`
 		];
@@ -147,6 +156,17 @@ class QuizEditorDetail extends ActivityQuizEditorTelemetryMixin(ActivityEditorMi
 			</div>
 
 			<div id="score-and-duedate-container">
+				<div id="score-container" class="d2l-editor-layout-section">
+					<div class="d2l-activity-label-container d2l-label-text d2l-skeletize">
+						${this.localize('gradeOutOf')}
+					</div>
+					<d2l-activity-score-editor
+						?skeleton="${this.skeleton}"
+						.href="${this.activityUsageHref}"
+						.token="${this.token}"
+						.activityName="${name}">
+					</d2l-activity-score-editor>
+				</div>
 				<div id="duedate-container" class="d2l-editor-layout-section">
 					<d2l-activity-due-date-editor
 						?skeleton="${this.skeleton}"

--- a/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
+++ b/components/d2l-activity-editor/d2l-activity-quiz-editor/lang/en.js
@@ -133,5 +133,6 @@ export default {
 	"headerAndFooter": "Header and footer added", // Header and footer summary text for closed accordion
 	"createNewLabel": "Create New", // Label for button to open menu for adding new items to the quiz.
 	"addExistingLabel": "Add Existing", // Label for button to open menu for adding pre-existing items to the quiz.
-	"addQuestionsLabel": "New Question" // Label for button to open menu for adding new questions to the quiz.
+	"addQuestionsLabel": "New Question", // Label for button to open menu for adding new questions to the quiz.
+	"gradeOutOf": "Grade Out Of" // Label for the grade-out-of field when creating/editing an activity
 };


### PR DESCRIPTION
…checkout the activity-usage
https://rally1.rallydev.com/#/29180338367ud/custom/486232622040?detail=%2Fuserstory%2F606249971567&fdp=true

The `d2l-activity-score-editor` will checkout on load, so adding the component will cause the activity-usage to be checked out and the associate-grade endpoint to be called.

For this to work properly depends on [this fix](https://github.com/BrightspaceHypermediaComponents/activities/pull/1970).