### PR TITLE
DE45687 [FACE] Removing indirectly associated rubrics may not store correct `defaultScoringRubricId` on an Assignment

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js
@@ -133,8 +133,11 @@ export class Assignment {
 		return restrictedExtensions;
 	}
 
-	resetDefaultScoringRubricId() {
+	resetDefaultScoringRubricId(autoSaveIfInvalid) {
 		this.defaultScoringRubricId = '-1';
+		if (autoSaveIfInvalid && this.canEditDefaultScoringRubric) { // this should only be `true` on firstLoad or Cancel, see DE45687
+			this._entity.save({ defaultScoringRubricId: -1 });
+		}
 	}
 
 	async save() {

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -224,8 +224,8 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 		}
 
 		const defaultScoringRubricOptions = this._dedupeDefaultScoringRubricOptions([...entity.defaultScoringRubricOptions, ...indirectAssociations.defaultScoringRubricOptions]);
-		if (assignment.defaultScoringRubricId === '-2' || assignment.defaultScoringRubricId === '-1' || assignment.defaultScoringRubricId === '0') {
-			return true; // If the value is -2: Control not present (Legacy), -1: No default selected, 0: If `null` is ever cast to a Number
+		if (assignment.defaultScoringRubricId === '-1' || assignment.defaultScoringRubricId === null) {
+			return true; // -1: No default selected
 		}
 
 		const isDefaultScoringRubricValidOption = defaultScoringRubricOptions.some(

--- a/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/d2l-activity-rubrics-list-container.js
@@ -266,15 +266,15 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 		const defaultScoringRubricOptions = this._dedupeDefaultScoringRubricOptions([...entity.defaultScoringRubricOptions, ...indirectAssociations.defaultScoringRubricOptions]);
 		const isReadOnly = !assignment.canEditDefaultScoringRubric;
 
-		if (!defaultScoringRubricOptions || defaultScoringRubricOptions.length <= 1) {
-			return html``;
-		}
 		if (this._isFirstLoad) {
 			this._isFirstLoad = !this._validateDefaultScoringRubric(); // On Assignment load, ensure a rubric ID is associated and hence a valid option
 		}
+		if (!defaultScoringRubricOptions || defaultScoringRubricOptions.length <= 1) {
+			return html``;
+		}
 
 		if (assignment.defaultScoringRubricId === null) {
-			assignment.resetDefaultScoringRubricId();
+			assignment.resetDefaultScoringRubricId(false);
 		}
 
 		return html`
@@ -330,7 +330,7 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 			dialog.opened = toggle;
 		}
 	}
-	async _validateDefaultScoringRubric() {
+	_validateDefaultScoringRubric() {
 		const entity = associationStore.get(this.href);
 		const indirectAssociations = associationStore.get(this.indirectAssociationsHref);
 		const assignment = assignmentStore.get(this.assignmentHref);
@@ -349,9 +349,8 @@ class ActivityRubricsListContainer extends ActivityEditorMixin(RtlMixin(Localize
 		);
 
 		if (!isDefaultScoringRubricValidOption) {
-			// An indirectly associated rubric can be used as an option, Assignment saved, remove it, close the page and leave `defaultScoringRubricId` now invalid.
-			assignment.resetDefaultScoringRubricId();
-			await assignment._entity.save({ defaultScoringRubricId: -1 });
+			// An indirectly associated rubric can be used as an option, Assignment saved, remove it, close the page and leave `defaultScoringRubricId` is now invalid.
+			assignment.resetDefaultScoringRubricId(true);
 		}
 		return isDefaultScoringRubricValidOption;
 	}

--- a/components/d2l-activity-editor/d2l-activity-rubrics/state/association-collection.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/state/association-collection.js
@@ -185,7 +185,7 @@ export class AssociationCollection {
 			const rubricId = this.getRubricIdFromHref(rubricHref);
 			// typeof assignment.defaultScoringRubricId is `string`, rubricId is `string`
 			if (assignment.defaultScoringRubricId === rubricId && !rubricIsAlsoIndirectlyAssociated) {
-				assignment.resetDefaultScoringRubricId();
+				assignment.resetDefaultScoringRubricId(false);
 			}
 
 			this.defaultScoringRubricOptions = this.defaultScoringRubricOptions.filter(


### PR DESCRIPTION
[DE45687](https://rally1.rallydev.com/#/?detail=/defect/612303356763&fdp=true): [FACE] Removing indirectly associated rubrics may not store correct defaultScoringRubricId on an assignment

Todo:
- [x] Refactor