### PR TITLE
fix: US130775 extra grade update

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-score-editor.js
+++ b/components/d2l-activity-editor/d2l-activity-score-editor.js
@@ -370,9 +370,11 @@ class ActivityScoreEditor extends ActivityEditorMixin(SkeletonMixin(LocalizeActi
 	}
 
 	async save() {
+		let isNewGrade = false;
 		if (this._createSelectboxGradeItemEnabled) {
 			const associateGradeEntity = associateGradeStore.get(this._associateGradeHref);
-			if (associateGradeEntity && associateGradeEntity.gradebookStatus === GradebookStatus.NewGrade) {
+			isNewGrade = associateGradeEntity && associateGradeEntity.gradebookStatus === GradebookStatus.NewGrade;
+			if (isNewGrade) {
 				const scoring = scoringStore.get(this._scoringHref);
 				const gradeMaxPoints = scoring && scoring.gradeMaxPoints;
 				this._associateGradeSetMaxPoints(gradeMaxPoints);
@@ -380,10 +382,14 @@ class ActivityScoreEditor extends ActivityEditorMixin(SkeletonMixin(LocalizeActi
 			}
 		}
 
-		await super.save();
+		await super.save(this._createSelectboxGradeItemEnabled);
 
 		if (this._createSelectboxGradeItemEnabled) {
-			const scoring = scoringStore.get(this._scoringHref);
+			await associateGradeStore.get(this._associateGradeHref).fetch(true);
+			let scoring = scoringStore.get(this._scoringHref);
+			if (isNewGrade) {
+				scoring = await scoring.fetch(true);
+			}
 			await scoring.save();
 		}
 	}

--- a/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
+++ b/components/d2l-activity-editor/mixins/d2l-activity-editor-mixin.js
@@ -95,7 +95,7 @@ export const ActivityEditorMixin = superclass => class extends superclass {
 	hasPendingChanges() {
 		return false;
 	}
-	async save() {
+	async save(createSelectboxGradeItemEnabled) {
 		if (this.checkoutOnLoad) {
 			const entity = this.store.get(this.checkedOutHref);
 			if (!entity) return;
@@ -107,7 +107,7 @@ export const ActivityEditorMixin = superclass => class extends superclass {
 			}
 			await entity.fetch(true);
 
-			await entity.checkin(this.store, true);
+			await entity.checkin(this.store, true, createSelectboxGradeItemEnabled);
 			this.pendingUpdates = [];
 		}
 	}

--- a/components/d2l-activity-editor/state/activity-usage.js
+++ b/components/d2l-activity-editor/state/activity-usage.js
@@ -18,11 +18,11 @@ export class ActivityUsage extends WorkingCopy {
 		this.token = token;
 	}
 
-	async checkin(store, refetch) {
+	async checkin(store, refetch, createSelectboxGradeItemEnabled) {
 		/* We `skipStoringResult` in the super.checkin function so that entity.load is not called.
 		 * This keeps the existing `scoreAndGrade` (out of) value instead of refetching the scoreAndGrade entity and overwriting it.
 		 */
-		const { sirenEntity } = await super.checkin(store, refetch, true) || {};
+		const { sirenEntity } = await super.checkin(store, refetch, !createSelectboxGradeItemEnabled) || {};
 		if (!sirenEntity) return;
 		const entity = store.get(sirenEntity.self());
 		if (entity) {


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367ud/custom/486232622040?detail=%2Fuserstory%2F606249971567&fdp=true

This fixes the issue where the wrong grade was being updated. Now when we create a new grade, we fetch the new score value (which has already been updated by working copy) so that the `save` method within `scoring` doesn't think the maxGradePoints has been updated (and therefore doesn't do the PATCH on the old grade item).