### PR TITLE
Kco/de45099 scorm from content service

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-content-editor/scorm/d2l-activity-content-scorm-activity-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/scorm/d2l-activity-content-scorm-activity-detail.js
@@ -69,9 +69,11 @@ class ContentScormActivityDetail extends SkeletonMixin(ErrorHandlingMixin(Locali
 
 		if (scormActivityEntity) {
 			this.skeleton = false;
-			title = `${this.localize('content.scormActivity')}: ${scormActivityEntity.title}`;
-			if (scormActivityEntity.lastEdited) {
-				subTitle = `${this.localize('content.lastEdited')} ${new Date(Date.parse(scormActivityEntity.lastEdited)).toUTCString()}`;
+			title = `${this.localize('content.scormActivity')}: ${scormActivityEntity.contentServiceName}`;
+			if (scormActivityEntity.contentServiceLastModified) {
+				const date = new Date(Date.parse(scormActivityEntity.contentServiceLastModified))
+					.toLocaleDateString('en-us', { year: 'numeric', month: 'long', day: 'numeric' });
+				subTitle = `${this.localize('content.lastEdited')} ${date}`;
 			}
 		}
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/scorm/d2l-activity-content-scorm-activity-detail.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/scorm/d2l-activity-content-scorm-activity-detail.js
@@ -69,9 +69,9 @@ class ContentScormActivityDetail extends SkeletonMixin(ErrorHandlingMixin(Locali
 
 		if (scormActivityEntity) {
 			this.skeleton = false;
-			title = `${this.localize('content.scormActivity')}: ${scormActivityEntity.contentServiceName}`;
-			if (scormActivityEntity.contentServiceLastModified) {
-				const date = new Date(Date.parse(scormActivityEntity.contentServiceLastModified))
+			title = `${this.localize('content.scormActivity')}: ${scormActivityEntity.contentServiceTitle}`;
+			if (scormActivityEntity.contentServiceUpdatedAt) {
+				const date = new Date(Date.parse(scormActivityEntity.contentServiceUpdatedAt))
 					.toLocaleDateString('en-us', { year: 'numeric', month: 'long', day: 'numeric' });
 				subTitle = `${this.localize('content.lastEdited')} ${date}`;
 			}

--- a/components/d2l-activity-editor/d2l-activity-content-editor/scorm/state/content-scorm-activity.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/scorm/state/content-scorm-activity.js
@@ -12,7 +12,8 @@ export class ContentScormActivity {
 		this.title = '';
 		this.link = '';
 		this.isExternalResource = false;
-		this.lastModified = null;
+		this.contentServiceName = null;
+		this.contentServiceLastModified = null;
 	}
 
 	get dirty() {
@@ -35,8 +36,10 @@ export class ContentScormActivity {
 		this._contentScormActivity = scormActivity;
 		this.title = scormActivity.title();
 		this.isExternalResource = scormActivity.isExternalResource();
-		this.lastEdited = scormActivity.lastModified();
 		this.link = scormActivity.url();
+		this.contentServiceName = scormActivity.contentServiceName();
+		// TODO: Parse date
+		this.contentServiceLastModified = scormActivity.contentServiceLastModified();
 	}
 
 	async save() {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/scorm/state/content-scorm-activity.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/scorm/state/content-scorm-activity.js
@@ -38,7 +38,6 @@ export class ContentScormActivity {
 		this.isExternalResource = scormActivity.isExternalResource();
 		this.link = scormActivity.url();
 		this.contentServiceName = scormActivity.contentServiceName();
-		// TODO: Parse date
 		this.contentServiceLastModified = scormActivity.contentServiceLastModified();
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/scorm/state/content-scorm-activity.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/scorm/state/content-scorm-activity.js
@@ -12,7 +12,7 @@ export class ContentScormActivity {
 		this.title = '';
 		this.link = '';
 		this.isExternalResource = false;
-		this.contentServiceName = null;
+		this.contentServiceName = '';
 		this.contentServiceLastModified = null;
 	}
 

--- a/components/d2l-activity-editor/d2l-activity-content-editor/scorm/state/content-scorm-activity.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/scorm/state/content-scorm-activity.js
@@ -12,8 +12,8 @@ export class ContentScormActivity {
 		this.title = '';
 		this.link = '';
 		this.isExternalResource = false;
-		this.contentServiceName = '';
-		this.contentServiceLastModified = null;
+		this.contentServiceTitle = '';
+		this.contentServiceUpdatedAt = null;
 	}
 
 	get dirty() {

--- a/components/d2l-activity-editor/d2l-activity-content-editor/scorm/state/content-scorm-activity.js
+++ b/components/d2l-activity-editor/d2l-activity-content-editor/scorm/state/content-scorm-activity.js
@@ -37,8 +37,8 @@ export class ContentScormActivity {
 		this.title = scormActivity.title();
 		this.isExternalResource = scormActivity.isExternalResource();
 		this.link = scormActivity.url();
-		this.contentServiceName = scormActivity.contentServiceName();
-		this.contentServiceLastModified = scormActivity.contentServiceLastModified();
+		this.contentServiceTitle = scormActivity.contentServiceTitle();
+		this.contentServiceUpdatedAt = scormActivity.contentServiceUpdatedAt();
 	}
 
 	async save() {


### PR DESCRIPTION
## Relevant Rally Links

- https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=/defect/608756964175



## Description

> Editing a SCORM topic should not update the Last Edited time of SCORM package in content service.
> 
> Changing the name of the SCORM topic should not change the title of the SCORM package in the content service



## Goal/Solution

A related pull changes `ContentScormActivityEntity.js` in *Siren-SDK*.

Two new properties are exposed via siren, `contentServiceName()` and `contentServiceLastModified()` containing the actual SCORM package name and last updated date from content service.

In activities, *contentServiceName* is mapped to a similarly named new field in `ContentScormActivity` and *contentServiceLastModified* replaces *lastEdited*.

`d2l-activity-content-scorm-activity-detail.js` is modified to use the these when rendering, with added logic for formatting *contentServiceLastModified*.

## Video/Screenshots

See the SCORM package text now correctly showing the actual package name despite being edited in the LMS:

![FACE SCORM Test](https://user-images.githubusercontent.com/89945180/133341144-54a48b62-82f1-432d-94f7-c80d33c99740.PNG)



## Related PRs

- https://github.com/Brightspace/lms/pull/14130
- https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/373



## Remaining Work

- [ ] Dev Testing: another developer will test this code on their machine
