### PR TITLE
fix: US131442 wait for pending actions to complete before fetching wo…

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -27,6 +27,7 @@ class ActivityScoreEditor extends ActivityEditorMixin(SkeletonMixin(LocalizeActi
 		return {
 			activityName: { type: String },
 			disableResetToUngraded: { type: Boolean },
+			pendingUpdates: { type: Array },
 			_focusUngraded: { type: Boolean },
 			_createSelectboxGradeItemEnabled: { type: Boolean },
 			_associateGradeHref: { type: String }
@@ -166,6 +167,7 @@ class ActivityScoreEditor extends ActivityEditorMixin(SkeletonMixin(LocalizeActi
 		super(store);
 		this.saveOrder = 500;
 		this.disableResetToUngraded = false;
+		this.pendingUpdates = [];
 	}
 
 	connectedCallback() {
@@ -338,6 +340,7 @@ class ActivityScoreEditor extends ActivityEditorMixin(SkeletonMixin(LocalizeActi
 			}
 		}
 		await super.save();
+		this.pendingUpdates = [];
 	}
 
 	updateSelectedGrade() {
@@ -384,17 +387,20 @@ class ActivityScoreEditor extends ActivityEditorMixin(SkeletonMixin(LocalizeActi
 	_associateGradeSetGradebookStatus(gradebookStatus) {
 		if (!this._createSelectboxGradeItemEnabled) return;
 		const associateGradeEntity = associateGradeStore.get(this._associateGradeHref);
-		associateGradeEntity && associateGradeEntity.setGradebookStatus(gradebookStatus);
+		const promise = associateGradeEntity && associateGradeEntity.setGradebookStatus(gradebookStatus);
+		this.pendingUpdates.push(promise);
 	}
 	_associateGradeSetGradeName(name) {
 		if (!this._createSelectboxGradeItemEnabled) return;
 		const associateGradeEntity = associateGradeStore.get(this._associateGradeHref);
-		associateGradeEntity && associateGradeEntity.setGradeName(name);
+		const promise = associateGradeEntity && associateGradeEntity.setGradeName(name);
+		this.pendingUpdates.push(promise);
 	}
 	_associateGradeSetMaxPoints(maxPoints) {
 		if (!this._createSelectboxGradeItemEnabled) return;
 		const associateGradeEntity = associateGradeStore.get(this._associateGradeHref);
-		associateGradeEntity && associateGradeEntity.setGradeMaxPoints(maxPoints);
+		const promise = associateGradeEntity && associateGradeEntity.setGradeMaxPoints(maxPoints);
+		this.pendingUpdates.push(promise);
 	}
 	_chooseFromGrades() {
 		this._prefetchGradeCandidates();

--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -27,7 +27,6 @@ class ActivityScoreEditor extends ActivityEditorMixin(SkeletonMixin(LocalizeActi
 		return {
 			activityName: { type: String },
 			disableResetToUngraded: { type: Boolean },
-			pendingUpdates: { type: Array },
 			_focusUngraded: { type: Boolean },
 			_createSelectboxGradeItemEnabled: { type: Boolean },
 			_associateGradeHref: { type: String }
@@ -167,7 +166,6 @@ class ActivityScoreEditor extends ActivityEditorMixin(SkeletonMixin(LocalizeActi
 		super(store);
 		this.saveOrder = 500;
 		this.disableResetToUngraded = false;
-		this.pendingUpdates = [];
 	}
 
 	connectedCallback() {
@@ -340,7 +338,6 @@ class ActivityScoreEditor extends ActivityEditorMixin(SkeletonMixin(LocalizeActi
 			}
 		}
 		await super.save();
-		this.pendingUpdates = [];
 	}
 
 	updateSelectedGrade() {

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
@@ -93,7 +93,11 @@ export const ActivityEditorMixin = superclass => class extends superclass {
 			const entity = this.store.get(this.checkedOutHref);
 			if (!entity) return;
 
-			// Refetch entity in case presence of the check in action has changed
+			// Refetch entity in case presence of the check in action has changed,
+			// but make sure all updates have completed before refetching
+			if(this.pendingUpdates) {
+				await Promise.all(this.pendingUpdates);
+			}
 			await entity.fetch(true);
 
 			await entity.checkin(this.store, true);

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
@@ -39,6 +39,12 @@ export const ActivityEditorMixin = superclass => class extends superclass {
 			},
 			checkedOutHref: {
 				type: String
+			},
+			/**
+			 * Any pending promises before working-copy checkin can occur
+			 */
+			pendingUpdates: {
+				type: Array
 			}
 		};
 	}
@@ -48,6 +54,7 @@ export const ActivityEditorMixin = superclass => class extends superclass {
 		this._container = null;
 		this.store = store;
 		this.saveOrder = 1000;
+		this.pendingUpdates = [];
 	}
 
 	connectedCallback() {
@@ -101,6 +108,7 @@ export const ActivityEditorMixin = superclass => class extends superclass {
 			await entity.fetch(true);
 
 			await entity.checkin(this.store, true);
+			this.pendingUpdates = [];
 		}
 	}
 

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
@@ -95,7 +95,7 @@ export const ActivityEditorMixin = superclass => class extends superclass {
 
 			// Refetch entity in case presence of the check in action has changed,
 			// but make sure all updates have completed before refetching
-			if(this.pendingUpdates) {
+			if (this.pendingUpdates) {
 				await Promise.all(this.pendingUpdates);
 			}
 			await entity.fetch(true);


### PR DESCRIPTION
…rking copy activity usage

fixes https://trello.com/c/IYlEGfc7/448-after-loading-an-ungraded-assignment-if-you-click-ungraded-and-enter-a-grade-and-save-quickly-before-all-the-cache-primers-have

The bug is because the `fetch` requests and siren `actions` are not coordinated, and we need to make sure that working-copy PATCH requests are completed before the `fetch` is done to see if the working-copy has a checkin action. The action is only present if there are changes, and changes are only made after the PATCH requests.