### PR TITLE
DE45687 Work with `async` default scoring rubric option loading

### DIFF
--- a/components/d2l-activity-editor/d2l-activity-rubrics/state/association-collection.js
+++ b/components/d2l-activity-editor/d2l-activity-rubrics/state/association-collection.js
@@ -155,6 +155,7 @@ export class AssociationCollection {
 	}
 
 	load(entity) {
+		this.loading = true;
 		this._entity = entity;
 
 		this.associationsMap = new Map();
@@ -175,9 +176,12 @@ export class AssociationCollection {
 		const associations = this.fetchAssociations();
 		const validDefaultScoringOption = associations.filter(association => (association.isAssociating || association.isAssociated) && !association.isDeleting);
 
+		const defaultScoringRubricOptionsAreReady = [];
 		for (const option of validDefaultScoringOption) {
-			this.addDefaultScoringRubricOption(option.rubricHref);
+			defaultScoringRubricOptionsAreReady.push(this.addDefaultScoringRubricOption(option.rubricHref));
 		}
+		Promise.all(defaultScoringRubricOptionsAreReady).then(
+			() => runInAction(() => this.loading = false));
 	}
 
 	removeDefaultScoringRubricOption(rubricHref, assignment, rubricIsAlsoIndirectlyAssociated) {
@@ -237,6 +241,7 @@ decorate(AssociationCollection, {
 	// props
 	associationsMap: observable,
 	defaultScoringRubricOptions: observable,
+	loading: observable,
 	// actions
 	load: action,
 	save: action,

--- a/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
@@ -233,12 +233,7 @@ describe('Assignment ', function() {
 		const assignment = new Assignment('http://assignment/1', 'token');
 		await assignment.fetch();
 		assignment.setDefaultScoringRubric(2);
-		assignment.resetDefaultScoringRubricId(false);
-
-		expect(assignment.defaultScoringRubricId).to.equal('-1');
-
-		assignment.setDefaultScoringRubric(3);
-		assignment.resetDefaultScoringRubricId(true);
+		assignment.resetDefaultScoringRubricId();
 
 		expect(assignment.defaultScoringRubricId).to.equal('-1');
 	});

--- a/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
+++ b/test/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.spec.js
@@ -233,7 +233,12 @@ describe('Assignment ', function() {
 		const assignment = new Assignment('http://assignment/1', 'token');
 		await assignment.fetch();
 		assignment.setDefaultScoringRubric(2);
-		assignment.resetDefaultScoringRubricId();
+		assignment.resetDefaultScoringRubricId(false);
+
+		expect(assignment.defaultScoringRubricId).to.equal('-1');
+
+		assignment.setDefaultScoringRubric(3);
+		assignment.resetDefaultScoringRubricId(true);
 
 		expect(assignment.defaultScoringRubricId).to.equal('-1');
 	});


### PR DESCRIPTION
[DE45687](https://rally1.rallydev.com/#/?detail=/defect/612303356763&fdp=true): [FACE] Removing indirectly associated rubrics may not store correct defaultScoringRubricId on an assignment

Previously the `defaultScoringRubric` dropdown would asynchronously add in the rubrics as they came in.

This change now causes the `defaultScoringRubric` dropdown to only re-render when all the rubrics that need to be fetched have returned.

May need to consider doing a disable and blur on the dropdown while that happens?