### PR TITLE
De45879/jtran fix duplicate allowable file type

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
+++ b/components/d2l-activity-editor/d2l-activity-assignment-editor/d2l-activity-assignment-editor-submission-and-completion.js
@@ -175,8 +175,9 @@ class ActivityAssignmentSubmissionAndCompletionEditor extends SkeletonMixin(Acti
 
 		const hasInvalidFormat = fileTypesList.some(fileType => !isValidExtensionFormat.test(fileType));
 		const hasRestrictedFileType = fileTypesList.some(fileType => this.restrictedFileTypes.includes(fileType));
+		const hasDuplicateFileType = fileTypesList.length !== Array.from(new Set(fileTypesList)).length;
 
-		return hasInvalidFormat || hasRestrictedFileType;
+		return hasInvalidFormat || hasRestrictedFileType || hasDuplicateFileType;
 	}
 	async _loadRestrictedFileTypes(assignment) {
 		this.restrictedFileTypes = await assignment.loadRestrictedExtensions() || [];


### PR DESCRIPTION
[De45879](https://rally1.rallydev.com/#/42960320374d/custom/236803223728?detail=%2Fdefect%2F613394489133)
Fixes the issue where saving duplicate allowable file extensions would fail and not save