### PR TITLE
DE45521 - Save custom allowable file types as lowercase

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -548,7 +548,7 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 			this.setError(errorProperty, invalidCustomFileTypesErrorLangterm, tooltipId);
 		} else {
 			this.clearError(errorProperty);
-			store.get(this.href).setCustomAllowableFileTypes(fileTypes);
+			store.get(this.href).setCustomAllowableFileTypes(fileTypes.toLowerCase());
 		}
 	}
 	_saveSubmissionTypeOnChange(event) {


### PR DESCRIPTION
[DE45521 ](https://rally1.rallydev.com/#/10153049633d/dashboard?detail=%2Fdefect%2F610904031713)

There is a defect where setting `allowableFyleType` to `.GIF` was not letting students submit ANY files to the assignment. 
Could not figure out why this only happens on `.GIF` during the investigation.

Saving the file ext. as lower case avoids this issue, this doesn't affect any other files as our file ext. comparisons are not case sensitive (eg. with `allowableFyleType` set to `.pdf`, students can submit both `.PDF` and `.pdf`)